### PR TITLE
Reworked check_strings() output

### DIFF
--- a/bin/wee_database
+++ b/bin/wee_database
@@ -21,7 +21,7 @@ import weedb
 import weewx.manager
 import weewx.units
 
-from weeutil.weeutil import TimeSpan
+from weeutil.weeutil import TimeSpan, timestamp_to_string
 
 usage = """wee_database --help
        wee_database --create
@@ -582,23 +582,24 @@ def check_strings(config_dict, db_binding, options, fix=False):
     """
 
     t1 = time.time()
+    if options.dry_run or not fix:
+        _log_level = syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_WARNING))
     if fix:
         syslog.syslog(syslog.LOG_INFO, "Preparing 'Null String' fix...")
-        print "Preparing 'Null String' fix..."
+        print "Preparing 'Null String' fix, this may take a while..."
         # notify if this is a dry run
         if options.dry_run:
-            syslog.syslog(syslog.LOG_INFO, "This is a dry run. Null strings will be found but not fixed.")
             print "This is a dry run. Null strings will be found but not fixed."
     else:
-        print "Preparing 'Null String' check..."
+        print "Preparing 'Null String' check, this may take a while..."
 
-    # Open up the main database archive table
+    # open up the main database archive table
     with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
 
         obs_pytype_list = []
         obs_list = []
 
-        # Get the schema and extract the Python type each observation type should be
+        # get the schema and extract the Python type each observation type should be
         for column in dbmanager.connection.genSchemaOf('archive'):
             schema_type = column[2]
             if schema_type == 'INTEGER':
@@ -607,93 +608,111 @@ def check_strings(config_dict, db_binding, options, fix=False):
                 schema_type = float
             elif schema_type == 'STR':
                 schema_type = str
-            # Save the observation type for this column (eg, 'outTemp'):
+            # save the observation type for this column (eg, 'outTemp'):
             obs_list.append(column[1])
-            # Save the Python type for this column (eg, 'int'):
+            # save the Python type for this column (eg, 'int'):
             obs_pytype_list.append(schema_type)
 
-        found = 0
-        fixed = 0
-        # Cycle through each row in the database
+        records = 0
+        _found = []
+        # cycle through each row in the database
         for record in dbmanager.genBatchRows():
-            # Now examine each column
+            records += 1
+            # now examine each column
             for icol in range(len(record)):
-                # Check to see if this column is an instance of the correct Python type
+                # check to see if this column is an instance of the correct
+                # Python type
                 if record[icol] is not None and not isinstance(record[icol], obs_pytype_list[icol]):
-                    # Oops. Found a bad one. Print it out
-                    found += 1
+                    # Oops. Found a bad one. Print it out.
                     if fix:
                         syslog.syslog(syslog.LOG_INFO,
                                       "Timestamp = %s; record['%s']= %r; ... " % (record[0],
                                                                                  obs_list[icol],
                                                                                  record[icol]))
-                    sys.stdout.write("Timestamp = %s; record['%s']= %r; ... " % (record[0],
-                                                                                 obs_list[icol],
-                                                                                 record[icol]))
 
                     if fix:
-                        # Cooerce to the correct type. If it can't be done, then set it to None
+                        # coerce to the correct type. If it can't be done, then
+                        # set it to None.
                         try:
                             corrected_value = obs_pytype_list[icol](record[icol])
                         except ValueError:
                             corrected_value = None
-                        # Update the database with the new value but only if
+                        # update the database with the new value but only if
                         # it's not a dry run
                         if not options.dry_run:
                             dbmanager.updateValue(record[0], obs_list[icol], corrected_value)
-                        fixed += 1
-                        # Log it and inform the user
-                        if options.dry_run:
-                            syslog.syslog(syslog.LOG_INFO, "     would have been changed to %r\n" % corrected_value)
-                            sys.stdout.write("would have been changed to %r\n" % corrected_value)
-                        else:
-                            syslog.syslog(syslog.LOG_INFO, "     changed to %r\n" % corrected_value)
-                            sys.stdout.write("changed to %r\n" % corrected_value)
+                        _found.append((record[0], obs_list[icol], record[icol], corrected_value))
+                        # log it
+                        syslog.syslog(syslog.LOG_INFO, "     changed to %r\n" % corrected_value)
                     else:
-                        sys.stdout.write("ignored.\n")
+                        _found.append((record[0], obs_list[icol], record[icol]))
+            # notify the user of progress
+            if records % 1000 == 0:
+                print >>sys.stdout, "Checking record: %d; Timestamp: %s\r" % \
+                    (records, timestamp_to_string(record[0])),
+                sys.stdout.flush()
+    # update our final count now that we have finished
+    print >>sys.stdout, "Checking record: %d; Timestamp: %s\r" % \
+        (records, timestamp_to_string(record[0])),
+    print
     tdiff = time.time() - t1
