### PR TITLE
Allow timestamp_to_string() output format to be specified

### DIFF
--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -911,7 +911,7 @@ def secs_to_string(secs):
     ans = ', '.join(str_list)
     return ans
 
-def timestamp_to_string(ts):
+def timestamp_to_string(ts, format_str="%Y-%m-%d %H:%M:%S %Z"):
     """Return a string formatted from the timestamp
     
     Example:
@@ -923,7 +923,7 @@ def timestamp_to_string(ts):
     ******* N/A *******     (    N/A   )
     """
     if ts:
-        return "%s (%d)" % (time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime(ts)), ts)
+        return "%s (%d)" % (time.strftime(format_str, time.localtime(ts)), ts)
     else:
         return "******* N/A *******     (    N/A   )"
 


### PR DESCRIPTION
Allow calls to timestamp_to_string() to specify the date-time format string of the resulting output.
Use of an argument with a default value maintains backward compatibility.