### PR TITLE
Added APRS/CWOP packet DEBUG logging

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1056,8 +1056,9 @@ class CWOPThread(RESTThread):
                         self._send(_sock, login, 'login')
                         # ... and then the packet
                         self._send(_sock, tnc_packet, 'packet')
-                        syslog.syslog(syslog.LOG_DEBUG, "restx: %s: APRS Packet: %s" %
-                                  (self.protocol_name, tnc_packet))
+                        if weewx.debug >= 2:
+                                   syslog.syslog(syslog.LOG_DEBUG, "restx: %s: APRS Packet: %s" %
+                                   (self.protocol_name, tnc_packet))
                         return
                         
                     finally:

--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1056,6 +1056,8 @@ class CWOPThread(RESTThread):
                         self._send(_sock, login, 'login')
                         # ... and then the packet
                         self._send(_sock, tnc_packet, 'packet')
+                        syslog.syslog(syslog.LOG_DEBUG, "restx: %s: APRS Packet: %s" %
+                                  (self.protocol_name, tnc_packet))
                         return
                         
                     finally:


### PR DESCRIPTION
Had some CWOP/APRS posting issues...patched restx.py to log raw APRS/CWOP tnc_packets to DEBUG log facility.