### PR TITLE
implement caching for wu

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -512,9 +512,15 @@ class StdWunderground(StdRESTful):
         do_rapidfire_post = to_bool(_ambient_dict.pop('rapidfire', False))
         do_archive_post = to_bool(_ambient_dict.pop('archive_post',
                                                     not do_rapidfire_post))
+
+        # use the same staleness for every observation, loop or archive
+        self.stale_dict = dict()
+        for obs in AmbientThread._formats:
+            self.stale_dict[obs] = 900 # 15 minutes
         
         if do_archive_post:
             _ambient_dict.setdefault('server_url', StdWunderground.pws_url)
+            self.archive_cache = weeutil.weeutil.ObservationCache()
             self.archive_queue = Queue.Queue()
             self.archive_thread = AmbientThread(
                 self.archive_queue,
@@ -533,6 +539,7 @@ class StdWunderground(StdRESTful):
             _ambient_dict.setdefault('log_failure', False)
             _ambient_dict.setdefault('max_backlog', 0)
             _ambient_dict.setdefault('max_tries', 1)
+            self.loop_cache = weeutil.weeutil.ObservationCache()
             self.loop_queue = Queue.Queue()
             self.loop_thread = AmbientLoopThread(
                 self.loop_queue,
@@ -547,12 +554,17 @@ class StdWunderground(StdRESTful):
 
     def new_loop_packet(self, event):
         """Puts new LOOP packets in the loop queue"""
-        self.loop_queue.put(event.packet)
+        self.loop_cache.add_record(event.packet)
+        packet = self.loop_cache.get_most_recent(self.stale_dict)
+        self.loop_queue.put(packet)
 
     def new_archive_record(self, event):
         """Puts new archive records in the archive queue"""
-        self.archive_queue.put(event.record)
-                
+        self.archive_cache.add_record(event.record)
+        record = self.archive_cache.get_most_recent(self.stale_dict)
+        self.archive_queue.put(record)
+
+
 class StdPWSWeather(StdRESTful):
     """Specialized version of the Ambient protocol for PWSWeather"""
     
@@ -626,6 +638,7 @@ class StdWOW(StdRESTful):
         
     def new_archive_record(self, event):
         self.archive_queue.put(event.record)
+
 
 class AmbientThread(RESTThread):
     """Concrete class for threads posting from the archive queue,


### PR DESCRIPTION
this has been tested with a wmr300 station, which emits partial packets, and standard wu (not rapid-fire).  the wmr300 emits a pressure packet every 15 minutes, so only every third archive record has pressure.  this patch retains the pressure value so packets sent to wu always have pressure.  this patch has no effect on data saved to the database.

rain is still an issue.  wu uses an accumulated rain value (dayRain) instead of a delta rain value (rain).  so, caching the dayRain across day boundary might result in bogus data.
