### PR TITLE
Fix #295

### DIFF
--- a/bin/weewx/drivers/ws23xx.py
+++ b/bin/weewx/drivers/ws23xx.py
@@ -343,7 +343,7 @@ class WS23xxConfigurator(weewx.drivers.AbstractConfigurator):
     def show_history(self, ts=None, count=0):
         """Show the indicated number of records or records since timestamp"""
         print "Querying the station for historical records..."
-        for i, r in enumerate(self.station.genStartupRecords(since_ts=ts,
+        for i, r in enumerate(self.station.genArchiveRecords(since_ts=ts,
                                                              count=count)):
             print r
             if count and i > count:


### PR DESCRIPTION
a00babf appears to be a mistaken commit, which was attempted to be reverted in
7e6054513a6ed68bbb52ca1f6e07ffc6ee3bc843 however the reversion was not accurate
and missed reverting the name of the function called on line 337 back to
genArchiveRecords.

Fixes #295