### PR TITLE
Add a layer of abstraction to StdQC

### DIFF
--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -25,6 +25,7 @@ import daemon
 import weedb
 import weewx.accum
 import weewx.manager
+import weewx.qc
 import weewx.station
 import weewx.reportengine
 import weeutil.weeutil
@@ -394,13 +395,18 @@ class StdCalibrate(StdService):
 #==============================================================================
 
 class StdQC(StdService):
-    """Service that performs quality check on incoming data."""
+    """Service that performs quality check on incoming data.
 
+    A StdService wrapper for a QC object so it may be called as a service. This 
+    also allows the weewx.qc.QC class to be used elsewhere without the 
+    overheads of running it as a weewx service.
+    """
+    
     def __init__(self, engine, config_dict):
         super(StdQC, self).__init__(engine, config_dict)
 
         # Get a QC object to apply the QC checks to our data
-        self.qc = QC(config_dict)
+        self.qc = weewx.qc.QC(config_dict)
         
         self.bind(weewx.NEW_LOOP_PACKET, self.new_loop_packet)
         self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)
@@ -414,57 +420,6 @@ class StdQC(StdService):
         """Apply quality check to the data in an archive record"""
         
         self.qc.apply_qc(event.record)
-
-#==============================================================================
-#                    Class QC
-#==============================================================================
-
-class QC(object):
-    """Class to apply quality checks to a record."""
-    
-    def __init__(self, config_dict, parent='engine'):
-        
-        # Save our 'parent' - for use when logging
-        self.parent = parent
-        
-        # If the 'StdQC' or 'MinMax' sections do not exist in the configuration
-        # dictionary, then an exception will get thrown and nothing will be
-        # done.
-        try:
-            mm_dict = config_dict['StdQC']['MinMax']
-        except KeyError:
-            syslog.syslog(syslog.LOG_NOTICE, 
-                          self.parent + ": No QC information in config file.")
-            return
-
-        self.min_max_dict = {}
-
-        target_unit_name = config_dict['StdConvert']['target_unit']
-        target_unit = weewx.units.unit_constants[target_unit_name.upper()]
-        converter = weewx.units.StdUnitConverters[target_unit]
-
-        for obs_type in mm_dict.scalars:
-            minval = float(mm_dict[obs_type][0])
-            maxval = float(mm_dict[obs_type][1])
-            if len(mm_dict[obs_type]) == 3:
-                group = weewx.units._getUnitGroup(obs_type)
-                vt = (minval, mm_dict[obs_type][2], group)
-                minval = converter.convert(vt)[0]
-                vt = (maxval, mm_dict[obs_type][2], group)
-                maxval = converter.convert(vt)[0]
-            self.min_max_dict[obs_type] = (minval, maxval)
-        
-    def apply_qc(self, data_dict):
-        """Apply quality checks to the data in a record"""
-
-        for obs_type in self.min_max_dict:
-            if data_dict.has_key(obs_type) and data_dict[obs_type] is not None:
-                if not self.min_max_dict[obs_type][0] <= data_dict[obs_type] <= self.min_max_dict[obs_type][1]:
-                    syslog.syslog(syslog.LOG_NOTICE, self.parent + ": %s LOOP value '%s' %s outside limits (%s, %s)" % 
-                                  (weeutil.weeutil.timestamp_to_string(data_dict['dateTime']), 
-                                   obs_type, data_dict[obs_type], 
-                                   self.min_max_dict[obs_type][0], self.min_max_dict[obs_type][1]))
-                    data_dict[obs_type] = None
 
 #==============================================================================
 #                    Class StdArchive

--- a/bin/weewx/qc.py
+++ b/bin/weewx/qc.py
@@ -1,0 +1,65 @@
+#
+#    Copyright (c) 2009-2016 Tom Keffer <tkeffer@gmail.com>
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Classes and functions related to Quality Control of incoming data."""
+
+# Python imports
+import syslog
+
+# weewx imports
+import weeutil.weeutil
+import weewx.units
+
+#==============================================================================
+#                    Class QC
+#==============================================================================
+
+class QC(object):
+    """Class to apply quality checks to a record."""
+    
+    def __init__(self, config_dict, parent='engine'):
+        
+        # Save our 'parent' - for use when logging
+        self.parent = parent
+        
+        # If the 'StdQC' or 'MinMax' sections do not exist in the configuration
+        # dictionary, then an exception will get thrown and nothing will be
+        # done.
+        try:
+            mm_dict = config_dict['StdQC']['MinMax']
+        except KeyError:
+            syslog.syslog(syslog.LOG_NOTICE, 
+                          self.parent + ": No QC information in config file.")
+            return
+
+        self.min_max_dict = {}
+
+        target_unit_name = config_dict['StdConvert']['target_unit']
+        target_unit = weewx.units.unit_constants[target_unit_name.upper()]
+        converter = weewx.units.StdUnitConverters[target_unit]
+
+        for obs_type in mm_dict.scalars:
+            minval = float(mm_dict[obs_type][0])
+            maxval = float(mm_dict[obs_type][1])
+            if len(mm_dict[obs_type]) == 3:
+                group = weewx.units._getUnitGroup(obs_type)
+                vt = (minval, mm_dict[obs_type][2], group)
+                minval = converter.convert(vt)[0]
+                vt = (maxval, mm_dict[obs_type][2], group)
+                maxval = converter.convert(vt)[0]
+            self.min_max_dict[obs_type] = (minval, maxval)
+        
+    def apply_qc(self, data_dict):
+        """Apply quality checks to the data in a record"""
+
+        for obs_type in self.min_max_dict:
+            if data_dict.has_key(obs_type) and data_dict[obs_type] is not None:
+                if not self.min_max_dict[obs_type][0] <= data_dict[obs_type] <= self.min_max_dict[obs_type][1]:
+                    syslog.syslog(syslog.LOG_NOTICE, self.parent + ": %s LOOP value '%s' %s outside limits (%s, %s)" % 
+                                  (weeutil.weeutil.timestamp_to_string(data_dict['dateTime']), 
+                                   obs_type, data_dict[obs_type], 
+                                   self.min_max_dict[obs_type][0], self.min_max_dict[obs_type][1]))
+                    data_dict[obs_type] = None
+


### PR DESCRIPTION
Taking a leaf out of the 'Ask for forgiveness, rather than permission' mantra...

Following on from @matthewwall #148 comments of 9 Sep, this PR adds a layer of abstraction to the `StdQC` service to allow other apps to hook into the underlying weewx QC system.