### PR TITLE
Wind direction filter for fousb.py

### DIFF
--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -49,6 +49,7 @@ FineOffset stations are branded by many vendors, including
  * National Geographic
  * Elecsa
  * Tycon
+ * Aercus Instruments
 
 There are many variants, for example WS1080, WS1090, WH2080, WH2081, WA2080,
 WA2081, WH2081, WH1080, WH1081.  The variations include uv/luminance, solar
@@ -293,7 +294,7 @@ class FOUSBWindDirectionFilter:
     def reject_outliers(self):
         prevailing = self.prevailing_direction()
         filtered = [reading for reading in self.last_readings if self.close_enough(reading, prevailing)]
-        logdbg("*** Rejected %d outliers" % (len(self.last_readings) - len(filtered)))
+        # logdbg("Rejected %d outliers" % (len(self.last_readings) - len(filtered)))
         return filtered
 
     def average_reading(self):
@@ -327,17 +328,14 @@ class FOUSBWindDirectionFilter:
     # the same wind reading will be added again.
     def update_packet(self, packet):
         if packet["windDir"] is not None:
-            logdbg("windDir packet is %.2f" % (packet["windDir"]))
             if packet["windDir"] < 0 or packet["windDir"] > 359:
-                logdbg("*** Rejecting out of range wind direction - substituting average")
+                logdbg("Rejecting out of range wind direction - substituting average")
             else:
                 self.add_reading(packet["windDir"])
             aver = self.average_reading()
-            logdbg("*** WILL update windDir of %.2f to %.2f rolling average" % (packet["windDir"], aver))
+            # logdbg("Updating windDir of %.2f to %.2f rolling average" % (packet["windDir"], aver))
             packet["windDir"] = aver
             packet["windGustDir"] = aver
-        else:
-            logdbg("*** No windDir in packet")
 
 
 def stash(slist, s):

--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -406,6 +406,11 @@ class FOUSBConfEditor(weewx.drivers.AbstractConfEditor):
 
     # The driver to use:
     driver = weewx.drivers.fousb
+
+    # Number of observations to average wind direction over,
+    # to smooth a jittery wind vane.  Zero means do not
+    # average.  A good starting point for experimentation is 15.
+    wind_direction_filter = 0
 """
 
     def get_conf(self, orig_stanza=None):

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -38,6 +38,12 @@ Fixed bug that crashed program if a sqlite permission error occurred.
 If wind speed is zero, accumulators now return last known wind direction
 (instead of None). Thanks to user DigitalDan05. PR #303.
 
+The Fine Offset driver provides an optional smoothing filter which uses
+a rolling average of the last n wind direction observations instead of
+the raw data.  This improves considerably the stability of the reported
+wind direction, at the expense of being slower to react to a genuine
+change of direction.
+
 
 3.8.0 11/22/2017
 


### PR DESCRIPTION
I've been using this modification for a year or so, and thought I would offer it back to the project.  Its purpose is to smooth out the readings from the physically very twitchy wind vane on my Fine Offset derived station.  I am attaching an image captured from wunderground that shows the effect; without averaging, my wind direction is all but useless.

Maybe it should be refactored to be outside the driver, but I don't have the time to do that.  Also I don't know how applicable this is to other makes of station, and don't have access to other stations to test with.

![windaveraging](https://user-images.githubusercontent.com/25867027/37560273-26f555ca-2a2d-11e8-8604-293f599c8f05.PNG)
