### PR TITLE
Make WS1 TCP/IP driver code retry connection if it fails.

### DIFF
--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -111,17 +111,17 @@ class WS1Driver(weewx.drivers.AbstractDevice):
         try:
             self.max_tries = int(stn_dict.get('max_tries', 5))
         except ValueError, ex:
-            logdbg(valerrstr % ('max_tries', 5))
+            loginf(valerrstr % ('max_tries', 5))
 
         try:
             self.retry_wait = int(stn_dict.get('retry_wait', 10))
         except ValueError, ex:
-            logdbg(valerrstr % ('retry_wait', 10))
+            loginf(valerrstr % ('retry_wait', 10))
 
         try:
             timeout = int(stn_dict.get('timeout', 3))
         except ValueError, ex:
-            logdbg(valerrstr % ('timeout', 3))
+            loginf(valerrstr % ('timeout', 3))
 
         self.last_rain = None
 
@@ -131,7 +131,7 @@ class WS1Driver(weewx.drivers.AbstractDevice):
         try:
             DEBUG_READ = int(stn_dict.get('debug_read', DEBUG_READ))
         except ValueError, ex:
-            logdbg(valerrstr % ('debug_read', DEBUG_READ))
+            loginf(valerrstr % ('debug_read', DEBUG_READ))
 
         if con_mode == 'tcp' or con_mode == 'udp':
             self.station = StationSocket(self.port, con_mode, timeout,
@@ -352,7 +352,6 @@ class StationSocket(object):
         import socket
 
         logdbg("Connecting to %s:%d." % (self.conn_info[0], self.conn_info[1]))
-        exstr = ''
 
         for conn_attempt in range(self.max_retries):
             try:
@@ -363,14 +362,14 @@ class StationSocket(object):
             except (socket.error, socket.timeout, socket.herror), ex:
                 logerr("Cannot connect to %s:%d for some reason: %s. "
                        "%d tries left." % (
-                           self.conn_info[0], self.conn_info[1], ex))
+                           self.conn_info[0], self.conn_info[1], ex,
+                           self.max_retries - (conn_attempt + 1)))
                 logdbg("Will retry in %d seconds..." % self.retry_interval)
-                exstr = '%s' % ex
                 time.sleep(self.retry_interval)
         else:
             logerr("Max retries (%d) exceeded for connection." %
                    self.max_retries)
-            raise weewx.WeeWxIOError(exstr)
+            raise weewx.WeeWxIOError()
 
     def close(self):
         import socket

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -284,17 +284,6 @@ class StationInet(object):
         ip_addr = None
         ip_port = None
 
-        if protocol in ['tcp', 'udp']: self.protocol = protocol
-        else: self.protocol = 'tcp'
-
-        if isinstance(max_retries, int): self.max_retries = max_retries
-        else: self.max_retries = 5
-
-        if isinstance(retry_interval, int):
-            self.retry_interval = retry_interval
-        else:
-            self.retry_interval = 10
-
         if addr.find(':') != -1:
             self.conn_info = addr.split(':')
             try:

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -100,12 +100,17 @@ class WS1Driver(weewx.drivers.AbstractDevice):
             port_match = REGEX_IP_ADDR.match(port)
             if port_match:
                 ip_addr = port_match.groups()
+
                 if not all([0 <= int(x) <= 255 for x in ip_addr[:4]]):
                     raise ValueError("Invalid byte in IP:Port address!")
-                if not 1 <= int(ip_addr[4][1:]) <= 65535:
-                    raise ValueError("Invalid port number in IP:Port address!")
+                if ip_addr[4] is not None:
+                    if not 1 <= int(ip_addr[4][1:]) <= 65535:
+                        raise ValueError(
+                            "Invalid port number in IP:Port address!")
+                    self.port = port
+                else:
+                    self.port = "%s:%d" % (port, DEFAULT_TCP_PORT)
 
-                self.port = port
             else:
                 # self.port = '%s:%d' % (DEFAULT_TCP_ADDR, DEFAULT_TCP_PORT)
                 # logdbg(valerrstr % ('port', self.port))

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -66,7 +66,8 @@ class WS1Driver(weewx.drivers.AbstractDevice):
     [Required. Default is serial]
 
     port - Serial port or network address.
-    [Required. Default is /dev/ttyS0 for serial, and 192.168.36.25:3000 for TCP/IP]
+    [Required. Default is /dev/ttyS0 for serial,
+     and 192.168.36.25:3000 for TCP/IP]
 
     max_tries - how often to retry serial communication before giving up.
     [Optional. Default is 5]
@@ -101,8 +102,8 @@ class WS1Driver(weewx.drivers.AbstractDevice):
         DEBUG_READ = int(stn_dict.get('debug_read', DEBUG_READ))
 
         if con_mode == 'tcp' or con_mode == 'udp':
-            self.station = StationInet(self.port, con_mode, timeout, max_tries,
-                                       retry_wait)
+            self.station = StationInet(self.port, con_mode, timeout,
+                                       self.max_tries, self.retry_wait)
         else:
             self.station = StationSerial(self.port, timeout=timeout)
         self.station.open()
@@ -284,6 +285,9 @@ class StationInet(object):
         ip_addr = None
         ip_port = None
 
+        self.max_retries = max_retries
+        self.retry_interval = retry_interval
+
         if addr.find(':') != -1:
             self.conn_info = addr.split(':')
             try:
@@ -297,10 +301,10 @@ class StationInet(object):
             self.conn_info = (ip_addr, ip_port)
 
         try:
-            if self.protocol == 'tcp':
+            if protocol == 'tcp':
                 self.net_socket = socket.socket(
                     socket.AF_INET, socket.SOCK_STREAM)
-            elif self.protocol == 'udp':
+            elif protocol == 'udp':
                 self.net_socket = socket.socket(
                     socket.AF_INET, socket.SOCK_DGRAM)
         except (socket.error, socket.herror), ex:

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -312,8 +312,7 @@ class StationSocket(object):
             logerr("Cannot create socket for some reason: %s" % ex)
             raise weewx.WeeWxIOError(ex)
 
-        if isinstance(timeout, int): self.net_socket.settimeout(timeout)
-        else: self.net_socket.settimeout(3)
+        self.net_socket.settimeout(timeout)
         self.rec_start = False
 
     def open(self):

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -89,8 +89,10 @@ class WS1Driver(weewx.drivers.AbstractDevice):
         if con_mode == 'tcp' or con_mode == 'udp':
             port = stn_dict.get(
                 'port', '%s:%d' % (DEFAULT_TCP_ADDR, DEFAULT_TCP_PORT))
-        else:
+        elif con_mode == 'serial':
             port = stn_dict.get('port', DEFAULT_SER_PORT)
+        else:
+            raise ValueError("Invalid driver connection mode %s!" % con_mode)
 
         self.max_tries = int(stn_dict.get('max_tries', 5))
         self.retry_wait = int(stn_dict.get('retry_wait', 10))


### PR DESCRIPTION
I made some more changes to the weewx WS1 driver so that it re-tries the socket connection if it fails. The number of attempts and the interval between attempts are specified by the max_tries and retry_wait configuration settings respectively.

I have not tested this, however. But I'm hopeful that this code works as I expect it to.