### PR TITLE
Permite the user to plot some line in the grid with a different colors

### DIFF
--- a/bin/weeplot/genplot.py
+++ b/bin/weeplot/genplot.py
@@ -44,7 +44,11 @@ class GeneralPlot(object):
         self.image_background_color = weeplot.utilities.tobgr(config_dict.get('image_background_color', '0xf5f5f5'))
 
         self.chart_background_color = weeplot.utilities.tobgr(config_dict.get('chart_background_color', '0xd8d8d8'))
-        self.chart_gridline_color   = weeplot.utilities.tobgr(config_dict.get('chart_gridline_color',   '0xa0a0a0'))
+        self.chart_gridline_color        = weeplot.utilities.tobgr(config_dict.get('chart_gridline_color',   '0xa0a0a0'))
+        self.chart_gridline_bold_color   = weeplot.utilities.tobgr(config_dict.get('chart_gridline_bold_color',   '0x545454'))
+        self.chart_gridline_bold_x_spacing = int(config_dict.get('chart_gridline_bold_x_spacing', 1))
+        self.chart_gridline_bold_y_spacing = int(config_dict.get('chart_gridline_bold_y_spacing', 1))
+
         color_list                  = config_dict.get('chart_line_colors', ['0xff0000', '0x00ff00', '0x0000ff'])
         fill_color_list             = config_dict.get('chart_fill_colors', color_list)
         width_list                  = config_dict.get('chart_line_width',  [1, 1, 1])
@@ -271,8 +275,12 @@ class GeneralPlot(object):
 
         drawlabelcount = 0
         for x in weeutil.weeutil.stampgen(self.xscale[0], self.xscale[1], self.xscale[2]) :
-            sdraw.line((x, x), (self.yscale[0], self.yscale[1]), fill=self.chart_gridline_color,
-                       width=self.anti_alias)
+            # plot bold color lines if requested
+            fill=self.chart_gridline_color
+            if self.chart_gridline_bold_color and self.chart_gridline_bold_x_spacing > 1 and drawlabelcount % self.chart_gridline_bold_x_spacing == 0 :
+                fill=self.chart_gridline_bold_color
+            
+            sdraw.line((x, x), (self.yscale[0], self.yscale[1]), fill=fill, width=self.anti_alias)
             if drawlabelcount % self.x_label_spacing == 0 :
                 xlabel = self._genXLabel(x)
                 axis_label_size = sdraw.draw.textsize(xlabel, font=axis_label_font)
@@ -292,9 +300,14 @@ class GeneralPlot(object):
         
         # Draw the (constant y) grid lines 
         for i in xrange(nygridlines) :
+            # plot bold color lines if requested
+            fill=self.chart_gridline_color
+            if self.chart_gridline_bold_color and self.chart_gridline_bold_y_spacing > 1 and i % self.chart_gridline_bold_y_spacing == 0 :
+                fill=self.chart_gridline_bold_color
+            
             y = self.yscale[0] + i * self.yscale[2]
-            sdraw.line((self.xscale[0], self.xscale[1]), (y, y), fill=self.chart_gridline_color,
-                       width=self.anti_alias)
+            sdraw.line((self.xscale[0], self.xscale[1]), (y, y), fill=fill, width=self.anti_alias)
+
             # Draw a label on every other line:
             if i % self.y_label_spacing == 0 :
                 ylabel = self._genYLabel(y)
@@ -554,6 +567,7 @@ class PlotLine(object):
     def __init__(self, x, y, label='', color=None, fill_color=None, width=None, plot_type='line',
                  line_type='solid', marker_type=None, marker_size=10, 
                  bar_width=None, vector_rotate = None, gap_fraction=None,
+                 chart_gridline_bold_x_spacing=1, chart_gridline_bold_y_spacing=1,
                  x_label_spacing=2, y_label_spacing=2):
         self.x               = x
         self.y               = y
@@ -568,6 +582,8 @@ class PlotLine(object):
         self.bar_width       = bar_width
         self.vector_rotate   = vector_rotate
         self.gap_fraction    = gap_fraction
+        self.chart_gridline_bold_x_spacing = chart_gridline_bold_x_spacing
+        self.chart_gridline_bold_y_spacing = chart_gridline_bold_y_spacing
         self.x_label_spacing = x_label_spacing
         self.y_label_spacing = y_label_spacing
 

--- a/bin/weewx/imagegenerator.py
+++ b/bin/weewx/imagegenerator.py
@@ -209,6 +209,10 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
                     x_label_spacing = plot_options.get('x_label_spacing', 2)
                     y_label_spacing = plot_options.get('y_label_spacing', 2)
 
+                    # Get the spacing of the bold lines(every how many lines a bold line is drawn)
+                    chart_gridline_bold_x_spacing = int(plot_options.get('chart_gridline_bold_x_spacing', 1))
+                    chart_gridline_bold_y_spacing = int(plot_options.get('chart_gridline_bold_y_spacing', 1))
+                    
                     # Add the line to the emerging plot:
                     plot.addLine(weeplot.genplot.PlotLine(
                         new_stop_vec_t[0], new_data_vec_t[0],
@@ -223,6 +227,8 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
                         bar_width     = interval_vec,
                         vector_rotate = vector_rotate,
                         gap_fraction  = gap_fraction,
+                        chart_gridline_bold_x_spacing = chart_gridline_bold_x_spacing,
+                        chart_gridline_bold_y_spacing = chart_gridline_bold_y_spacing,
                         x_label_spacing = x_label_spacing,
                         y_label_spacing = y_label_spacing))
 


### PR DESCRIPTION
I added 3 new variables:

- chart_gridline_bold_color, inspired to chart_gridline_color, with default value 0x545454 (a darker gray): the color for plotting some other line, as specified by the spacing defined by the following 2 variables
- chart_gridline_bold_x_spacing: every how many grid lines the vertical darker line is to be plotted
- chart_gridline_bold_y_spacing: every how many grid lines the horizontal darker line is to be plotted

chart_gridline_bold_x_spacing and chart_gridline_bold_y_spacing default to 1, which means no darker lines

An example:

![daytemp](https://cloud.githubusercontent.com/assets/1417508/24018009/7efc163e-0a92-11e7-9b66-89edf3934fef.png)

The docs update is still missing, I'm going to do it afterwards