### PR TITLE
Fix missing humidity of the second sensor TE923

### DIFF
--- a/bin/weewx/drivers/te923.py
+++ b/bin/weewx/drivers/te923.py
@@ -408,6 +408,7 @@ schema, plus additional fields.  To use the default mapping with the wview
 schema, these are the additional fields that must be added to the schema:
 
           ('extraTemp4',           'REAL'),
+          ('extraHumid2',          'REAL'),
           ('extraHumid3',          'REAL'),
           ('extraHumid4',          'REAL'),
           ('extraBatteryStatus1',  'REAL'),
@@ -477,7 +478,7 @@ DEFAULT_OBSERVATION_MAP = {
     'bat_2': 'extraBatteryStatus1',
     'link_2': 'extraLinkStatus1',
     't_3': 'extraTemp2',
-    'h_3': 'extraHumid3',
+    'h_3': 'extraHumid2',
     'bat_3': 'extraBatteryStatus2',
     'link_3': 'extraLinkStatus2',
     't_4': 'extraTemp3',


### PR DESCRIPTION
I use three outside sensors on my TFA Nexus. All sensors report temperature and
humidity. But the humidity of the second sensor is not recorded in weewx. I
found it missing in the driver and fixed the error there.

This fix works for my station and the humidity for the second sensor is back
and working.