-    if found == 0:
-        # found no strings
-        if fix:
-            syslog.syslog(syslog.LOG_INFO, "No null strings found.")
+    # now display details of what we found if we found any null strings
+    if len(_found) > 0:
+        print "The following null strings were found:"
+        for item in _found:
+            if len(item) == 4:
+                print "Timestamp = %s; record['%s'] = %r; ... changed to %r" % item
+            else:
+                print "Timestamp = %s; record['%s'] = %r; ... ignored" % item
+    # how many did we fix?
+    fixed = len([a for a in _found if len(a)==4])
+    # summarise our results
+    if len(_found) == 0:
+        # found no null strings, log it and display on screen
+        syslog.syslog(syslog.LOG_INFO, "No null strings found.")
         print "No null strings found."
-    elif fixed == found:
+    elif fixed == len(_found):
         # fixed all we found
         if options.dry_run:
-            syslog.syslog(syslog.LOG_INFO,
-                          "%d of %d null strings found would have been fixed." % (fixed,
-                                                                                  found))
-            print "%d of %d null strings found would hav ebeen fixed." % (fixed,
-                                                                          found)
+            # its a dry run so display to screen but not to log
+            print "%d of %d null strings found would have been fixed." % (fixed,
+                                                                          len(_found))
         else:
+            # really did fix so log and display to screen
             syslog.syslog(syslog.LOG_INFO,
                           "%d of %d null strings found were fixed." % (fixed,
-                                                                       found))
-            print "%d of %d null strings found were fixed." % (fixed, found)
+                                                                       len(_found)))
+            print "%d of %d null strings found were fixed." % (fixed, len(_found))
     elif fix:
         # this should never occur - found some but didn't fix them all when we
-        # should have.
+        # should have
         if options.dry_run:
-            syslog.syslog(syslog.LOG_INFO,
-                          "Could not fix all null strings. %d of %d null strings would have been fixed." % (fixed,
-                                                                                                            found))
+            # its a dry run so say what would have happened
             print "Could not fix all null strings. %d of %d null strings found would have been fixed." % (fixed,
-                                                                                                          found)
+                                                                                                          len(_found))
         else:
+            # really did fix so log and display to screen
             syslog.syslog(syslog.LOG_INFO,
                           "Could not fix all null strings. %d of %d null strings found were fixed." % (fixed,
-                                                                                                       found))
+                                                                                                       len(_found)))
             print "Could not fix all null strings. %d of %d null strings found were fixed." % (fixed,
-                                                                                               found)
+                                                                                               len(_found))
     else:
-        # this is just a check
+        # found some null string but it was only a check not a fix, just
+        # display to screen
         print ("%d null strings were found.\r\n"
-               "Recommend running 'wee_database --fix' to fix these strings." % found)
+               "Recommend running 'wee_database --fix-strings' to fix these strings." % len(_found))
+
+    # and finally details on time taken
     if fix:
-        syslog.syslog(syslog.LOG_INFO, "Applied 'Null String' fix in %0.2f seconds." % tdiff)
-        print "Applied 'Null String' fix in %0.2f seconds." % tdiff
+        syslog.syslog(syslog.LOG_INFO, "Applied 'Null String' fix in %0.3f seconds." % tdiff)
+        print "Applied 'Null String' fix in %0.3f seconds." % tdiff
     else:
+        # it was a check not a fix so just display to screen
         print "Completed 'Null String' check in %0.3f seconds." % tdiff
+    # just in case, set the syslog level back where we found it
+    if options.dry_run or not fix:
+        syslog.setlogmask(_log_level)
 
 def _parse_dates(options):
     """Parse --date, --from and --to command line options.


### PR DESCRIPTION
Submitted this as a PR since I have deviated substantially from the old `check_strings()` - thought this way it would be easier kick this into touch if its no good. Still a few other minor things to tweak but this implements the main changes to `check_strings()` output.

Reworked `check_strings()` screen and syslog output:
- now gives progress à la `--rebuild-daily`
- syslog is silent for both `--check-strings` and `--fix-strings` when used with `--dry-run`
- left 'Preparing' (rather than 'Starting') but added 'this may take a while' as there is a significant delay in `dbmanager.genBatchRows()` initialising at line 619 (well there was some 30 seconds for my 400k records). I think this is long enough we need to tell the user something but I don't see anything else we can do other than the 'this may take a while'