### PR TITLE
Let weewx.restx.StdWOW use post_interval=900

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -683,7 +683,8 @@ class StdWOW(StdRESTful):
         _ambient_dict.setdefault('server_url', StdWOW.archive_url)
         self.archive_queue = Queue.Queue()
         self.archive_thread = WOWThread(self.archive_queue, _manager_dict, 
-                                        protocol_name="WOW",
+                                        protocol_name="WOW", 
+                                        post_interval=900,
                                         **_ambient_dict)
         self.archive_thread.start()
         self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)


### PR DESCRIPTION
The WOW API documentation says
"
Frequency of submitting observations

It is recommended that the interval between automatic observations from your AWS is at least 15 minutes.
"
Respect this by using a post_interval of 900.
Without the post_interval, we get a HTTP status 429: Too frequent observations.
And the log gets the following entries
Dec 15 18:54:25 weather1 weewx[2400]: restx: WOW: Failed upload attempt 1: HTTP Error 429: Too frequent observations.
Dec 15 18:54:30 weather1 weewx[2400]: restx: WOW: Failed upload attempt 2: HTTP Error 429: Too frequent observations.
Dec 15 18:54:35 weather1 weewx[2400]: restx: WOW: Failed upload attempt 3: HTTP Error 429: Too frequent observations.