### PR TITLE
Add leafTemp1 and leafWet1 to Archive Types appendix

### DIFF
--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -6688,7 +6688,19 @@ xstats/bin/user/xstats.py</pre>
             <td>X</td>
           </tr>
           <tr>
+            <td class="first_col code">leafTemp1</td>
+            <td>X</td>
+            <td>X</td>
+            <td>X</td>
+          </tr>
+          <tr>
             <td class="first_col code">leafTemp2</td>
+            <td>X</td>
+            <td>X</td>
+            <td>X</td>
+          </tr>
+          <tr>
+            <td class="first_col code">leafWet1</td>
             <td>X</td>
             <td>X</td>
             <td>X</td>


### PR DESCRIPTION
Unless I have missed the obvious (hence the PR) it seems that `leafTemp1` and `leafWet1` have disappeared from the Archive Types appendix in the Customization Guide. Funnily enough `leafTemp2` and `leafWet2` are there but not their friends.