### PR TITLE
Add MySQL Error 2006 to exceptions

### DIFF
--- a/bin/weedb/NOTES.md
+++ b/bin/weedb/NOTES.md
@@ -1,6 +1,6 @@
 This table shows how the various MySQLdb and sqlite exceptions are mapped to a weedb exception.
 
-#weewx Version 3.6 or earlier:
+# weewx Version 3.6 or earlier:
 
 | weedb class        | Sqlite class       | MySQLdb class      | MySQLdb error number | Description                     |
 |--------------------|--------------------|--------------------|:--------------------:|---------------------------------|
@@ -17,7 +17,7 @@ This table shows how the various MySQLdb and sqlite exceptions are mapped to a w
 | `OperationalError` | `OperationalError` | `OperationalError` |         1054         | SELECT non-existing column      |
 | `IntegrityError`   | `IntegrityError`   | `IntegrityError`   |         1062         | Duplicate key                   |
 
-###V3.6 Exception hierarchy
+### V3.6 Exception hierarchy
 
 ~~~
 StandardError
@@ -30,13 +30,14 @@ StandardError
 ~~~
 
 
-#weewx Version 3.7 and later:
+# weewx Version 3.7 and later:
 
 | weedb class           | Sqlite class       | MySQLdb class      | MySQLdb error number | Description                     |
 |-----------------------|--------------------|--------------------|:--------------------:|---------------------------------|
 | `CannotConnectError`  | *N/A*              | `OperationalError` |         2002         | Server down                     |
 | `CannotConnectError`  | *N/A*              | `OperationalError` |         2003         | Host error                      |
 | `CannotConnectError`  | *N/A*              | `OperationalError` |         2005         | Unknown host                    |
+| `CannotConnectError`  | *N/A*              | `OperationalError` |         2006         | Server gone                     |
 | `BadPasswordError`    | *N/A*              | `OperationalError` |         1045         | Bad or non-existent password    |
 | `NoDatabaseError`     | *N/A*              | `OperationalError` |         1008         | Drop non-existent database      |
 | `PermissionError`     | `OperationalError` | `OperationalError` |         1044         | No permission                   |
@@ -48,7 +49,7 @@ StandardError
 | `NoColumnError`       | `OperationalError` | `OperationalError` |         1054         | SELECT non-existing column      |
 | `IntegrityError`      | `IntegrityError`   | `IntegrityError`   |         1062         | Duplicate key                   |
 
-###V3.7 Exception hierarchy
+### V3.7 Exception hierarchy
 
 ~~~
 StandardError
@@ -65,4 +66,3 @@ StandardError
       |__BadPasswordError
       |__PermissionError
 ~~~
-

--- a/bin/weedb/mysql.py
+++ b/bin/weedb/mysql.py
@@ -28,6 +28,7 @@ exception_map = {
     2002: weedb.CannotConnectError,
     2003: weedb.CannotConnectError,
     2005: weedb.CannotConnectError,
+    2006: weedb.CannotConnectError,
     None: weedb.DatabaseError
     }
 


### PR DESCRIPTION
I noticed that weewx crashes when the MySQL server is (temporarily) gone. The MySQL client throws MySQL error 2006, which isn't catched by weewx at this moment. This commit will map MySQL error 2006 to CannotConnectError.

```
Mar 24 20:50:02 raspberrypi weewx[613]: ****    File "/home/weewx/bin/weewx/wxservices.py", line 232, in calc_pressure
Mar 24 20:50:02 raspberrypi weewx[613]: ****      data['dateTime'], interval)
Mar 24 20:50:02 raspberrypi weewx[613]: ****    File "/home/weewx/bin/weewx/wxservices.py", line 434, in _get_tempe...re_12h
Mar 24 20:50:02 raspberrypi weewx[613]: ****      record = dbmanager.getRecord(ts12, max_delta=self.max_delta_12h)
Mar 24 20:50:02 raspberrypi weewx[613]: ****    File "/home/weewx/bin/weewx/manager.py", line 369, in getRecord
Mar 24 20:50:02 raspberrypi weewx[613]: ****      (time_start_ts, time_stop_ts, timestamp))
Mar 24 20:50:02 raspberrypi weewx[613]: ****    File "/home/weewx/bin/weedb/mysql.py", line 47, in guarded_fn
Mar 24 20:50:02 raspberrypi weewx[613]: ****      raise klass(e)
Mar 24 20:50:02 raspberrypi weewx[613]: ****  DatabaseError: (2006, 'MySQL server has gone away')
Mar 24 20:50:02 raspberrypi weewx[613]: ****  Exiting.
```