### PR TITLE
Add more documentation for configuration of WOW upload

### DIFF
--- a/docs/usersguide.htm
+++ b/docs/usersguide.htm
@@ -1881,8 +1881,10 @@ longitude = -77.0366</pre>
                 Weather Observations Website (WOW)</a> service. If you wish
             to do this, set the option <span class='code'>enable</span> to
             <span class="code">true</span>, then set options <span class="code">station</span>
-            and <span class="code">password</span> appropriately. When you are done,
-            it will look something like</p>
+            and <span class="code">password</span> appropriately. Read
+            <a href="http://wow.metoffice.gov.uk/support/dataformats#automatic">Importing Weather Data into WOW</a>
+            on how to find your site's username and how to set the password for your site.
+            When you are done, it will look something like</p>
     <pre class="tty">[StdRestful]
     [[WOW]]
         enable = true


### PR DESCRIPTION
The WOW website where you enter a new site does not
have information on the username and password to
use when uploading to WOW.

So it should help to document that you need to read
another WOW page on how to find the station id, and
that you need to set the password yourself for the
site, and it should be a 6 digit pin code.