### PR TITLE
Add Solaris SMF config to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -633,6 +633,8 @@ if __name__ == "__main__":
              ['util/newsyslog.d/weewx.conf']),
             ('util/rsyslog.d',
              ['util/rsyslog.d/weewx.conf']),
+            ('util/solaris',
+             ['util/solaris/weewx-smf.xml']),
             ('util/systemd',
              ['util/systemd/weewx.service']),
             ('util/udev/rules.d',


### PR DESCRIPTION
Just realized when doing a test install that the SMF file added in 7cb05c5b674a9466100dec5c36a7cf9aea71edad doesn't get installed without setup.py help.
So here it is, for your convenience.