### PR TITLE
Add MySQL Error 2003 to exceptions

### DIFF
--- a/bin/weedb/NOTES.md
+++ b/bin/weedb/NOTES.md
@@ -35,6 +35,7 @@ StandardError
 | weedb class           | Sqlite class       | MySQLdb class      | MySQLdb error number | Description                     |
 |-----------------------|--------------------|--------------------|:--------------------:|---------------------------------|
 | `CannotConnectError`  | *N/A*              | `OperationalError` |         2002         | Server down                     |
+| `CannotConnectError`  | *N/A*              | `OperationalError` |         2003         | Host error                      |
 | `CannotConnectError`  | *N/A*              | `OperationalError` |         2005         | Unknown host                    |
 | `BadPasswordError`    | *N/A*              | `OperationalError` |         1045         | Bad or non-existent password    |
 | `NoDatabaseError`     | *N/A*              | `OperationalError` |         1008         | Drop non-existent database      |

--- a/bin/weedb/mysql.py
+++ b/bin/weedb/mysql.py
@@ -26,6 +26,7 @@ exception_map = {
     1062: weedb.IntegrityError,
     1146: weedb.NoTableError,
     2002: weedb.CannotConnectError,
+    2003: weedb.CannotConnectError,
     2005: weedb.CannotConnectError,
     None: weedb.DatabaseError
     }


### PR DESCRIPTION
Sometimes after I restart my Raspberry Pi, the WiFi connection isn't restored before weewx starts. I noticed that weewx didn't catch MySQL error 2003 (which I got). This commit will map MySQL error 2003 to CannotConnectError.

```
Mar 15 19:04:23 raspberrypi weewx[608]: ****    File "/home/weewx/bin/weewx/manager.py", line 127, in open_with_create
Mar 15 19:04:23 raspberrypi weewx[608]: ****      connection = weedb.connect(database_dict)
Mar 15 19:04:23 raspberrypi weewx[608]: ****    File "/home/weewx/bin/weedb/__init__.py", line 89, in connect
Mar 15 19:04:23 raspberrypi weewx[608]: ****      return driver_mod.connect(**db_dict)
Mar 15 19:04:23 raspberrypi weewx[608]: ****    File "/home/weewx/bin/weedb/mysql.py", line 55, in connect
Mar 15 19:04:23 raspberrypi weewx[608]: ****      database_name=database_name, engine=engine, **kwargs)
Mar 15 19:04:23 raspberrypi weewx[608]: ****    File "/home/weewx/bin/weedb/mysql.py", line 46, in guarded_fn
Mar 15 19:04:23 raspberrypi weewx[608]: ****      raise klass(e)
Mar 15 19:04:23 raspberrypi weewx[608]: ****  DatabaseError: (2003, "Can't connect to MySQL server on '192.168.1.3' (101)")
Mar 15 19:04:23 raspberrypi weewx[608]: ****  Exiting.
```