### PR TITLE
Change "rtfreq" in RapidFire mode of WUnderground publish to be automatic

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -81,6 +81,8 @@ import time
 import urllib
 import urllib2
 
+from collections import deque
+
 import weedb
 import weeutil.weeutil
 import weewx.engine
@@ -533,6 +535,7 @@ class StdWunderground(StdRESTful):
             _ambient_dict.setdefault('log_failure', False)
             _ambient_dict.setdefault('max_backlog', 0)
             _ambient_dict.setdefault('max_tries', 1)
+            _ambient_dict.setdefault('rtfreq_sma_window',  _ambient_dict.get('rtfreq_sma_window', 7))
             self.loop_queue = Queue.Queue()
             self.loop_thread = AmbientLoopThread(
                 self.loop_queue,
@@ -736,6 +739,51 @@ class AmbientThread(RESTThread):
         
 class AmbientLoopThread(AmbientThread):
     """Version used for the Rapidfire protocol."""
+    class SimpleMovingAverage():
+        def __init__(self, window):
+            assert window == int(window) and window > 0, "Simplemovingaverage: window must be a positive integer"
+            self.window = window
+            self.queue = deque()
+    
+        def __call__(self, x):
+            queue = self.queue
+            n = len(queue)
+            if n == self.window:
+                queue.popleft()
+            queue.append(x)
+            n = min(n+1, self.window)
+            return sum( queue ) / float(n)
+
+    def __init__(self, queue, manager_dict,
+                 station, password, server_url,
+                 protocol_name="Unknown-Ambient",
+                 post_interval=None, max_backlog=sys.maxint, stale=None, 
+                 log_success=True, log_failure=True,
+                 timeout=10, max_tries=3, retry_wait=5, rtfreq_sma_window=17):
+        """
+        Initializer for the AmbientLoopThread class.
+
+        Parameters specific to this class:
+          
+          rtfreq_sma_window: How many time samples to include when computing rtfreq for RapidFire
+        """
+        super(AmbientLoopThread, self).__init__(queue,
+                                            station=station,
+                                            password=password,
+                                            server_url=server_url,
+                                            protocol_name=protocol_name,
+                                            manager_dict=manager_dict,
+                                            post_interval=post_interval,
+                                            max_backlog=max_backlog,
+                                            stale=stale,
+                                            log_success=log_success,
+                                            log_failure=log_failure,
+                                            timeout=timeout,
+                                            max_tries=max_tries,
+                                            retry_wait=retry_wait)
+
+        self.sma = self.SimpleMovingAverage(int(rtfreq_sma_window))
+        self.prevtick = time.time()
 
     def get_record(self, record, dbmanager):
         """Prepare a record for the Rapidfire protocol."""
@@ -744,7 +792,9 @@ class AmbientLoopThread(AmbientThread):
         _record = AmbientThread.get_record(self, record, dbmanager)
         # Add the Rapidfire-specific keywords:
         _record['realtime'] = '1'
-        _record['rtfreq'] = '2.5'
+        tick = time.time()
+        _record['rtfreq'] = str(round(self.sma(tick - self.prevtick), 1))
+        self.prevtick = tick
 
         return _record
 

--- a/weewx.conf
+++ b/weewx.conf
@@ -111,6 +111,8 @@ version = 3.5.0
         # Set the following to True to have weewx use the WU "Rapidfire"
         # protocol. Not all hardware can support it. See the User's Guide.
         rapidfire = False
+        # This many packet time intervals are used to compute the moving average
+        # rtfreq_sma_window = 7
 
 ##############################################################################
 


### PR DESCRIPTION
Rather than hardcoded 2.5 sec, a moving average over packet timestamps
is computed and sent.
This addresses [#128]