### PR TITLE
Allow user to specify the Vantage Pro model type in weewx.conf

### DIFF
--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -455,22 +455,18 @@ class Vantage(weewx.drivers.AbstractDevice):
         Default is 4]
         
         iss_id: The station number of the ISS [Optional. Default is 1]
-        
-        model_type: Vantage Pro model type. 1 := Vantage Pro; 2 := Vantage Pro2
-        [Optional. Default is 2]
         """
 
         syslog.syslog(syslog.LOG_DEBUG, 'vantage: driver version is %s' % DRIVER_VERSION)
 
+        # TODO: These values should really be retrieved dynamically from the VP:
+        self.model_type = 2  # = 1 for original VantagePro, = 2 for VP2
         self.hardware_type = None
 
         # These come from the configuration dictionary:
-        self.max_tries  = int(vp_dict.get('max_tries', 4))
-        self.iss_id     = to_int(vp_dict.get('iss_id'))
-        self.model_type = int(vp_dict.get('model_type', 2))
-        if self.model_type not in range (1, 3):
-            raise weewx.UnsupportedFeature("Unknown model_type (%d)" % self.model_type)
-
+        self.max_tries = int(vp_dict.get('max_tries', 4))
+        self.iss_id    = to_int(vp_dict.get('iss_id'))
+        
         self.save_monthRain = None
         self.max_dst_jump = 7200
 
@@ -1179,9 +1175,6 @@ class Vantage(weewx.drivers.AbstractDevice):
         # Get hardware type, if not done yet.
         if self.hardware_type is None:
             self.hardware_type = self._determine_hardware()
-            # Overwrite model_type if we have Vantage Vue.
-            if self.hardware_type == 17:
-                self.model_type = 2
 
         unit_bits              = self._getEEPROM_value(0x29)[0]
         setup_bits             = self._getEEPROM_value(0x2B)[0]

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -1137,9 +1137,12 @@ class Vantage(weewx.drivers.AbstractDevice):
     @property
     def hardware_name(self):    
         if self.hardware_type == 16:
-            return "VantagePro2"
+            if self.model_type == 1:
+                return "Vantage Pro"
+            else:
+                return "Vantage Pro2"
         elif self.hardware_type == 17:
-            return "VantageVue"
+            return "Vantage Vue"
         else:
             raise weewx.UnsupportedFeature("Unknown hardware type %d" % self.hardware_type)
 

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -461,6 +461,7 @@ class Vantage(weewx.drivers.AbstractDevice):
 
         # TODO: These values should really be retrieved dynamically from the VP:
         self.model_type = 2  # = 1 for original VantagePro, = 2 for VP2
+        self.hardware_type = None
 
         # These come from the configuration dictionary:
         self.max_tries = int(vp_dict.get('max_tries', 4))
@@ -1169,7 +1170,10 @@ class Vantage(weewx.drivers.AbstractDevice):
         """Retrieve the EEPROM data block from a VP2 and use it to set various properties"""
         
         self.port.wakeup_console(max_tries=self.max_tries)
-        self.hardware_type = self._determine_hardware()
+
+        # Get hardware type, if not done yet.
+        if self.hardware_type is None:
+            self.hardware_type = self._determine_hardware()
 
         unit_bits              = self._getEEPROM_value(0x29)[0]
         setup_bits             = self._getEEPROM_value(0x2B)[0]

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -455,18 +455,22 @@ class Vantage(weewx.drivers.AbstractDevice):
         Default is 4]
         
         iss_id: The station number of the ISS [Optional. Default is 1]
+        
+        model_type: Vantage Pro model type. 1 := Vantage Pro; 2 := Vantage Pro2
+        [Optional. Default is 2]
         """
 
         syslog.syslog(syslog.LOG_DEBUG, 'vantage: driver version is %s' % DRIVER_VERSION)
 
-        # TODO: These values should really be retrieved dynamically from the VP:
-        self.model_type = 2  # = 1 for original VantagePro, = 2 for VP2
         self.hardware_type = None
 
         # These come from the configuration dictionary:
-        self.max_tries = int(vp_dict.get('max_tries', 4))
-        self.iss_id    = to_int(vp_dict.get('iss_id'))
-        
+        self.max_tries  = int(vp_dict.get('max_tries', 4))
+        self.iss_id     = to_int(vp_dict.get('iss_id'))
+        self.model_type = int(vp_dict.get('model_type', 2))
+        if self.model_type not in range (1, 3):
+            raise weewx.UnsupportedFeature("Unknown model_type (%d)" % self.model_type)
+
         self.save_monthRain = None
         self.max_dst_jump = 7200
 
@@ -1175,6 +1179,9 @@ class Vantage(weewx.drivers.AbstractDevice):
         # Get hardware type, if not done yet.
         if self.hardware_type is None:
             self.hardware_type = self._determine_hardware()
+            # Overwrite model_type if we have Vantage Vue.
+            if self.hardware_type == 17:
+                self.model_type = 2
 
         unit_bits              = self._getEEPROM_value(0x29)[0]
         setup_bits             = self._getEEPROM_value(0x2B)[0]

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -478,7 +478,6 @@ class Vantage(weewx.drivers.AbstractDevice):
 
         # Read the EEPROM and fill in properties in this instance
         self._setup()
-        syslog.syslog(syslog.LOG_DEBUG, "vantage: __init__: hardware determined: %s" % self.hardware_name)
         
     def openPort(self):
         """Open up the connection to the console"""

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -2427,6 +2427,9 @@ class VantageConfEditor(weewx.drivers.AbstractConfEditor):
     # How many times to try before giving up:
     max_tries = 4
 
+    # Vantage model Type: 1 = Vantage Pro; 2 = Vantage Pro2
+    model_type = 2
+
     # The driver to use:
     driver = weewx.drivers.vantage
 """

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -1137,12 +1137,9 @@ class Vantage(weewx.drivers.AbstractDevice):
     @property
     def hardware_name(self):    
         if self.hardware_type == 16:
-            if self.model_type == 1:
-                return "Vantage Pro"
-            else:
-                return "Vantage Pro2"
+            return "VantagePro2"
         elif self.hardware_type == 17:
-            return "Vantage Vue"
+            return "VantageVue"
         else:
             raise weewx.UnsupportedFeature("Unknown hardware type %d" % self.hardware_type)
 

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -478,6 +478,7 @@ class Vantage(weewx.drivers.AbstractDevice):
 
         # Read the EEPROM and fill in properties in this instance
         self._setup()
+        syslog.syslog(syslog.LOG_DEBUG, "vantage: __init__: hardware determined: %s" % self.hardware_name)
         
     def openPort(self):
         """Open up the connection to the console"""

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -26,6 +26,9 @@ max values.
 Fixed bug in wmr200 driver that resulted in archive records with no
 interval field and 'NOT NULL constraint failed: archive.interval' errors.
 
+Vantage driver:
+Allow user to specify the Vantage Pro model type in weewx.conf.
+
 
 3.7.2 MM/DD/YYYY
 


### PR DESCRIPTION
Allow user to specify the Vantage Pro model type in `weewx.conf`.
Only allowed values are `1` for Vantage Pro and `2` for Vantage Pro2.
Vantage Vue will always overwrite `model_type` with value `2.`
If `model_type` is not defined in `weewx.conf` the default will be `2`, as it is hard coded now.
Invalid specified values in `weewx.conf` will raise an exception and stop loading the driver.
Addition:
`_determine_hardware()` function name corrected.
Duplicate `docstring` removed.
Call `_determine_hardware()` only once in `_setup()`