### PR TITLE
Maintain wind direction when speed is zero

### DIFF
--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -204,11 +204,15 @@ class VecStats(object):
  
     @property
     def vec_dir(self):
-        if self.dirsumtime:
+        if self.dirsumtime and self.ysum != 0 and self.xsum != 0:
             _result = 90.0 - math.degrees(math.atan2(self.ysum, self.xsum))
             if _result < 0.0:
                 _result += 360.0
             return _result
+        elif self.last:
+            # Return the last known direction when our vector sum is 0
+            return self.last[1]
+
 
 #===============================================================================
 #                             Class Accum

--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -204,7 +204,7 @@ class VecStats(object):
  
     @property
     def vec_dir(self):
-        if self.dirsumtime and self.ysum != 0 and self.xsum != 0:
+        if self.dirsumtime and (self.ysum or self.xsum):
             _result = 90.0 - math.degrees(math.atan2(self.ysum, self.xsum))
             if _result < 0.0:
                 _result += 360.0

--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -209,10 +209,8 @@ class VecStats(object):
             if _result < 0.0:
                 _result += 360.0
             return _result
-        elif self.last:
-            # Return the last known direction when our vector sum is 0
-            return self.last[1]
-
+		# Return the last known direction when our vector sum is 0
+        return self.last[1]:
 
 #===============================================================================
 #                             Class Accum


### PR DESCRIPTION
Even if ignore_zero_wind was set to False, the wind direction
information could get set to 90º because the x and y sum of the
wind vector would be 0.  This changes the accumulator to
return the last known direction when the sum is otherwise zero.

My anemometer isn't mounted in the best location, but I'd like to be able to tell the difference from when the wind vane isn't changing direction at all and when it is moving, but the wind is too gentle to
register on the anemometer.  I'm using an Ambient Weather ws-1401-ip.