### PR TITLE
Fix wee_import unit system error

### DIFF
--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -309,7 +309,7 @@ class Source(object):
                 # map the raw data to a weewx archive compatible dictionary
                 _msg = 'Mapping raw import data for period %d...' % self.period_no
                 self.wlog.verboselog(syslog.LOG_INFO, _msg)
-                _mapped_data = self.mapRawData(_raw_data, weewx.US)
+                _mapped_data = self.mapRawData(_raw_data, self.archive_unit_sys)
                 _msg = 'Raw import data mapped successfully for period %d.' % self.period_no
                 self.wlog.verboselog(syslog.LOG_INFO, _msg)
 


### PR DESCRIPTION
wee_import was assuming that the destination database was always in US customary units. Fixes bug identified here: https://groups.google.com/d/msg/weewx-user/mlw2k1encLU/0plOuIGjAwAJ