### PR TITLE
prevent KeyError and update to txTempBatteryStatus

### DIFF
--- a/examples/lowBattery.py
+++ b/examples/lowBattery.py
@@ -108,7 +108,7 @@ class BatteryAlarm(StdService):
         """This function is called on each new LOOP packet."""
 
         # If the Transmit Battery Status byte is non-zero, an alarm is on
-        if event.packet['txBatteryStatus']:
+        if event.packet.get('txTempBatteryStatus', 0):
 
             self.alarm_count += 1
 
@@ -121,7 +121,7 @@ class BatteryAlarm(StdService):
                 if abs(time.time() - self.last_msg_ts) >= self.time_wait :
                     # Sound the alarm!
                     timestamp = event.packet['dateTime']
-                    battery_status = event.packet['txBatteryStatus']
+                    battery_status = event.packet['txTempBatteryStatus']
                     # Launch in a separate thread so it does not block the
                     # main LOOP thread:
                     t  = threading.Thread(target=BatteryAlarm.soundTheAlarm,


### PR DESCRIPTION
I can't tell if I'm getting txTempBatteryStatus instead of txBatteryStatus simply because my station is an accurite.. but I figured I'd ask the question in the form of a pull request.

I'm also seeing sensor_battery, so I'm less confident now...
Jan 11 14:01:34 weatherasp weewx[11567]: packet received: {'sensor_id': 645, 'outHumidity': 61, 'maxSolarRad': None, 'altimeter': None, 'heatindex': 40.5, 'inDewpoint': None, 'channel': None, 'barometer': None, 'windchill': 31.740679430262393, 'dewpoint': 28.123793591658, 'humidex': 40.5, 'pressure': None, 'sensor_battery': 0, 'rxCheckPercent': 100.0, 'rainRate': 0, 'usUnits': 1, 'txTempBatteryStatus': 0, 'appTemp': 26.