### PR TITLE
Modify weewx shebang

### DIFF
--- a/bin/weewxd
+++ b/bin/weewxd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #    Copyright (c) 2009-2015 Tom Keffer <tkeffer@gmail.com>
 #


### PR DESCRIPTION
Issue:
Weewx registers itself in the process list generically as "python" rather than as "weewxd".  While this does not affect weewx's functionality, this makes it more difficult for health monitoring apps, such as Zabbix, to monitor the status of weewx.

Cause:
After some research, it seems that the root cause is due to the shebang statement in weewxd. This pull request removes env from the shebang.  It seems the only disadvantage to this proposed change is flexibility in choosing which python interpreter to use, but is that really an issue in this case?

Further Reading:
Note that there are at lease two other ways to "solve" this issue, but they both involved importing additional libraries into weewx. At the time, those solutions seemed unnecessary.

Reference:
http://stackoverflow.com/questions/2429511/why-do-people-write-usr-bin-env-python-on-the-first-line-of-a-python-script

Testing this change produced the desired results. Weewx registers its name as weewxd, rather than python, and Zabbix stops complaining that the weewx service is not running:
```
[abauer@pidora bin]$ systemctl status weewx
weewx.service - weewx weather system
   Loaded: loaded (/usr/lib/systemd/system/weewx.service; enabled)
   Active: active (running) since Sat 2015-05-23 07:37:44 CDT; 7min ago
 Main PID: 9005 (weewxd)
   CGroup: /system.slice/weewx.service
           └─9005 /usr/bin/python /usr/bin/weewxd --pidfile=/var/run/weewx.pi...

May 23 07:44:30 pidora.local weewx[9005]: acurite: next read in 18 seconds
May 23 07:44:48 pidora.local weewx[9005]: acurite: Found station at bus=001 ...5
May 23 07:44:48 pidora.local weewx[9005]: acurite: R1: 01 00 bd 78 00 28 1f ...f
May 23 07:44:48 pidora.local weewx[9005]: acurite: next read in 6 seconds
May 23 07:44:54 pidora.local weewx[9005]: acurite: Found station at bus=001 ...5
May 23 07:44:54 pidora.local weewx[9005]: acurite: R2: 02 00 00 80 00 00 00 ...e
May 23 07:44:54 pidora.local weewx[9005]: acurite: next read in 12 seconds
May 23 07:45:06 pidora.local weewx[9005]: acurite: Found station at bus=001 ...5
May 23 07:45:06 pidora.local weewx[9005]: acurite: R1: 01 00 bd 71 00 1b 09 ...f
May 23 07:45:06 pidora.local weewx[9005]: acurite: next read in 18 seconds
Hint: Some lines were ellipsized, use -l to show in full.
[abauer@pidora bin]$ ps -A |grep weewx
 9005 ?        00:00:57 weewxd
```