### PR TITLE
Show difference of total daylight in minutes and seconds

### DIFF
--- a/skins/Seasons/celestial.inc
+++ b/skins/Seasons/celestial.inc
@@ -28,12 +28,12 @@
     #set $seconds %= 3600
     #set $minutes = $seconds//60
     #set $seconds %= 60
-    #if $difference > 0
-      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d minutes, %d seconds more than yesterday" % ($hours, $minutes, $seconds, $difference // 60, $difference % 60 )
-    #else
-      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d minutes, %d seconds less than yesterday" % ($hours, $minutes, $seconds, abs($difference) // 60, abs($difference) % 60 )
-    #end if
 
+    #if $difference > 0
+      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%s %d seconds more than yesterday" % ($hours, $minutes, $seconds, str(int($difference) // 60) + ' minutes,' if ($difference // 60) > 0 else '', $difference % 60 if ($difference // 60) > 0 else $difference)
+    #else
+      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%s %d seconds less than yesterday" % ($hours, $minutes, $seconds, str(int($difference) // -60) + ' minutes,' if ($difference // -60) > 0 else '', abs($difference % -60) if ($difference // -60) > 0 else abs($difference))
+    #end if
 
   #end if
 #end if

--- a/skins/Seasons/celestial.inc
+++ b/skins/Seasons/celestial.inc
@@ -29,9 +29,9 @@
     #set $minutes = $seconds//60
     #set $seconds %= 60
     #if $difference > 0
-      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d seconds more than yesterday" % ($hours, $minutes, $seconds, $difference)
+      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d minutes, %d seconds more than yesterday" % ($hours, $minutes, $seconds, $difference // 60, $difference % 60 )
     #else
-      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d seconds less than yesterday" % ($hours, $minutes, $seconds, $difference)
+      #set $daylight_str = "%d hours, %d minutes, %d seconds <br/>%d minutes, %d seconds less than yesterday" % ($hours, $minutes, $seconds, abs($difference) // 60, abs($difference) % 60 )
     #end if
 
 


### PR DESCRIPTION
Show difference of total daylight in "human readable" format (e.g., 3 minutes, 5 seconds more than yesterday).