### PR TITLE
Correct nsteps

### DIFF
--- a/bin/weeplot/utilities.py
+++ b/bin/weeplot/utilities.py
@@ -74,6 +74,12 @@ def scale(fmn, fmx, prescale = (None, None, None), nsteps = 10):
             fmx = fmn + .01*abs(fmn)
 
     frange = fmx - fmn
+    if min_interval :
+        newNsteps = math.ceil(frange / min_interval)
+        if newNsteps > 20 :
+            nsteps = 20
+        else :
+            nsteps = newNsteps
     steps = frange / nsteps
     
     mag = math.floor(math.log10(steps))


### PR DESCRIPTION
This patch solves the problem discussed in https://groups.google.com/forum/#!topic/weewx-user/6gevHcrAoDk : a value of y min interval in yscale causes the yscale to have unwanted max values: the code used a value of 10 for nsteps, while here nsteps takes into account the y interval specified in yscale tuple, till a maximum value of 20 for the new nsteps