### PR TITLE
Fix operation of 'resume' keyword

### DIFF
--- a/bin/weewx/drivers/simulator.py
+++ b/bin/weewx/drivers/simulator.py
@@ -29,7 +29,7 @@ def loader(config_dict, engine):
         start_ts = time.mktime(start_tt)
         # If the 'resume' keyword is present and True, then get the last
         # archive record out of the database and resume with that.
-        if weeutil.weeutil.to_bool(config_dict[DRIVER_NAME].get('resume', True)):
+        if weeutil.weeutil.to_bool(config_dict[DRIVER_NAME].get('resume', False)):
             import weewx.manager
             try:
                 # Resume with the last time in the database. If there is no such


### PR DESCRIPTION
Line 30-31 comments indicate Simulator will resume if 'resume' keyword is present and True; this implies that the Simulator will not resume for all other cases (ie 'resume' keyword is absent or it is present but set to false). The if statement at line 32 will resume in all cases unless 'resume' is explicitly set False. This operation does not agree with the comments.

Changed default for line 32 get so that if statement operates as per comments.

The other approach is to alter the comments.

Or of course I may be reading this completely wrong!