### PR TITLE
Restore some lost log detail to the new StdQC service

### DIFF
--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -414,12 +414,12 @@ class StdQC(StdService):
     def new_loop_packet(self, event):
         """Apply quality check to the data in a loop packet"""
         
-        self.qc.apply_qc(event.packet)
+        self.qc.apply_qc(event.packet, 'LOOP')
 
     def new_archive_record(self, event):
         """Apply quality check to the data in an archive record"""
         
-        self.qc.apply_qc(event.record)
+        self.qc.apply_qc(event.record, 'Archive')
 
 #==============================================================================
 #                    Class StdArchive

--- a/bin/weewx/qc.py
+++ b/bin/weewx/qc.py
@@ -18,19 +18,19 @@ import weewx.units
 
 class QC(object):
     """Class to apply quality checks to a record."""
-    
+
     def __init__(self, config_dict, parent='engine'):
-        
+
         # Save our 'parent' - for use when logging
         self.parent = parent
-        
+
         # If the 'StdQC' or 'MinMax' sections do not exist in the configuration
         # dictionary, then an exception will get thrown and nothing will be
         # done.
         try:
             mm_dict = config_dict['StdQC']['MinMax']
         except KeyError:
-            syslog.syslog(syslog.LOG_NOTICE, 
+            syslog.syslog(syslog.LOG_NOTICE,
                           self.parent + ": No QC information in config file.")
             return
 
@@ -50,16 +50,17 @@ class QC(object):
                 vt = (maxval, mm_dict[obs_type][2], group)
                 maxval = converter.convert(vt)[0]
             self.min_max_dict[obs_type] = (minval, maxval)
-        
-    def apply_qc(self, data_dict):
+
+    def apply_qc(self, data_dict, data_type=''):
         """Apply quality checks to the data in a record"""
 
         for obs_type in self.min_max_dict:
             if data_dict.has_key(obs_type) and data_dict[obs_type] is not None:
                 if not self.min_max_dict[obs_type][0] <= data_dict[obs_type] <= self.min_max_dict[obs_type][1]:
-                    syslog.syslog(syslog.LOG_NOTICE, self.parent + ": %s LOOP value '%s' %s outside limits (%s, %s)" % 
-                                  (weeutil.weeutil.timestamp_to_string(data_dict['dateTime']), 
-                                   obs_type, data_dict[obs_type], 
+                    syslog.syslog(syslog.LOG_NOTICE, "%s: %s %s value '%s' %s outside limits (%s, %s)" %
+                                  (self.parent,
+                                   weeutil.weeutil.timestamp_to_string(data_dict['dateTime']),
+                                   data_type, obs_type, data_dict[obs_type],
                                    self.min_max_dict[obs_type][0], self.min_max_dict[obs_type][1]))
                     data_dict[obs_type] = None
 


### PR DESCRIPTION
Old `StdQC` distinguished between 'LOOP' and 'Archive' data in its log output; the new arrangement did not include such a distinction. This PR restores the old log output.