### PR TITLE
V3.8.0 python3

### DIFF
--- a/bin/daemon.py
+++ b/bin/daemon.py
@@ -49,20 +49,20 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
     try:
         pid = os.fork()
         if pid > 0: sys.exit(0) # Exit first parent.
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #1 failed: (%d) %s\n" % (e.errno, e.strerror))
         sys.exit(1)
 
     # Decouple from parent environment.
     os.chdir("/")
-    os.umask(0022)
+    os.umask(0o022)
     os.setsid()
 
     # Do second fork.
     try:
         pid = os.fork()
         if pid > 0: sys.exit(0) # Exit second parent.
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror))
         sys.exit(1)
 

--- a/bin/wee_database
+++ b/bin/wee_database
@@ -233,7 +233,7 @@ def rebuildDaily(config_dict, db_binding, options):
         _msg = "Daily summaries from %s through %s inclusive will be rebuilt." % (start_d, stop_d)
 
     syslog.syslog(syslog.LOG_INFO, _msg)
-    print _msg
+    print (_msg)
 
     ans = None
     while ans not in ['y', 'n']:
@@ -472,13 +472,13 @@ def check(config_dict, db_binding, options):
     _daily_summary_version = dbm._read_metadata('Version')
     msg = "Daily summary tables are at version %s" % _daily_summary_version
     syslog.syslog(syslog.LOG_INFO, msg)
-    print msg
+    print (msg)
 
     if _daily_summary_version is not None and _daily_summary_version >= '2.0':
         # interval weighting fix has been applied
         msg = "Interval Weighting Fix is not required."
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
     else:
         print ("Recommend running --update to recalculate interval weightings.")
     print ("Daily summary tables version check completed in %0.2f seconds." % (time.time() - t1))
@@ -504,7 +504,7 @@ def update(config_dict, db_binding, options):
         # we decided not to update the summary tables
         msg = "Update cancelled"
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
         return
 
     if options.dry_run:
@@ -512,7 +512,7 @@ def update(config_dict, db_binding, options):
 
     msg = "Preparing Interval Weighting Fix..."
     syslog.syslog(syslog.LOG_INFO, msg)
-    print msg
+    print (msg)
 
     # notify if this is a dry run
     if options.dry_run:
@@ -536,23 +536,23 @@ def update(config_dict, db_binding, options):
     _daily_summary_version = dbm._read_metadata('Version')
     msg = "Daily summary tables are at version %s" % _daily_summary_version
     syslog.syslog(syslog.LOG_INFO, msg)
-    print msg
+    print (msg)
 
     if _daily_summary_version is not None and _daily_summary_version >= '2.0':
         # interval weighting fix has been applied
         msg = "Interval Weighting Fix is not required."
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
     else:
         # apply the interval weighting
         msg = "Calculating interval weights..."
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
         t1 = time.time()
         weight_obj.run()
         msg = "Interval Weighting Fix completed in %0.2f seconds." % (time.time() - t1)
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
 
     # recalc the max/maxtime windSpeed values
     _fix_wind(config_dict, db_binding, options)
@@ -571,7 +571,7 @@ def _fix_wind(config_dict, db_binding, options):
     t1 = time.time()
     msg = "Preparing Maximum windSpeed Fix..."
     syslog.syslog(syslog.LOG_INFO, msg)
-    print msg
+    print (msg)
 
     # notify if this is a dry run
     if options.dry_run:
@@ -592,11 +592,11 @@ def _fix_wind(config_dict, db_binding, options):
     except weedb.NoTableError, e:
         msg = "Maximum windSpeed Fix applied: no windSpeed found"
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
     else:
         msg = "Maximum windSpeed Fix completed in %0.2f seconds" % (time.time() - t1)
         syslog.syslog(syslog.LOG_INFO, msg)
-        print msg
+        print (msg)
 
 def check_strings(config_dict, db_binding, options, fix=False):
     """Scan the archive table for null strings.

--- a/bin/wee_database
+++ b/bin/wee_database
@@ -193,7 +193,7 @@ def dropDaily(config_dict, db_binding):
     ans = None
     while ans not in ['y', 'n']:
         print "Proceeding will delete all your daily summaries from database '%s'" % database_name
-        ans = raw_input("Are you sure you want to proceed (y/n)? ")
+        ans = input("Are you sure you want to proceed (y/n)? ")
         if ans == 'y' :
             t1 = time.time()
             print "Dropping daily summary tables from '%s' ... " % database_name
@@ -237,7 +237,7 @@ def rebuildDaily(config_dict, db_binding, options):
 
     ans = None
     while ans not in ['y', 'n']:
-        ans = raw_input("Proceed (y/n)? ")
+        ans = input("Proceed (y/n)? ")
         if ans == 'y':
             break
         elif ans == 'n':
@@ -291,7 +291,7 @@ def reconfigMainDatabase(config_dict, db_binding):
     except weedb.DatabaseExists:
         ans = None
         while ans not in ['y', 'n']:
-            ans = raw_input("New database '%s' already exists. Delete it first (y/n)? " % (new_database_dict['database_name'],))
+            ans = input("New database '%s' already exists. Delete it first (y/n)? " % (new_database_dict['database_name'],))
             if ans == 'y':
                 weedb.drop(new_database_dict)
             elif ans == 'n':
@@ -326,7 +326,7 @@ def reconfigMainDatabase(config_dict, db_binding):
             print ("Units will be converted from the '%s' system to the '%s' system." %
                    (weewx.units.unit_nicknames[old_unit_system],
                     weewx.units.unit_nicknames[target_unit_system]))
-        ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+        ans = input("Are you sure you wish to proceed (y/n)? ")
         if ans == 'y':
             t1 = time.time()
             weewx.manager.reconfig(manager_dict['database_dict'],
@@ -398,7 +398,7 @@ def transferDatabase(config_dict, db_binding, options):
         if not options.dry_run: # is it a dry run ?
             # not a dry run, actually do the transfer
             while ans not in ['y', 'n']:
-                ans = raw_input("Transfer %s records from source database '%s' to destination database '%s' (y/n)? " %
+                ans = input("Transfer %s records from source database '%s' to destination database '%s' (y/n)? " %
                                 (num_recs, src_manager.database_name, dest_manager_dict['database_dict']['database_name']))
                 if ans == 'y':
                     t1 = time.time()
@@ -499,7 +499,7 @@ def update(config_dict, db_binding, options):
     # prompt for confirmation if it is not a dry run
     ans = 'y' if options.dry_run else None
     while ans not in ['y', 'n']:
-        ans = raw_input("The update process does not affect archive data, but does alter the database.\nContinue (y/n)? ")
+        ans = input("The update process does not affect archive data, but does alter the database.\nContinue (y/n)? ")
     if ans == 'n':
         # we decided not to update the summary tables
         msg = "Update cancelled"

--- a/bin/wee_database
+++ b/bin/wee_database
@@ -131,7 +131,7 @@ def main():
 
     # get config_dict to use
     config_path, config_dict = weecfg.read_config(options.config_path, args)
-    print "Using configuration file %s" % config_path
+    print ("Using configuration file %s" % config_path)
 
     # set syslog level based
     if int(config_dict.get('debug', 0)):
@@ -141,7 +141,7 @@ def main():
 
     db_binding = options.binding
     database = config_dict['DataBindings'][db_binding]['database']
-    print "Using database binding '%s', which is bound to database '%s'" % (db_binding, database)
+    print ("Using database binding '%s', which is bound to database '%s'" % (db_binding, database))
 
     if options.create_database:
         createMainDatabase(config_dict, db_binding)
@@ -177,11 +177,11 @@ def createMainDatabase(config_dict, db_binding):
     # exists and is initialized. Otherwise, an exception will be thrown.
     try:
         with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
-            print "Database '%s' already exists. Nothing done." % (dbmanager.database_name,)
+            print ("Database '%s' already exists. Nothing done." % (dbmanager.database_name,))
     except weedb.OperationalError:
         # Database does not exist. Try again, but allow initialization:
         with weewx.manager.open_manager_with_config(config_dict, db_binding, initialize=True) as dbmanager:
-            print "Created database '%s'" % (dbmanager.database_name,)
+            print ("Created database '%s'" % (dbmanager.database_name,))
 
 def dropDaily(config_dict, db_binding):
     """Drop the daily summaries from a weeWX database"""
@@ -192,23 +192,23 @@ def dropDaily(config_dict, db_binding):
 
     ans = None
     while ans not in ['y', 'n']:
-        print "Proceeding will delete all your daily summaries from database '%s'" % database_name
+        print ("Proceeding will delete all your daily summaries from database '%s'" % database_name)
         ans = input("Are you sure you want to proceed (y/n)? ")
         if ans == 'y' :
             t1 = time.time()
-            print "Dropping daily summary tables from '%s' ... " % database_name
+            print ("Dropping daily summary tables from '%s' ... " % database_name)
             try:
                 with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
                     try:
                         dbmanager.drop_daily()
                     except weedb.OperationalError, e:
-                        print "Got error '%s'\nPerhaps there was no daily summary?" % e
+                        print ("Got error '%s'\nPerhaps there was no daily summary?" % e)
                     else:
                         tdiff = time.time() - t1
-                        print "Daily summary tables dropped from database '%s' in %.2f seconds" % (database_name, tdiff)
+                        print ("Daily summary tables dropped from database '%s' in %.2f seconds" % (database_name, tdiff))
             except weedb.OperationalError:
                 # No daily summaries. Nothing to be done.
-                print "No daily summaries found in database '%s'. Nothing done." % (database_name,)
+                print ("No daily summaries found in database '%s'. Nothing done." % (database_name,))
 
 def rebuildDaily(config_dict, db_binding, options):
     """Rebuild the daily summaries."""
@@ -241,7 +241,7 @@ def rebuildDaily(config_dict, db_binding, options):
         if ans == 'y':
             break
         elif ans == 'n':
-            print "Nothing done."
+            print ("Nothing done.")
             return
 
     t1 = time.time()
@@ -251,9 +251,9 @@ def rebuildDaily(config_dict, db_binding, options):
     with weewx.manager.open_manager_with_config(config_dict, db_binding, initialize=True) as dbmanager:
 
         syslog.syslog(syslog.LOG_INFO, "Rebuilding daily summaries in database '%s' ..." % database_name)
-        print "Rebuilding daily summaries in database '%s' ..." % database_name
+        print ("Rebuilding daily summaries in database '%s' ..." % database_name)
         if options.dry_run:
-            print "Dry run. Nothing done."
+            print ("Dry run. Nothing done.")
             return
         else:
             # now do the actual rebuild
@@ -266,12 +266,12 @@ def rebuildDaily(config_dict, db_binding, options):
     if nrecs:
         sys.stdout.flush()
         print
-        print "Processed %d records to rebuild %d day summaries in %.2f seconds      " % (nrecs,
+        print ("Processed %d records to rebuild %d day summaries in %.2f seconds      " % (nrecs,
                                                                                           ndays,
-                                                                                          tdiff)
-        print "Rebuild of daily summaries in database '%s' complete" % database_name
+                                                                                          tdiff))
+        print ("Rebuild of daily summaries in database '%s' complete" % database_name)
     else:
-        print "Daily summaries up to date in '%s'" % database_name
+        print ("Daily summaries up to date in '%s'" % database_name)
 
 def reconfigMainDatabase(config_dict, db_binding):
     """Create a new database, then populate it with the contents of an old database"""
@@ -295,7 +295,7 @@ def reconfigMainDatabase(config_dict, db_binding):
             if ans == 'y':
                 weedb.drop(new_database_dict)
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
                 return
 
     # Get the unit system of the old archive:
@@ -303,7 +303,7 @@ def reconfigMainDatabase(config_dict, db_binding):
         old_unit_system = old_dbmanager.std_unit_system
 
     if old_unit_system is None:
-        print "Old database has not been initialized. Nothing to be done."
+        print ("Old database has not been initialized. Nothing to be done.")
         return
 
     # Get the unit system of the new archive:
@@ -317,8 +317,8 @@ def reconfigMainDatabase(config_dict, db_binding):
 
     ans = None
     while ans not in ['y', 'n']:
-        print "Copying database '%s' to '%s'" % (manager_dict['database_dict']['database_name'],
-                                                 new_database_dict['database_name'])
+        print ("Copying database '%s' to '%s'" % (manager_dict['database_dict']['database_name'],
+                                                 new_database_dict['database_name']))
         if target_unit_system is None or old_unit_system==target_unit_system:
             print ("The new database will use the same unit system as the old ('%s')." %
                    (weewx.units.unit_nicknames[old_unit_system],))
@@ -334,18 +334,18 @@ def reconfigMainDatabase(config_dict, db_binding):
                                    new_unit_system=target_unit_system,
                                    new_schema=manager_dict['schema'])
             tdiff = time.time() - t1
-            print "Database '%s' copied to '%s' in %.2f seconds." % (manager_dict['database_dict']['database_name'],
+            print ("Database '%s' copied to '%s' in %.2f seconds." % (manager_dict['database_dict']['database_name'],
                                                                      new_database_dict['database_name'],
-                                                                     tdiff)
+                                                                     tdiff))
         elif ans == 'n':
-            print "Nothing done."
+            print ("Nothing done.")
 
 def transferDatabase(config_dict, db_binding, options):
     """Transfer 'archive' data from one database to another"""
 
     # do we have enough to go on, must have a dest binding
     if options.dest_binding is None:
-        print "Destination binding not specified. Nothing Done. Aborting."
+        print ("Destination binding not specified. Nothing Done. Aborting.")
         return
     # get manager dict for our source binding
     src_manager_dict = weewx.manager.get_manager_dict_from_config(config_dict,
@@ -358,25 +358,25 @@ def transferDatabase(config_dict, db_binding, options):
         # if we can't find the binding display a message then return
         print ("Unknown destination binding '%s', confirm destination binding." %
                (options.dest_binding, ))
-        print "Nothing Done. Aborting."
+        print ("Nothing Done. Aborting.")
         return
     except weewx.UnknownDatabase:
         # if we can't find the database display a message then return
-        print "Error accessing destination database, confirm destination binding and/or database."
-        print "Nothing Done. Aborting."
+        print ("Error accessing destination database, confirm destination binding and/or database.")
+        print ("Nothing Done. Aborting.")
         return
     except (ValueError, AttributeError):
         # maybe a schema issue
-        print "Error accessing destination database."
+        print ("Error accessing destination database.")
         print ("Maybe the destination schema is incorrectly specified in binding '%s' in weewx.conf?" %
                (options.dest_binding, ))
-        print "Nothing Done. Aborting."
+        print ("Nothing Done. Aborting.")
         return
     except (weewx.UnknownDatabaseType):
         # maybe a [Databases] issue
-        print "Error accessing destination database."
-        print "Maybe the destination database is incorrectly defined in weewx.conf?"
-        print "Nothing Done. Aborting."
+        print ("Error accessing destination database.")
+        print ("Maybe the destination database is incorrectly defined in weewx.conf?")
+        print ("Nothing Done. Aborting.")
         return
     # get a manager for our source
     with weewx.manager.Manager.open(src_manager_dict['database_dict']) as src_manager:
@@ -392,7 +392,7 @@ def transferDatabase(config_dict, db_binding, options):
             # we have no source records to transfer so abort with a message
             print ("No records found in source database '%s' for transfer." %
                    (src_manager.database_name, ))
-            print "Nothing done. Aborting."
+            print ("Nothing done. Aborting.")
             exit()
         ans = None
         if not options.dry_run: # is it a dry run ?
@@ -412,7 +412,7 @@ def transferDatabase(config_dict, db_binding, options):
                             # do the transfer, should be quick as it's done as a
                             # single transaction
                             dest_manager.addRecord(src_manager.genBatchRecords())
-                            print "complete"
+                            print ("complete")
                             # get first and last timestamps from the dest so we can
                             # count the records transferred and display a message
                             first_ts = dest_manager.firstGoodStamp()
@@ -432,25 +432,25 @@ def transferDatabase(config_dict, db_binding, options):
                         # Probably when trying to load db driver
                         print ("Error accessing destination database '%s'." %
                                (dest_manager_dict['database_dict']['database_name'], ))
-                        print "Nothing done. Aborting."
+                        print ("Nothing done. Aborting.")
                         raise
                     except (OSError, weedb.OperationalError):
                         # probably a weewx.conf typo or MySQL db not created
                         print ("Error accessing destination database '%s'." %
                                (dest_manager_dict['database_dict']['database_name'], ))
-                        print "Maybe it does not exist (MySQL) or is incorrectly defined in weewx.conf?"
-                        print "Nothing done. Aborting."
+                        print ("Maybe it does not exist (MySQL) or is incorrectly defined in weewx.conf?")
+                        print ("Nothing done. Aborting.")
                         return
 
                 elif ans == 'n':
                     # we decided not to do the transfer
-                    print "Nothing done."
+                    print ("Nothing done.")
                     return
         else:
             # it's a dry run so say what we would have done then return
             print ("Transfer %s records from source database '%s' to destination database '%s'." %
                    (num_recs, src_manager.database_name, dest_manager_dict['database_dict']['database_name']))
-            print "Dry run, nothing done."
+            print ("Dry run, nothing done.")
 
 def check(config_dict, db_binding, options):
     """Check database and report outstanding fixes/issues.
@@ -463,7 +463,7 @@ def check(config_dict, db_binding, options):
     t1 = time.time()
 
     # Check interval weighting
-    print "Checking daily summary tables version..."
+    print ("Checking daily summary tables version...")
 
     # Get a database manager object
     dbm = weewx.manager.open_manager_with_config(config_dict, db_binding)
@@ -480,8 +480,8 @@ def check(config_dict, db_binding, options):
         syslog.syslog(syslog.LOG_INFO, msg)
         print msg
     else:
-        print "Recommend running --update to recalculate interval weightings."
-    print "Daily summary tables version check completed in %0.2f seconds." % (time.time() - t1)
+        print ("Recommend running --update to recalculate interval weightings.")
+    print ("Daily summary tables version check completed in %0.2f seconds." % (time.time() - t1))
 
     # now check for null strings
     check_strings(config_dict, db_binding, options, fix=False)
@@ -516,7 +516,7 @@ def update(config_dict, db_binding, options):
 
     # notify if this is a dry run
     if options.dry_run:
-        print "This is a dry run: weighted intervals will be calculated but not saved."
+        print ("This is a dry run: weighted intervals will be calculated but not saved.")
 
     # Get a database manager object
     dbm = weewx.manager.open_manager_with_config(config_dict, db_binding)
@@ -575,7 +575,7 @@ def _fix_wind(config_dict, db_binding, options):
 
     # notify if this is a dry run
     if options.dry_run:
-        print "This is a dry run: maximum windSpeed will be calculated but not saved."
+        print ("This is a dry run: maximum windSpeed will be calculated but not saved.")
 
     # construct a windSpeed recalculation config dict
     wind_config_dict = {'name': 'Maximum windSpeed Fix',
@@ -610,12 +610,12 @@ def check_strings(config_dict, db_binding, options, fix=False):
         _log_level = syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_WARNING))
     if fix:
         syslog.syslog(syslog.LOG_INFO, "Preparing Null String Fix")
-        print "Preparing Null String Fix, this may take a while..."
+        print ("Preparing Null String Fix, this may take a while...")
         # notify if this is a dry run
         if options.dry_run:
-            print "This is a dry run: null strings will be detected but not fixed"
+            print ("This is a dry run: null strings will be detected but not fixed")
     else:
-        print "Preparing Null String Check, this may take awhile..."
+        print ("Preparing Null String Check, this may take awhile...")
 
     # open up the main database archive table
     with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
@@ -683,44 +683,44 @@ def check_strings(config_dict, db_binding, options, fix=False):
     tdiff = time.time() - t1
     # now display details of what we found if we found any null strings
     if len(_found) > 0:
-        print "The following null strings were found:"
+        print ("The following null strings were found:")
         for item in _found:
             if len(item) == 4:
-                print "Timestamp = %s; record['%s'] = %r; ... changed to %r" % item
+                print ("Timestamp = %s; record['%s'] = %r; ... changed to %r" % item)
             else:
-                print "Timestamp = %s; record['%s'] = %r; ... ignored" % item
+                print ("Timestamp = %s; record['%s'] = %r; ... ignored" % item)
     # how many did we fix?
     fixed = len([a for a in _found if len(a)==4])
     # summarise our results
     if len(_found) == 0:
         # found no null strings, log it and display on screen
         syslog.syslog(syslog.LOG_INFO, "No null strings found.")
-        print "No null strings found."
+        print ("No null strings found.")
     elif fixed == len(_found):
         # fixed all we found
         if options.dry_run:
             # its a dry run so display to screen but not to log
-            print "%d of %d null strings found would have been fixed." % (fixed,
-                                                                          len(_found))
+            print ("%d of %d null strings found would have been fixed." % (fixed,
+                                                                          len(_found)))
         else:
             # really did fix so log and display to screen
             syslog.syslog(syslog.LOG_INFO,
                           "%d of %d null strings found were fixed." % (fixed,
                                                                        len(_found)))
-            print "%d of %d null strings found were fixed." % (fixed, len(_found))
+            print ("%d of %d null strings found were fixed." % (fixed, len(_found)))
     elif fix:
         # this should never occur - found some but didn't fix them all when we
         # should have
         if options.dry_run:
             # its a dry run so say what would have happened
-            print "Could not fix all null strings. %d of %d null strings found would have been fixed." % (fixed,
-                                                                                                          len(_found))
+            print ("Could not fix all null strings. %d of %d null strings found would have been fixed." % (fixed,
+                                                                                                          len(_found)))
         else:
             # really did fix so log and display to screen
             syslog.syslog(syslog.LOG_INFO,
                           "Could not fix all null strings. %d of %d null strings found were fixed." % (fixed,
                                                                                                        len(_found)))
-            print "Could not fix all null strings. %d of %d null strings found were fixed." % (fixed,
+            print ("Could not fix all null strings. %d of %d null strings found were fixed." % (fixed,
                                                                                                len(_found))
     else:
         # found some null string but it was only a check not a fix, just
@@ -731,10 +731,10 @@ def check_strings(config_dict, db_binding, options, fix=False):
     # and finally details on time taken
     if fix:
         syslog.syslog(syslog.LOG_INFO, "Applied Null String Fix in %0.2f seconds." % tdiff)
-        print "Applied Null String Fix in %0.2f seconds." % tdiff
+        print ("Applied Null String Fix in %0.2f seconds." % tdiff)
     else:
         # it was a check not a fix so just display to screen
-        print "Completed Null String Check in %0.2f seconds." % tdiff
+        print ("Completed Null String Check in %0.2f seconds." % tdiff)
     # just in case, set the syslog level back where we found it
     if options.dry_run or not fix:
         syslog.setlogmask(_log_level)

--- a/bin/wee_database
+++ b/bin/wee_database
@@ -201,7 +201,7 @@ def dropDaily(config_dict, db_binding):
                 with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
                     try:
                         dbmanager.drop_daily()
-                    except weedb.OperationalError, e:
+                    except weedb.OperationalError as e:
                         print ("Got error '%s'\nPerhaps there was no daily summary?" % e)
                     else:
                         tdiff = time.time() - t1
@@ -589,7 +589,7 @@ def _fix_wind(config_dict, db_binding, options):
     # perform the recalculation, wrap in a try..except to catch any db errors
     try:
         wind_obj.run()
-    except weedb.NoTableError, e:
+    except weedb.NoTableError as e:
         msg = "Maximum windSpeed Fix applied: no windSpeed found"
         syslog.syslog(syslog.LOG_INFO, msg)
         print (msg)

--- a/bin/wee_debug
+++ b/bin/wee_debug
@@ -230,10 +230,10 @@ def generateDebugInfo(config_dict, config_path, db_binding_wx, verbosity):
     # weewx archive info
     try:
         manager_info_dict = getManagerInfo(config_dict, db_binding_wx)
-    except weedb.CannotConnect, e:
+    except weedb.CannotConnect as e:
         print ("Unable to connect to database:", e)
         print
-    except weedb.OperationalError, e:
+    except weedb.OperationalError as e:
         print ("Error hitting database. It may not be properly initialized:")
         print (e)
         print

--- a/bin/wee_debug
+++ b/bin/wee_debug
@@ -107,9 +107,9 @@ def main():
     # check weewx version number for compatibility
     if VERSION[0] < 3:
         # incompatible version of weewx
-        print "Incompatible version of weewx detected (%s). Weewx v3.0.0 or greater required." % \
-            VERSION
-        print "Nothing done, exiting."
+        print ("Incompatible version of weewx detected (%s). Weewx v3.0.0 or greater required." % \
+            VERSION)
+        print ("Nothing done, exiting.")
         exit(1)
 
     # get config_dict to use
@@ -117,24 +117,24 @@ def main():
 
     # display wee_debug version info
     if options.version:
-        print "wee_debug version: %s" % WEE_DEBUG_VERSION
+        print ("wee_debug version: %s" % WEE_DEBUG_VERSION)
         exit(1)
 
     # display debug info
     if options.info:
         # first a message re verbosity
         if options.verbosity == 0:
-            print "Using verbosity=0, displaying minimal info"
+            print ("Using verbosity=0, displaying minimal info")
         elif options.verbosity == 1:
-            print "Using verbosity=1, displaying most info"
+            print ("Using verbosity=1, displaying most info")
         else:
-            print "Using verbosity=2, displaying all info"
+            print ("Using verbosity=2, displaying all info")
         print
         # then a message re output destination
         if options.debug_file is not None:
-            print "wee_debug output will be written to %s" % options.debug_file
+            print ("wee_debug output will be written to %s" % options.debug_file)
         else:
-            print "wee_debug output will be sent to stdout(console)"
+            print ("wee_debug output will be sent to stdout(console)")
         print
 
         # get some key weewx parameters
@@ -149,9 +149,9 @@ def main():
             _debug_file = open(options.debug_file, 'w')
             # redirect stdout to our file
             sys.stdout = _debug_file
-        print "Using configuration file %s" % config_path
-        print "Using database binding '%s', which is bound to database '%s'" % (db_binding_wx,
-                                                                                database_wx)
+        print ("Using configuration file %s" % config_path)
+        print ("Using database binding '%s', which is bound to database '%s'" % (db_binding_wx,
+                                                                                database_wx))
         print
         # generate our debug info
         generateDebugInfo(config_dict,
@@ -159,7 +159,7 @@ def main():
                           db_binding_wx,
                           options.verbosity)
         print
-        print "Parsed and obfuscated weewx.conf"
+        print ("Parsed and obfuscated weewx.conf")
         # generate our obfuscated weewx.conf
         generateDebugConf(config_dict)
         if options.debug_file is not None:
@@ -167,10 +167,10 @@ def main():
             _debug_file.close()
             # revert stdout
             sys.stdout = old_stdout
-            print "wee_debug output successfully written to %s" % options.debug_file
+            print ("wee_debug output successfully written to %s" % options.debug_file)
         else:
             print
-            print "wee_debug report successfully generated"
+            print ("wee_debug report successfully generated")
         exit(1)
 
     # if we have a compatible weewx version but did not use --version or --info
@@ -201,27 +201,27 @@ def generateDebugInfo(config_dict, config_path, db_binding_wx, verbosity):
     generateSysInfo(verbosity)
 
     # weewx version info
-    print "General Weewx info"
-    print "  Weewx version %s detected." % VERSION
+    print ("General Weewx info")
+    print ("  Weewx version %s detected." % VERSION)
     print
 
     # station info
-    print "Station info"
+    print ("Station info")
     stationType = config_dict['Station']['station_type']
-    print "  Station type: %s" % stationType
-    print "  Driver:       %s" % config_dict[stationType]['driver']
+    print ("  Station type: %s" % stationType)
+    print ("  Driver:       %s" % config_dict[stationType]['driver'])
     print
 
     # driver info
     if verbosity > 0:
-        print "Driver info"
+        print ("Driver info")
         driver_dict = {stationType: config_dict[stationType]}
         _config = ConfigObj(driver_dict)
         _config.write(sys.stdout)
         print
 
     # installed extensions info
-    print "Currently installed extensions"
+    print ("Currently installed extensions")
     ext = ExtensionEngine(config_path=config_path,
                           config_dict=config_dict)
     ext.enumerate_extensions()
@@ -231,61 +231,61 @@ def generateDebugInfo(config_dict, config_path, db_binding_wx, verbosity):
     try:
         manager_info_dict = getManagerInfo(config_dict, db_binding_wx)
     except weedb.CannotConnect, e:
-        print "Unable to connect to database:", e
+        print ("Unable to connect to database:", e)
         print
     except weedb.OperationalError, e:
-        print "Error hitting database. It may not be properly initialized:"
-        print e
+        print ("Error hitting database. It may not be properly initialized:")
+        print (e)
         print
     else:
         if manager_info_dict['units'] in weewx.units.unit_nicknames:
             units_nickname = weewx.units.unit_nicknames[manager_info_dict['units']]
         else:
             units_nickname = "Unknown unit constant"
-        print "Archive info"
-        print "  Database name:        %s" % manager_info_dict['db_name']
-        print "  Table name:           %s" % manager_info_dict['table_name']
-        print "  Unit system:          %s (%s)" % (manager_info_dict['units'],
-                                                  units_nickname)
-        print "  First good timestamp: %s" % timestamp_to_string(manager_info_dict['first_ts'])
-        print "  Last good timestamp:  %s" % timestamp_to_string(manager_info_dict['last_ts'])
+        print ("Archive info")
+        print ("  Database name:        %s" % manager_info_dict['db_name'])
+        print ("  Table name:           %s" % manager_info_dict['table_name'])
+        print ("  Unit system:          %s (%s)" % (manager_info_dict['units'],
+                                                  units_nickname))
+        print ("  First good timestamp: %s" % timestamp_to_string(manager_info_dict['first_ts']))
+        print ("  Last good timestamp:  %s" % timestamp_to_string(manager_info_dict['last_ts']))
         if manager_info_dict['ts_count']:
-            print "  Number of records:    %s" % manager_info_dict['ts_count'].value
+            print ("  Number of records:    %s" % manager_info_dict['ts_count'].value)
         else:
-            print "  Number of records:    %s (no archive records found)" % \
-                manager_info_dict['ts_count']
+            print ("  Number of records:    %s (no archive records found)" % \
+                manager_info_dict['ts_count'])
         # if we have a database and a table but no start or stop ts and no records
         # inform the user that the database/table exists but appears empty
         if (manager_info_dict['db_name'] and manager_info_dict['table_name']) and \
         not (manager_info_dict['ts_count'] or manager_info_dict['units'] or \
         manager_info_dict['first_ts'] or manager_info_dict['last_ts']):
-            print "                        It is likely that the database (%s) archive table (%s)" % \
-                (manager_info_dict['db_name'], manager_info_dict['table_name'])
-            print "                        exists but contains no data."
-        print "  weewx (weewx.conf) is set to use an archive interval of %s seconds." % \
-            config_dict['StdArchive']['archive_interval']
-        print "  The station hardware was not interrogated in determining archive interval."
+            print ("                        It is likely that the database (%s) archive table (%s)" % \
+                (manager_info_dict['db_name'], manager_info_dict['table_name']))
+            print ("                        exists but contains no data.")
+        print ("  weewx (weewx.conf) is set to use an archive interval of %s seconds." % \
+            config_dict['StdArchive']['archive_interval'])
+        print ("  The station hardware was not interrogated in determining archive interval.")
         print
 
     # weewx database info
     if verbosity > 0:
-        print "Databases configured in weewx.conf"
+        print ("Databases configured in weewx.conf")
         for db_keys in config_dict['Databases']:
             database_dict = weewx.manager.get_database_dict_from_config(config_dict,
                                                                         db_keys)
             _ = sorted(database_dict.keys())
-            print "  Database name:        %s" % database_dict['database_name']
-            print "  Database driver:      %s" % database_dict['driver']
+            print ("  Database name:        %s" % database_dict['database_name'])
+            print ("  Database driver:      %s" % database_dict['driver'])
             if 'host' in database_dict:
-                print "  Database host:        %s" % database_dict['host']
+                print ("  Database host:        %s" % database_dict['host'])
             print
 
     # sqlkeys/obskeys info
     if verbosity > 1:
-        print "Supported SQL keys"
+        print ("Supported SQL keys")
         formatListCols(manager_info_dict['sqlkeys'], 3)
         print
-        print "Supported observation keys"
+        print ("Supported observation keys")
         formatListCols(manager_info_dict['obskeys'], 3)
         print
 
@@ -301,28 +301,28 @@ def generateDebugConf(config_dict):
 
 def generateSysInfo(verbosity):
     # % string operator deprecated Python 3.1 and up.
-    print "System info"
+    print ("System info")
 
     if verbosity > 0:
-       print "  Platform:       " + platform.platform()
-       print "  Python Version: " + platform.python_version()
+       print ("  Platform:       " + platform.platform())
+       print ("  Python Version: " + platform.python_version())
 
        # environment 
        if verbosity > 1:
-          print "\nEnvironment"
+          print ("\nEnvironment")
           for n in os.environ:
-             print "  %s=%s" % (n, os.environ[n])
+             print ("  %s=%s" % (n, os.environ[n]))
 
        # load info
        try:
            loadavg =  '%.2f %.2f %.2f' % os.getloadavg()
            (load1, load5, load15) = loadavg.split(" ")
    
-           print "\nLoad Information\n  1 minute load average:  " + load1
-           print "  5 minute load average:  " + load5
-           print "  15 minute load average: " + load15
+           print ("\nLoad Information\n  1 minute load average:  " + load1)
+           print ("  5 minute load average:  " + load5)
+           print ("  15 minute load average: " + load15)
        except OSError:
-           print "Sorry, the load average not available on this platform"
+           print ("Sorry, the load average not available on this platform")
 
     print
 
@@ -421,7 +421,7 @@ def formatListCols(the_list, cols):
     justifyList = map(lambda x: x.ljust(max_width), the_list)
     lines = (' '.join(justifyList[i:i + cols])
              for i in xrange(0, len(justifyList), cols))
-    print "\n".join(lines)
+    print ("\n".join(lines))
 
 if __name__=="__main__" :
     main()

--- a/bin/wee_device
+++ b/bin/wee_device
@@ -17,7 +17,7 @@ def main():
 
     # Load the configuration file
     config_fn, config_dict = weecfg.read_config(None, sys.argv[1:])
-    print 'Using configuration file %s' % config_fn
+    print ('Using configuration file %s' % config_fn)
 
     try:
         # Find the device type
@@ -36,8 +36,8 @@ def main():
         driver_name = driver_module.DRIVER_NAME
         driver_vers = driver_module.DRIVER_VERSION \
             if hasattr(driver_module, 'DRIVER_VERSION') else '?'
-        print 'Using %s driver version %s (%s)' % (
-            driver_name, driver_vers, driver)
+        print ('Using %s driver version %s (%s)' % (
+            driver_name, driver_vers, driver))
     except AttributeError, e:
         msg = "The driver %s does not include a configuration tool" % driver
         syslog.syslog(syslog.LOG_INFO, "%s: %s" % (msg, e))
@@ -45,7 +45,7 @@ def main():
     except Exception, e:
         msg = "Cannot load configurator for %s" % device_type
         syslog.syslog(syslog.LOG_ERR, "%s: %s" % (msg, e))
-        print msg
+        print (msg)
         exit(1)
 
     device.configure(config_dict)

--- a/bin/wee_device
+++ b/bin/wee_device
@@ -23,7 +23,7 @@ def main():
         # Find the device type
         device_type = config_dict['Station']['station_type']
         driver = config_dict[device_type]['driver']
-    except KeyError, e:
+    except KeyError as e:
         sys.exit("No configuration for device %s" % e)
 
     # Try to load the driver
@@ -38,11 +38,11 @@ def main():
             if hasattr(driver_module, 'DRIVER_VERSION') else '?'
         print ('Using %s driver version %s (%s)' % (
             driver_name, driver_vers, driver))
-    except AttributeError, e:
+    except AttributeError as e:
         msg = "The driver %s does not include a configuration tool" % driver
         syslog.syslog(syslog.LOG_INFO, "%s: %s" % (msg, e))
         exit(0)
-    except Exception, e:
+    except Exception as e:
         msg = "Cannot load configurator for %s" % device_type
         syslog.syslog(syslog.LOG_ERR, "%s: %s" % (msg, e))
         print (msg)

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -651,47 +651,47 @@ def main():
                                                               args,
                                                               wlog)
         source_obj.run()
-    except weeimport.weeimport.WeeImportOptionError, e:
+    except weeimport.weeimport.WeeImportOptionError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Command line option error.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportIOError, e:
+    except weeimport.weeimport.WeeImportIOError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load source file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportFieldError, e:
+    except weeimport.weeimport.WeeImportFieldError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to map source data.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportMapError, e:
+    except weeimport.weeimport.WeeImportMapError as e:
         wlog.printlog(syslog.LOG_INFO,
                       "**** Unable to parse source-to-weewx field map.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature), e:
+    except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         print
         parser.print_help()
         exit(1)
-    except SystemExit, e:
+    except SystemExit as e:
         print (e)
         exit(0)
-    except (ValueError, weewx.UnitError), e:
+    except (ValueError, weewx.UnitError) as e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except IOError, e:
+    except IOError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load config file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print ("**** Nothing done, exiting.")

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -626,13 +626,13 @@ def main():
 
     # check weewx version number for compatibility
     if StrictVersion(weewx.__version__) < StrictVersion(REQUIRED_WEEWX):
-        print "weewx %s or greater is required, found %s. Nothing done, exiting." % (REQUIRED_WEEWX,
-                                                                                     weewx.__version__)
+        print ("weewx %s or greater is required, found %s. Nothing done, exiting." % (REQUIRED_WEEWX,
+                                                                                     weewx.__version__))
         exit(1)
 
     # display wee_import version info
     if options.version:
-        print "wee_import version: %s" % WEE_IMPORT_VERSION
+        print ("wee_import version: %s" % WEE_IMPORT_VERSION)
         exit(0)
 
     # Set up logging
@@ -654,31 +654,31 @@ def main():
     except weeimport.weeimport.WeeImportOptionError, e:
         wlog.printlog(syslog.LOG_INFO, "**** Command line option error.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
     except weeimport.weeimport.WeeImportIOError, e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load source file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
     except weeimport.weeimport.WeeImportFieldError, e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to map source data.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
     except weeimport.weeimport.WeeImportMapError, e:
         wlog.printlog(syslog.LOG_INFO,
                       "**** Unable to parse source-to-weewx field map.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
     except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature), e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         print
         parser.print_help()
@@ -688,13 +688,13 @@ def main():
         exit(0)
     except (ValueError, weewx.UnitError), e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
     except IOError, e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load config file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print "**** Nothing done, exiting."
+        print ("**** Nothing done, exiting.")
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
 

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -684,7 +684,7 @@ def main():
         parser.print_help()
         exit(1)
     except SystemExit, e:
-        print e
+        print (e)
         exit(0)
     except (ValueError, weewx.UnitError), e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)

--- a/bin/wee_reports
+++ b/bin/wee_reports
@@ -42,12 +42,12 @@ def main():
     # If the user specified a time, retrieve it. Otherwise, set to None
     gen_ts = int(args[0]) if args else None
     
-    print "Using configuration file %s" % config_path
+    print ("Using configuration file %s" % config_path)
 
     if gen_ts is None:
-        print "Generating for all time"
+        print ("Generating for all time")
     else:
-        print "Generating for requested time", timestamp_to_string(gen_ts)
+        print ("Generating for requested time", timestamp_to_string(gen_ts))
         
     # Look for the debug flag. If set, ask for extra logging
     weewx.debug = int(config_dict.get('debug', 0))

--- a/bin/weecfg/__init__.py
+++ b/bin/weecfg/__init__.py
@@ -12,7 +12,10 @@ import glob
 import os.path
 import shutil
 import sys
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import tempfile
 
 import configobj
@@ -126,7 +129,7 @@ class Logger(object):
         self.verbosity = verbosity
     def log(self, msg, level=0):
         if self.verbosity >= level:
-            print "%s%s" % ('  ' * (level - 1), msg)
+            print ("%s%s" % ('  ' * (level - 1), msg))
     def set_verbosity(self, verbosity):
         self.verbosity = verbosity
 
@@ -275,7 +278,7 @@ def modify_config(config_dict, stn_info, logger, debug=False):
             # Look up driver info:
             driver_editor, driver_name, driver_version = \
                 load_driver_editor(driver)
-        except Exception, e:
+        except Exception as e:
             sys.exit("Driver %s failed to load: %s" % (driver, e))
         stn_info['station_type'] = driver_name
         if debug:
@@ -972,6 +975,7 @@ def get_driver_infos(driver_pkg_name='weewx.drivers', excludes=['__init__.py']):
     driver_list = [os.path.basename(f) for f in glob.glob(os.path.join(driver_pkg_directory, "*.py"))]
 
     driver_info_dict = {}
+
     for filename in driver_list:
         if filename in excludes:
             continue
@@ -997,14 +1001,14 @@ def get_driver_infos(driver_pkg_name='weewx.drivers', excludes=['__init__.py']):
                     'driver_name': driver_module.DRIVER_NAME,
                     'version': driver_module_version,
                     'status': ''}
-        except ImportError, e:
+        except ImportError as e:
             # If the import fails, report it in the status
             driver_info_dict[driver_module_name] = {
                 'module_name': driver_module_name,
                 'driver_name': '?',
                 'version': '?',
                 'status': e}
-        except Exception, e:
+        except Exception as e:
             # Ignore anything else.  This might be a python file that is not
             # a driver, a python file with errors, or who knows what.
             pass
@@ -1015,10 +1019,10 @@ def print_drivers():
     """Get information about all the available drivers, then print it out."""
     driver_info_dict = get_all_driver_infos()
     keys = sorted(driver_info_dict)
-    print "%-25s%-15s%-9s%-25s" % (
-        "Module name", "Driver name", "Version", "Status")
+    print ("%-25s%-15s%-9s%-25s" % (
+        "Module name", "Driver name", "Version", "Status"))
     for d in keys:
-        print "  %(module_name)-25s%(driver_name)-15s%(version)-9s%(status)-25s" % driver_info_dict[d]
+        print ("  %(module_name)-25s%(driver_name)-15s%(version)-9s%(status)-25s" % driver_info_dict[d])
 
 def load_driver_editor(driver_module_name):
     """Load the configuration editor from the driver file
@@ -1050,20 +1054,20 @@ def prompt_for_info(location=None, latitude='90.000', longitude='0.000',
     #
     #  Description
     #
-    print "Enter a brief description of the station, such as its location.  For example:"
-    print "Santa's Workshop, North Pole"
+    print ("Enter a brief description of the station, such as its location.  For example:")
+    print ("Santa's Workshop, North Pole")
     loc = prompt_with_options("description", location)
 
     #
     #  Altitude
     #
-    print "Specify altitude, with units 'foot' or 'meter'.  For example:"
-    print "35, foot"
-    print "12, meter"
+    print ("Specify altitude, with units 'foot' or 'meter'.  For example:")
+    print ("35, foot")
+    print ("12, meter")
     msg = "altitude [%s]: " % weeutil.weeutil.list_as_string(altitude) if altitude else "altitude: "
     alt = None
     while alt is None:
-        ans = raw_input(msg).strip()
+        ans = input(msg).strip()
         if ans:
             parts = ans.split(',')
             if len(parts) == 2:
@@ -1079,20 +1083,20 @@ def prompt_for_info(location=None, latitude='90.000', longitude='0.000',
             alt = altitude
 
         if not alt:
-            print "Unrecognized response. Try again."
+            print ("Unrecognized response. Try again.")
 
     #
     # Latitude & Longitude
     #
-    print "Specify latitude in decimal degrees, negative for south."
+    print ("Specify latitude in decimal degrees, negative for south.")
     lat = prompt_with_limits("latitude", latitude, -90, 90)
-    print "Specify longitude in decimal degrees, negative for west."
+    print ("Specify longitude in decimal degrees, negative for west.")
     lon = prompt_with_limits("longitude", longitude, -180, 180)
 
     #
     # Display units
     #
-    print "Indicate the preferred units for display: 'metric' or 'us'"
+    print ("Indicate the preferred units for display: 'metric' or 'us'")
     uni = prompt_with_options("units", units, ['us', 'metric'])
 
     return {'location': loc,
@@ -1107,17 +1111,16 @@ def prompt_for_driver(dflt_driver=None):
     infos = get_all_driver_infos()
     keys = sorted(infos)
     dflt_idx = None
-    print "Installed drivers include:"
     for i, d in enumerate(keys):
-        print " %2d) %-15s %-25s %s" % (i, infos[d].get('driver_name', '?'),
-                                        "(%s)" % d, infos[d].get('status', ''))
+        print (" %2d) %-15s %-25s %s" % (i, infos[d].get('driver_name', '?'),
+                                        "(%s)" % d, infos[d].get('status', '')))
         if dflt_driver == d:
             dflt_idx = i
     msg = "choose a driver [%d]: " % dflt_idx if dflt_idx is not None else "choose a driver: "
     idx = 0
     ans = None
     while ans is None:
-        ans = raw_input(msg).strip()
+        ans = input(msg).strip()
         if not ans:
             ans = dflt_idx
         try:
@@ -1156,7 +1159,7 @@ def prompt_with_options(prompt, default=None, options=None):
     msg = "%s [%s]: " % (prompt, default) if default is not None else "%s: " % prompt
     value = None
     while value is None:
-        value = raw_input(msg).strip()
+        value = input(msg).strip()
         if value:
             if options and value not in options:
                 value = None
@@ -1183,7 +1186,7 @@ def prompt_with_limits(prompt, default=None, low_limit=None, high_limit=None):
     msg = "%s [%s]: " % (prompt, default) if default is not None else "%s: " % prompt
     value = None
     while value is None:
-        value = raw_input(msg).strip()
+        value = input(msg).strip()
         if value:
             try:
                 v = float(value)
@@ -1277,7 +1280,7 @@ def mkdir_p(path):
     """equivalent to 'mkdir -p'"""
     try:
         os.makedirs(path)
-    except OSError, e:
+    except OSError as e:
         if e.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:

--- a/bin/weecfg/config.py
+++ b/bin/weecfg/config.py
@@ -25,7 +25,7 @@ class ConfigEngine(object):
     
     def run(self, args, options):
         if options.version:
-            print weewx.__version__
+            print (weewx.__version__)
             sys.exit(0)
     
         if options.list_drivers:
@@ -67,9 +67,9 @@ class ConfigEngine(object):
             try:        
                 dist_config_dict = configobj.ConfigObj(options.dist_config,
                                                        file_error=True)
-            except IOError, e:
+            except IOError as e:
                 sys.exit("Unable to open distribution configuration file: %s" % e)
-            except SyntaxError, e:
+            except SyntaxError as e:
                 sys.exit("Syntax error in distribution configuration file '%s': %s" %
                          (options.dist_config, e))
 
@@ -81,9 +81,9 @@ class ConfigEngine(object):
             try:
                 config_path, config_dict = weecfg.read_config(
                     options.config_path, args)
-            except SyntaxError, e:
+            except SyntaxError as e:
                 sys.exit("Syntax error in configuration file: %s" % e)
-            except IOError, e:
+            except IOError as e:
                 sys.exit("Unable to open configuration file: %s" % e)
             self.logger.log("Using configuration file %s" % config_path)
 

--- a/bin/weecfg/database.py
+++ b/bin/weecfg/database.py
@@ -196,7 +196,7 @@ class WindSpeedRecalculation(DatabaseFix):
             self.do_fix()
         except weedb.NoTableError:
             raise
-        except weewx.ViolatedPrecondition, e:
+        except weewx.ViolatedPrecondition as e:
             syslog.syslog(syslog.LOG_ERR,
                           "maxwindspeed: %s not applied: %s" % (self.name, e))
             # raise the error so caller can deal with it if they want
@@ -447,7 +447,7 @@ class IntervalWeighting(DatabaseFix):
                     if not self.dry_run:
                         with weedb.Transaction(self.dbm.connection) as _cursor:
                             self.dbm._write_metadata('Version', '2.0', _cursor)
-                except weewx.ViolatedPrecondition, e:
+                except weewx.ViolatedPrecondition as e:
                     syslog.syslog(syslog.LOG_INFO,
                                   "intervalweighting: %s not applied: %s"
                                   % (self.name, e))
@@ -518,7 +518,7 @@ class IntervalWeighting(DatabaseFix):
                                     _day_accum[_day_key].xsum *= _weight
                                     _day_accum[_day_key].ysum *= _weight
                                     _day_accum[_day_key].dirsumtime *= _weight
-                        except Exception, e:
+                        except Exception as e:
                             # log the exception and re-raise it
                             syslog.syslog(syslog.LOG_INFO,
                                           "intervalweighting: Interval weighting of '%s' daily summary "

--- a/bin/weecfg/extension.py
+++ b/bin/weecfg/extension.py
@@ -419,7 +419,7 @@ class ExtensionEngine(object):
             if not self.dry_run:
                 os.remove(filename)
                 return 1
-        except OSError, e:
+        except OSError as e:
             if report_errors:
                 self.logger.log("Delete failed: %s" % e, level=4)
         return 0
@@ -439,7 +439,7 @@ class ExtensionEngine(object):
                 self.logger.log("Deleting directory %s" % directory, level=2)
                 if not self.dry_run:
                     shutil.rmtree(directory)
-        except OSError, e:
+        except OSError as e:
             if report_errors:
                 self.logger.log("Delete failed on directory '%s': %s" %
                                 (directory, e), level=2)

--- a/bin/weecfg/test/test_config.py
+++ b/bin/weecfg/test/test_config.py
@@ -6,7 +6,10 @@
 """Test the configuration utilities."""
 from __future__ import with_statement
 
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import tempfile
 import os.path
@@ -24,7 +27,7 @@ try:
     import __builtin__  # @UnusedImport
     have_mock = True
 except ImportError:
-    print "Module 'mock' not installed. Testing will be restricted."
+    print ("Module 'mock' not installed. Testing will be restricted.")
     have_mock = False
 
 # Redirect the import of setup:

--- a/bin/weedb/mysql.py
+++ b/bin/weedb/mysql.py
@@ -38,7 +38,7 @@ def guard(fn):
     def guarded_fn(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except DatabaseError, e:
+        except DatabaseError as e:
             # Default exception is weedb.DatabaseError
             try:
                 errno = e[0]

--- a/bin/weedb/sqlite.py
+++ b/bin/weedb/sqlite.py
@@ -27,9 +27,9 @@ def guard(fn):
     def guarded_fn(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except sqlite3.IntegrityError, e:
+        except sqlite3.IntegrityError as e:
             raise weedb.IntegrityError(e)
-        except sqlite3.OperationalError, e:
+        except sqlite3.OperationalError as e:
             msg = str(e).lower()
             if msg.startswith("unable to open"):
                 raise weedb.PermissionError(e)
@@ -41,7 +41,7 @@ def guard(fn):
                 raise weedb.NoColumnError(e)
             else:
                 raise weedb.OperationalError(e)
-        except sqlite3.ProgrammingError, e:
+        except sqlite3.ProgrammingError as e:
             raise weedb.ProgrammingError(e)
 
     return guarded_fn
@@ -77,7 +77,7 @@ def drop(database_name='', SQLITE_ROOT='', driver='', **argv):  # @UnusedVariabl
     file_path = _get_filepath(SQLITE_ROOT, database_name, **argv)
     try:
         os.remove(file_path)
-    except OSError, e:
+    except OSError as e:
         errno = getattr(e, 'errno', 2)
         if errno == 13:
             raise weedb.PermissionError("No permission to drop database %s" % file_path)

--- a/bin/weeimport/csvimport.py
+++ b/bin/weeimport/csvimport.py
@@ -117,16 +117,16 @@ class CSVSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print ("Missing derived observations will be calculated.")
         if not self.UV_sensor:
-            print "All weeWX UV fields will be set to None."
+            print ("All weeWX UV fields will be set to None.")
         if not self.solar_sensor:
-            print "All weeWX radiation fields will be set to None."
+            print ("All weeWX radiation fields will be set to None.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print ("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), ))
+            print ("including %s will be imported." % (timestamp_to_string(self.last_ts), ))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print ("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Obtain an iterable containing the raw data to be imported.

--- a/bin/weeimport/cumulusimport.py
+++ b/bin/weeimport/cumulusimport.py
@@ -246,16 +246,16 @@ class CumulusSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print ("Missing derived observations will be calculated.")
         if not self.UV_sensor:
-            print "All weeWX UV fields will be set to None."
+            print ("All weeWX UV fields will be set to None.")
         if not self.solar_sensor:
-            print "All weeWX radiation fields will be set to None."
+            print ("All weeWX radiation fields will be set to None.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print ("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), ))
+            print ("including %s will be imported." % (timestamp_to_string(self.last_ts), ))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print ("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Get raw observation data and construct a map from Cumulus monthly

--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -1,4 +1,4 @@
-#
+#i
 #    Copyright (c) 2009-2016 Tom Keffer <tkeffer@gmail.com> and
 #                            Gary Roderick
 #
@@ -166,7 +166,7 @@ class Source(object):
                 altitude_vt = weewx.units.ValueTuple(float(altitude_t[0]),
                                                      altitude_t[1],
                                                      "group_altitude")
-            except KeyError, e:
+            except KeyError as e:
                 raise weewx.ViolatedPrecondition(
                     "Value 'altitude' needs a unit (%s)" % e)
             latitude_f = float(stn_dict['latitude'])
@@ -375,8 +375,8 @@ class Source(object):
                                                                                                                                self.total_unique_rec,
                                                                                                                                self.tdiff)
                     self.wlog.printlog(syslog.LOG_INFO, _msg)
-                    print "Those records with a timestamp already in the archive will not have been"
-                    print "imported. Confirm successful import in the weeWX log file."
+                    print ("Those records with a timestamp already in the archive will not have been")
+                    print ("imported. Confirm successful import in the weeWX log file.")
 
     def parseMap(self, source_type, source, import_config_dict):
         """Produce a source field-to-weeWX archive field map.
@@ -764,25 +764,25 @@ class Source(object):
             if _diff_interval and self.interval_ans != 'y':
                 # we had more than one unique value for interval, warn the user
                 self.wlog.printlog(syslog.LOG_INFO, "Warning: Records to be imported contain multiple different 'interval' values.")
-                print "         This may mean the imported data is missing some records and it may lead"
-                print "         to data integrity issues. If the raw data has a known, fixed interval"
-                print "         value setting the relevant 'interval' setting in wee_import config to"
-                print "         this value may give a better result."
+                print ("         This may mean the imported data is missing some records and it may lead")
+                print ("         to data integrity issues. If the raw data has a known, fixed interval")
+                print ("         value setting the relevant 'interval' setting in wee_import config to")
+                print ("         this value may give a better result.")
                 while self.interval_ans not in ['y', 'n']:
-                    self.interval_ans = raw_input('Are you sure you want to proceed (y/n)? ')
+                    self.interval_ans = input('Are you sure you want to proceed (y/n)? ')
                 if self.interval_ans == 'n':
                     # the user chose to abort, but we may have already
                     # processed some records. So log it then raise a SystemExit()
                     if self.dry_run:
-                        print "Dry run import aborted by user. %d records were processed." % self.total_rec_proc
+                        print ("Dry run import aborted by user. %d records were processed." % self.total_rec_proc)
                     else:
                         if self.total_rec_proc > 0:
-                            print "Those records with a timestamp already in the archive will not have been"
-                            print "imported. As the import was aborted before completion refer to the weeWX log"
-                            print "file to confirm which records were imported."
+                            print ("Those records with a timestamp already in the archive will not have been")
+                            print ("imported. As the import was aborted before completion refer to the weeWX log")
+                            print ("file to confirm which records were imported.")
                             raise SystemExit('Exiting.')
                         else:
-                            print "Import aborted by user. No records saved to archive."
+                            print ("Import aborted by user. No records saved to archive.")
                         _msg = "User chose to abort import. %d records were processed. Exiting." % self.total_rec_proc
                         self.wlog.logonly(syslog.LOG_INFO, _msg)
                         raise SystemExit('Exiting. Nothing done.')
@@ -957,9 +957,9 @@ class Source(object):
             self.t1 = time.time()
             # it's convenient to give this message now
             if self.dry_run:
-                print 'Starting dry run import ...'
+                print ('Starting dry run import ...')
             else:
-                print 'Starting import ...'
+                print ('Starting import ...')
         # do we have any records?
         if records and len(records) > 0:
             # if this is the first period then give a little summary about what
@@ -967,14 +967,14 @@ class Source(object):
             if self.first_period:
                 if self.last_period:
                     # there is only 1 period, so we can count them
-                    print "%s records identified for import." % len(records)
+                    print ("%s records identified for import." % len(records))
                 else:
                     # there are more periods so say so
-                    print "Records covering multiple periods have been identified for import."
+                    print ("Records covering multiple periods have been identified for import.")
             # we do, confirm the user actually wants to save them
             while self.ans not in ['y', 'n'] and not self.dry_run:
-                print "Proceeding will save all imported records in the weeWX archive."
-                self.ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will save all imported records in the weeWX archive.")
+                self.ans = input("Are you sure you want to proceed (y/n)? ")
             if self.ans == 'y' or self.dry_run:
                 # we are going to save them
                 # reset record counter
@@ -987,7 +987,7 @@ class Source(object):
                 # if we are importing multiple periods of data then tell the
                 # user what period we are up to
                 if not (self.first_period and self.last_period):
-                    print "Period %d ..." % self.period_no
+                    print ("Period %d ..." % self.period_no)
                 # step through each record in this period
                 for _rec in records:
                     # convert our record
@@ -1053,7 +1053,7 @@ class Source(object):
             else:
                 # multiple periods
                 _msg = 'Period %d - no records identified for import.' % self.period_no
-            print _msg
+            print (_msg)
         # if we have finished record the time taken for our summary
         if self.last_period:
             self.tdiff = time.time() - self.t1
@@ -1113,14 +1113,14 @@ class WeeImportLog(object):
     def printlog(self, level, message):
         """Print to screen and log to file."""
 
-        print message
+        print (message)
         self.logonly(level, message)
 
     def verboselog(self, level, message):
         """Print to screen if --verbose and log to file always."""
 
         if self.verbose:
-            print message
+            print (message)
             self.logonly(level, message)
 
 

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -154,12 +154,12 @@ class WUSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print ("Missing derived observations will be calculated.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print ("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), ))
+            print ("including %s will be imported." % (timestamp_to_string(self.last_ts), ))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print ("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Get raw observation data and construct a map from WU to weeWX
@@ -193,12 +193,12 @@ class WUSource(weeimport.Source):
         # hit the WU site, wrap in a try..except so we can catch any errors
         try:
             _wudata = urllib2.urlopen(_url)
-        except urllib2.URLError, e:
+        except urllib2.URLError as e:
             self.wlog.printlog(syslog.LOG_ERR,
                           "Unable to open Weather Underground station %s" % self.station_id)
             self.wlog.printlog(syslog.LOG_ERR, "   **** %s" % e)
             raise
-        except socket.timeout, e:
+        except socket.timeout as e:
             self.wlog.printlog(syslog.LOG_ERR,
                           "Socket timeout for Weather Underground station %s" % self.station_id)
             raise

--- a/bin/weeplot/genplot.py
+++ b/bin/weeplot/genplot.py
@@ -142,7 +142,7 @@ class GeneralPlot(object):
         
         """
         if None in line.x:
-            raise weeplot.ViolatedPrecondition, "X vector cannot have any values 'None' "
+            raise weeplot.ViolatedPrecondition("X vector cannot have any values 'None' ")
         self.line_list.append(line)
 
     def setLocation(self, lat, lon):

--- a/bin/weeplot/utilities.py
+++ b/bin/weeplot/utilities.py
@@ -199,7 +199,7 @@ def scaletime(tmin_ts, tmax_ts) :
     2013-05-16 17:00:00 PDT (1368748800) 2013-05-17 08:00:00 PDT (1368802800) 7200
     """
     if tmax_ts <= tmin_ts :
-        raise weeplot.ViolatedPrecondition, "scaletime called with tmax <= tmin"
+        raise weeplot.ViolatedPrecondition("scaletime called with tmax <= tmin")
     
     tdelta = tmax_ts - tmin_ts
     
@@ -571,5 +571,5 @@ if __name__ == "__main__":
     import doctest
 
     if not doctest.testmod().failed:
-        print "PASSED"
+        print ("PASSED")
     

--- a/bin/weeutil/Sun.py
+++ b/bin/weeutil/Sun.py
@@ -535,7 +535,7 @@ def rev180(x):
 
 if __name__ == "__main__":
     (sunrise_utc, sunset_utc) = sunRiseSet(2009, 3, 27, -122.65, 45.517)
-    print sunrise_utc, sunset_utc
+    print (sunrise_utc, sunset_utc)
     
     #Assert that the results are within 1 minute of NOAA's 
     # calculator (see http://www.srrb.noaa.gov/highlights/sunrise/sunrise.html)

--- a/bin/weeutil/ftpupload.py
+++ b/bin/weeutil/ftpupload.py
@@ -112,7 +112,7 @@ class FtpUpload(object):
                     else:
                         syslog.syslog(syslog.LOG_DEBUG, "ftpupload: Connected to %s" % self.server)
                     break
-                except ftplib.all_errors, e:
+                except ftplib.all_errors as e:
                     syslog.syslog(syslog.LOG_NOTICE, "ftpupload: Unable to connect or log into server : %s" % e)
             else:
                 # This is executed only if the loop terminates naturally (without a break statement),
@@ -153,7 +153,7 @@ class FtpUpload(object):
                             # Hence, the open is in the inner loop:
                             fd = open(full_local_path, "r")
                             ftp_server.storbinary(STOR_cmd, fd)
-                        except ftplib.all_errors, e:
+                        except ftplib.all_errors as e:
                             # Unsuccessful. Log it and go around again.
                             syslog.syslog(syslog.LOG_ERR, "ftpupload: Attempt #%d. Failed uploading %s to %s. Reason: %s" %
                                                           (count+1, full_remote_path, self.server, e))
@@ -221,7 +221,7 @@ class FtpUpload(object):
         for unused_count in range(self.max_tries):
             try:
                 ftp_server.mkd(remote_dir_path)
-            except ftplib.all_errors, e:
+            except ftplib.all_errors as e:
                 # Got an exception. It might be because the remote directory already exists:
                 if sys.exc_info()[0] is ftplib.error_perm:
                     msg =str(e).strip()
@@ -237,7 +237,7 @@ class FtpUpload(object):
                 return
         else:
             syslog.syslog(syslog.LOG_ERR, "ftpupload: Unable to create remote directory %s" % remote_dir_path)
-            raise IOError, "Unable to create remote directory %s" % remote_dir_path
+            raise IOError("Unable to create remote directory %s" % remote_dir_path)
             
     def _skipThisDir(self, local_dir):
         
@@ -270,13 +270,13 @@ if __name__ == '__main__':
     syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
 
     if len(sys.argv) < 2 :
-        print """Usage: ftpupload.py path-to-configuration-file [path-to-be-ftp'd]"""
+        print ("""Usage: ftpupload.py path-to-configuration-file [path-to-be-ftp'd]""")
         sys.exit(weewx.CMD_ERROR)
         
     try :
         config_dict = configobj.ConfigObj(sys.argv[1], file_error=True)
     except IOError:
-        print "Unable to open configuration file ", sys.argv[1]
+        print ("Unable to open configuration file ", sys.argv[1])
         raise
 
     if len(sys.argv) == 2:
@@ -284,7 +284,7 @@ if __name__ == '__main__':
             ftp_dir = os.path.join(config_dict['WEEWX_ROOT'],
                                    config_dict['StdReport']['HTML_ROOT'])
         except KeyError:
-            print "No HTML_ROOT in configuration dictionary."
+            print ("No HTML_ROOT in configuration dictionary.")
             sys.exit(1)
     else:
         ftp_dir = sys.argv[2]

--- a/bin/weeutil/rsyncupload.py
+++ b/bin/weeutil/rsyncupload.py
@@ -94,7 +94,7 @@ class RsyncUpload(object):
         
             stdout = rsynccmd.communicate()[0]
             stroutput = stdout.encode("utf-8").strip()
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 syslog.syslog(syslog.LOG_ERR, "rsyncupload: rsync does not appear to be installed on this system. (errno %d, \"%s\")" % (e.errno, e.strerror))
             raise
@@ -145,13 +145,13 @@ if __name__ == '__main__':
     syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
 
     if len(sys.argv) < 2 :
-        print """Usage: rsyncupload.py path-to-configuration-file [path-to-be-rsync'd]"""
+        print ("""Usage: rsyncupload.py path-to-configuration-file [path-to-be-rsync'd]""")
         sys.exit(weewx.CMD_ERROR)
         
     try :
         config_dict = configobj.ConfigObj(sys.argv[1], file_error=True)
     except IOError:
-        print "Unable to open configuration file ", sys.argv[1]
+        print ("Unable to open configuration file ", sys.argv[1])
         raise
 
     if len(sys.argv) == 2:
@@ -159,7 +159,7 @@ if __name__ == '__main__':
             rsync_dir = os.path.join(config_dict['WEEWX_ROOT'],
                                    config_dict['StdReport']['HTML_ROOT'])
         except KeyError:
-            print "No HTML_ROOT in configuration dictionary."
+            print ("No HTML_ROOT in configuration dictionary.")
             sys.exit(1)
     else:
         rsync_dir = sys.argv[2]

--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -8,7 +8,10 @@
 
 from __future__ import with_statement
 
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import calendar
 import datetime
 import math
@@ -18,7 +21,7 @@ import syslog
 import time
 import traceback
 
-import Sun
+from ephem import Sun
 
 def convertToFloat(seq):
     """Convert a sequence with strings to floats, honoring 'Nones'"""
@@ -1318,10 +1321,10 @@ def print_dict(d, margin=0, increment=4):
     """
     for k in d:
         if type(d[k]) is dict:
-            print margin * ' ', k
+            print (margin * ' ', k)
             print_dict(d[k], margin + increment, increment)
         else:
-            print margin * ' ', k, '=', d[k]
+            print (margin * ' ', k, '=', d[k])
 
 def move_with_timestamp(filepath):
     """Save a file to a path with a timestamp."""

--- a/bin/weewx/__init__.py
+++ b/bin/weewx/__init__.py
@@ -44,33 +44,33 @@ class CRCError(WeeWxIOError):
 class RetriesExceeded(WeeWxIOError):
     """Exception thrown when max retries exceeded."""
 
-class HardwareError(StandardError):
+class HardwareError(Exception):
     """Exception thrown when an error is detected in the hardware."""
     
 class UnknownArchiveType(HardwareError):
     """Exception thrown after reading an unrecognized archive type."""
 
-class UnsupportedFeature(StandardError):
+class UnsupportedFeature(Exception):
     """Exception thrown when attempting to access a feature that is not
     supported (yet)."""
     
-class ViolatedPrecondition(StandardError):
+class ViolatedPrecondition(Exception):
     """Exception thrown when a function is called with violated
     preconditions."""
     
-class StopNow(StandardError):
+class StopNow(Exception):
     """Exception thrown to stop the engine."""
     
-class UninitializedDatabase(StandardError):
+class UninitializedDatabase(Exception):
     """Exception thrown when attempting to use an uninitialized database."""
     
-class UnknownDatabase(StandardError):
+class UnknownDatabase(Exception):
     """Exception thrown when attempting to use an unknown database."""
 
-class UnknownDatabaseType(StandardError):
+class UnknownDatabaseType(Exception):
     """Exception thrown when attempting to use an unknown database type."""
 
-class UnknownBinding(StandardError):
+class UnknownBinding(Exception):
     """Exception thrown when attempting to use an unknown data binding."""
 
 class UnitError(ValueError):

--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -233,7 +233,7 @@ class Accum(dict):
         
         # Check to see if the record is within my observation timespan 
         if not self.timespan.includesArchiveTime(record['dateTime']):
-            raise OutOfSpan, "Attempt to add out-of-interval record"
+            raise OutOfSpan("Attempt to add out-of-interval record")
 
         for obs_type in record:
             # Get the proper function ...
@@ -489,7 +489,10 @@ defaults_ini = """
     [[windGustDir]]
         extractor = noop
 """
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 defaults = configobj.ConfigObj(StringIO.StringIO(defaults_ini))
 del StringIO
 

--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -329,7 +329,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                 with open(tmpname, mode='w') as _file:
                     print >> _file, compiled_template
                 os.rename(tmpname, _fullname)
-            except Exception, e:
+            except Exception as e:
                 # We would like to get better feedback when there are cheetah
                 # compiler failures, but there seem to be no hooks for this.
                 # For example, if we could get make cheetah emit the source

--- a/bin/weewx/drivers/acurite.py
+++ b/bin/weewx/drivers/acurite.py
@@ -505,7 +505,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                             self.polling_interval)
                 logdbg("next read in %s seconds" % delay)
                 time.sleep(delay)
-            except (usb.USBError, weewx.WeeWxIOError), e:
+            except (usb.USBError, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to get LOOP data: %s" %
                        (ntries, self.max_tries, e))
                 time.sleep(self.retry_wait)
@@ -561,7 +561,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                 for i in range(17):
                     r3.append(station.read_R3())
                 self.last_r3 = time.time()
-            except usb.USBError, e:
+            except usb.USBError as e:
                 self.r3_fail_count += 1
                 logdbg("R3: read failed %d of %d: %s" %
                        (self.r3_fail_count, self.r3_max_fail, e))
@@ -627,13 +627,13 @@ class Station(object):
         # FIXME: is it necessary to set the configuration?
         try:
             self.handle.setConfiguration(dev.configurations[0])
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
         # attempt to claim the interface
         try:
             self.handle.claimInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             logcrt("Unable to claim USB interface %s: %s" % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -641,14 +641,14 @@ class Station(object):
         # FIXME: is it necessary to set the alt interface?
         try:
             self.handle.setAltInterface(interface)
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
     def close(self):
         if self.handle is not None:
             try:
                 self.handle.releaseInterface()
-            except (ValueError, usb.USBError), e:
+            except (ValueError, usb.USBError) as e:
                 logerr("release interface failed: %s" % e)
             self.handle = None
 
@@ -754,7 +754,7 @@ class Station(object):
                 try:
                     for b in r:
                         buf.append(int(b, 16))
-                except ValueError, e:
+                except ValueError as e:
                     logerr("R3: bad value in row %d: %s" % (i, _fmt_bytes(r)))
                     fail = True
             elif len(r) != 33:
@@ -978,7 +978,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "acurite driver version %s" % DRIVER_VERSION
+        print ("acurite driver version %s" % DRIVER_VERSION)
         exit(0)
 
     test_r1 = True
@@ -992,20 +992,20 @@ if __name__ == '__main__':
                                               time.localtime(ts)), ts)
             if test_r1:
                 r1 = s.read_R1()
-                print tstr, _fmt_bytes(r1), Station.decode_R1(r1)
+                print (tstr, _fmt_bytes(r1), Station.decode_R1(r1))
                 delay = min(delay, 18)
             if test_r2:
                 r2 = s.read_R2()
-                print tstr, _fmt_bytes(r2), Station.decode_R2(r2)
+                print (tstr, _fmt_bytes(r2), Station.decode_R2(r2))
                 delay = min(delay, 60)
             if test_r3:
                 try:
                     x = s.read_x()
-                    print tstr, _fmt_bytes(x)
+                    print (tstr, _fmt_bytes(x))
                     for i in range(0, 17):
                         r3 = s.read_R3()
-                        print tstr, _fmt_bytes(r3)
-                except usb.USBError, e:
-                    print tstr, e
+                        print (tstr, _fmt_bytes(r3))
+                except usb.USBError as e:
+                    print (tstr, e)
                 delay = min(delay, 12*60)
             time.sleep(delay)

--- a/bin/weewx/drivers/cc3000.py
+++ b/bin/weewx/drivers/cc3000.py
@@ -159,286 +159,286 @@ class CC3000Configurator(weewx.drivers.AbstractConfigurator):
                           help='display daylight savings settings')
         parser.add_option('--set-dst', dest='dst',
                           metavar='mm/dd HH:MM,mm/dd HH:MM,[MM]M',
-                          help='set daylight savings start, end, and amount')
-        parser.add_option("--get-channel", dest="getch", action="store_true",
-                          help="display the station channel")
-        parser.add_option("--set-channel", dest="ch", metavar="CHANNEL",
-                          type=int,
-                          help="set the station channel")
+                              help='set daylight savings start, end, and amount')
+            parser.add_option("--get-channel", dest="getch", action="store_true",
+                              help="display the station channel")
+            parser.add_option("--set-channel", dest="ch", metavar="CHANNEL",
+                              type=int,
+                              help="set the station channel")
 
-    def do_options(self, options, parser, config_dict, prompt):
-        self.driver = CC3000Driver(**config_dict[DRIVER_NAME])
-        if options.current:
-            print self.driver.get_current()
-        elif options.nrecords is not None:
-            for r in self.driver.station.gen_records(nrecords):
-                print r
-        elif options.clear:
-            self.clear_memory(prompt)
-        elif options.reset:
-            self.reset_rain(prompt)
-        elif options.getclock:
-            print self.driver.station.get_time()
-        elif options.setclock:
-            self.set_clock(prompt)
-        elif options.getdst:
-            print self.driver.station.get_dst()
-        elif options.dst is not None:
-            self.set_dst(options.setdst, prompt)
-        elif options.getint:
-            print self.driver.station.get_interval() * 60
-        elif options.interval is not None:
-            self.set_interval(options.interval / 60, prompt)
-        elif options.getunits:
-            print self.driver.station.get_units()
-        elif options.units is not None:
-            self.set_units(options.units, prompt)
-        elif options.getch:
-            print self.driver.station.get_channel()
-        elif options.ch is not None:
-            self.set_channel(options.ch, prompt)
-        else:
-            print "firmware:", self.driver.station.get_version()
-            print "time:", self.driver.station.get_time()
-            print "dst:", self.driver.station.get_dst()
-            print "units:", self.driver.station.get_units()
-            print "memory:", self.driver.station.get_memory_status()
-            print "interval:", self.driver.station.get_interval() * 60
-            print "channel:", self.driver.station.get_channel()
-            print "charger:", self.driver.station.get_charger()
-            print "baro:", self.driver.station.get_baro()
-            print "rain:", self.driver.station.get_rain()
-        self.driver.closePort()
-
-    def clear_memory(self, prompt):
-        ans = None
-        while ans not in ['y', 'n']:
-            print self.driver.station.get_memory_status()
-            if prompt:
-                ans = raw_input("Clear console memory (y/n)? ")
+        def do_options(self, options, parser, config_dict, prompt):
+            self.driver = CC3000Driver(**config_dict[DRIVER_NAME])
+            if options.current:
+                print (self.driver.get_current())
+            elif options.nrecords is not None:
+                for r in self.driver.station.gen_records(nrecords):
+                    print (r)
+            elif options.clear:
+                self.clear_memory(prompt)
+            elif options.reset:
+                self.reset_rain(prompt)
+            elif options.getclock:
+                print (self.driver.station.get_time())
+            elif options.setclock:
+                self.set_clock(prompt)
+            elif options.getdst:
+                print (self.driver.station.get_dst())
+            elif options.dst is not None:
+                self.set_dst(options.setdst, prompt)
+            elif options.getint:
+                print (self.driver.station.get_interval() * 60)
+            elif options.interval is not None:
+                self.set_interval(options.interval / 60, prompt)
+            elif options.getunits:
+                print (self.driver.station.get_units())
+            elif options.units is not None:
+                self.set_units(options.units, prompt)
+            elif options.getch:
+                print (self.driver.station.get_channel())
+            elif options.ch is not None:
+                self.set_channel(options.ch, prompt)
             else:
-                print 'Clearing console memory'
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.clear_memory()
+                print ("firmware:", self.driver.station.get_version())
+                print ("time:", self.driver.station.get_time())
+                print ("dst:", self.driver.station.get_dst())
+                print ("units:", self.driver.station.get_units())
+                print ("memory:", self.driver.station.get_memory_status())
+                print ("interval:", self.driver.station.get_interval() * 60)
+                print ("channel:", self.driver.station.get_channel())
+                print ("charger:", self.driver.station.get_charger())
+                print ("baro:", self.driver.station.get_baro())
+                print ("rain:", self.driver.station.get_rain())
+            self.driver.closePort()
+
+        def clear_memory(self, prompt):
+            ans = None
+            while ans not in ['y', 'n']:
                 print self.driver.station.get_memory_status()
-            elif ans == 'n':
-                print "Clear memory cancelled."
-
-    def reset_rain(self, prompt):
-        ans = None
-        while ans not in ['y', 'n']:
-            print self.driver.station.get_rain()
-            if prompt:
-                ans = raw_input("Reset rain counter (y/n)? ")
-            else:
-                print 'Resetting rain counter'
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.reset_rain()
-                print self.driver.station.get_rain()
-            elif ans == 'n':
-                print "Reset rain cancelled."
-
-    def set_interval(self, interval, prompt):
-        if interval < 0 or 60 < interval:
-            raise ValueError("Logger interval must be 0-60 minutes")
-        ans = None
-        while ans not in ['y', 'n']:
-            print "Interval is", self.driver.station.get_interval()
-            if prompt:
-                ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
-            else:
-                print "Setting interval to %d minutes" % interval
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.set_interval(interval)
-                print "Interval is now", self.driver.station.get_interval()
-            elif ans == 'n':
-                print "Set interval cancelled."
-
-    def set_clock(self, prompt):
-        ans = None
-        while ans not in ['y', 'n']:
-            print "Station clock is", self.driver.station.get_time()
-            now = datetime.datetime.now()
-            if prompt:
-                ans = raw_input("Set station clock to %s (y/n)? " % now)
-            else:
-                print "Setting station clock to %s" % now
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.set_time()
-                print "Station clock is now", self.driver.station.get_time()
-            elif ans == 'n':
-                print "Set clock cancelled."
-
-    def set_units(self, units, prompt):
-        if units.lower() not in ['metric', 'english']:
-            raise ValueError("Units must be METRIC or ENGLISH")
-        ans = None
-        while ans not in ['y', 'n']:
-            print "Station units is", self.driver.station.get_units()
-            if prompt:
-                ans = raw_input("Set station units to %s (y/n)? " % units)
-            else:
-                print "Setting station units to %s" % units
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.set_units(units)
-                print "Station units is now", self.driver.station.get_units()
-            elif ans == 'n':
-                print "Set units cancelled."
-
-    def set_dst(self, dst, prompt):
-        if dst != '0' and len(dst.split(',')) != 3:
-            raise ValueError("DST must be 0 (disabled) or start, stop, amount "
-                             "with the format mm/dd HH:MM, mm/dd HH:MM, [MM]M")
-        ans = None
-        while ans not in ['y', 'n']:
-            print "Station DST is", self.driver.station.get_dst()
-            if prompt:
-                ans = raw_input("Set DST to %s (y/n)? " % dst)
-            else:
-                print "Setting station DST to %s" % dst
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.set_dst(dst)
-                print "Station DST is now", self.driver.station.get_dst()
-            elif ans == 'n':
-                print "Set DST cancelled."
-
-    def set_channel(self, ch, prompt):
-        if ch not in [0, 1, 2, 3]:
-            raise ValueError("Channel must be one of 0, 1, 2, or 3")
-        ans = None
-        while ans not in ['y', 'n']:
-            print "Station channel is", self.driver.station.get_channel()
-            if prompt:
-                ans = raw_input("Set channel to %s (y/n)? " % ch)
-            else:
-                print "Setting station channel to %s" % ch
-                ans = 'y'
-            if ans == 'y':
-                self.driver.station.set_channel(ch)
-                print "Station channel is now", self.driver.station.get_ch()
-            elif ans == 'n':
-                print "Set channel cancelled."
-
-
-class CC3000Driver(weewx.drivers.AbstractDevice):
-    """weewx driver that communicates with a RainWise CC3000 data logger."""
-
-    # map rainwise names to database schema names
-    DEFAULT_SENSOR_MAP = {
-        'dateTime': 'TIMESTAMP',
-        'outTemp': 'TEMP OUT',
-        'outHumidity': 'HUMIDITY',
-        'windDir': 'WIND DIRECTION',
-        'windSpeed': 'WIND SPEED',
-        'windGust': 'WIND GUST',
-        'pressure': 'PRESSURE',
-        'inTemp': 'TEMP IN',
-        'extraTemp1': 'TEMP 1',
-        'extraTemp2': 'TEMP 2',
-        'day_rain_total': 'RAIN',
-        'consBatteryVoltage': 'STATION BATTERY',
-        'bkupBatteryVoltage': 'BATTERY BACKUP',
-        'radiation': 'SOLAR RADIATION',
-        'UV': 'UV INDEX',
-    }
-
-    def __init__(self, **stn_dict):
-        loginf('driver version is %s' % DRIVER_VERSION)
-
-        global DEBUG_SERIAL
-        DEBUG_SERIAL = int(stn_dict.get('debug_serial', 0))
-        global DEBUG_CHECKSUM
-        DEBUG_CHECKSUM = int(stn_dict.get('debug_checksum', 0))
-        global DEBUG_OPENCLOSE
-        DEBUG_OPENCLOSE = int(stn_dict.get('debug_openclose', 0))
-
-        self.model = stn_dict.get('model', 'CC3000')
-        port = stn_dict.get('port', CC3000.DEFAULT_PORT)
-        loginf('using serial port %s' % port)
-        self.polling_interval = float(stn_dict.get('polling_interval', 1))
-        loginf('polling interval is %s seconds' % self.polling_interval)
-        self.use_station_time = weeutil.weeutil.to_bool(
-            stn_dict.get('use_station_time', True))
-        loginf('using %s time for loop packets' %
-               ('station' if self.use_station_time else 'computer'))
-        self.max_tries = int(stn_dict.get('max_tries', 5))
-        self.retry_wait = int(stn_dict.get('retry_wait', 60))
-        # start with the default sensormap, then augment with user-specified
-        self.sensor_map = dict(self.DEFAULT_SENSOR_MAP)
-        if 'sensor_map' in stn_dict:
-            self.sensor_map.update(stn_dict['sensor_map'])
-        loginf('sensor map is %s' % self.sensor_map)
-        self.last_rain = None
-
-        self.station = CC3000(port)
-        self.station.open()
-
-        # report the station configuration
-        settings = self._init_station_with_retries(
-            self.station, self.max_tries, self.retry_wait)
-        loginf('firmware: %s' % settings['firmware'])
-        self.arcint = settings['arcint']
-        loginf('archive_interval: %s' % self.arcint)
-        self.header = settings['header']
-        loginf('header: %s' % self.header)
-        self.units = weewx.METRICWX if settings['units'] == 'METRIC' else weewx.US
-        loginf('units: %s' % settings['units'])
-        loginf('channel: %s' % settings['channel'])
-        loginf('charger status: %s' % settings['charger'])
-
-    def genLoopPackets(self):
-        cmd_mode = True
-        if self.polling_interval == 0:
-            self.station.set_auto()
-            cmd_mode = False
-        # if logger loses contact with sensors, log it periodically
-        last_data_ts = int(time.time())
-        nodata_cnt = -1
-        nodata_interval = 1800 # seconds
-        # get data from the logger, with retries
-        ntries = 0
-        while ntries < self.max_tries:
-            ntries += 1
-            try:
-                values = self.station.get_current_data(cmd_mode)
-                now = int(time.time())
-                ntries = 0
-                logdbg("values: %s" % values)
-                if values:
-                    last_data_ts = now
-                    nodata_cnt = -1
-                    packet = self._parse_current(
-                        values, self.header, self.sensor_map)
-                    logdbg("parsed: %s" % packet)
-                    if packet and 'dateTime' in packet:
-                        if not self.use_station_time:
-                            packet['dateTime'] = int(time.time() + 0.5)
-                        packet['usUnits'] = self.units
-                        if 'day_rain_total' in packet:
-                            packet['rain'] = self._rain_total_to_delta(
-                                packet['day_rain_total'], self.last_rain)
-                            self.last_rain = packet['day_rain_total']
-                        else:
-                            logdbg("no rain in packet: %s" % packet)
-                        logdbg("packet: %s" % packet)
-                        yield packet
+                if prompt:
+                    ans = input("Clear console memory (y/n)? ")
                 else:
-                    cnt = (now - last_data_ts) / nodata_interval
-                    if cnt > nodata_cnt:
-                        loginf("no data from sensors since %s" %
-                               weeutil.weeutil.timestamp_to_string(last_data_ts))
-                    nodata_cnt = cnt
-                if self.polling_interval:
-                    time.sleep(self.polling_interval)
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
-                logerr("Failed attempt %d of %d to get data: %s" %
-                       (ntries, self.max_tries, e))
+                    print ('Clearing console memory')
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.clear_memory()
+                    print self.driver.station.get_memory_status()
+                elif ans == 'n':
+                    print ("Clear memory cancelled.")
+
+        def reset_rain(self, prompt):
+            ans = None
+            while ans not in ['y', 'n']:
+                print self.driver.station.get_rain()
+                if prompt:
+                    ans = input("Reset rain counter (y/n)? ")
+                else:
+                    print ('Resetting rain counter')
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.reset_rain()
+                    print self.driver.station.get_rain()
+                elif ans == 'n':
+                    print ("Reset rain cancelled.")
+
+        def set_interval(self, interval, prompt):
+            if interval < 0 or 60 < interval:
+                raise ValueError("Logger interval must be 0-60 minutes")
+            ans = None
+            while ans not in ['y', 'n']:
+                print ("Interval is", self.driver.station.get_interval())
+                if prompt:
+                    ans = input("Set interval to %d minutes (y/n)? " % interval)
+                else:
+                    print ("Setting interval to %d minutes" % interval)
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.set_interval(interval)
+                    print ("Interval is now", self.driver.station.get_interval())
+                elif ans == 'n':
+                    print ("Set interval cancelled.")
+
+        def set_clock(self, prompt):
+            ans = None
+            while ans not in ['y', 'n']:
+                print ("Station clock is", self.driver.station.get_time())
+                now = datetime.datetime.now()
+                if prompt:
+                    ans = input("Set station clock to %s (y/n)? " % now)
+                else:
+                    print ("Setting station clock to %s" % now)
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.set_time()
+                    print ("Station clock is now", self.driver.station.get_time())
+                elif ans == 'n':
+                    print ("Set clock cancelled.")
+
+        def set_units(self, units, prompt):
+            if units.lower() not in ['metric', 'english']:
+                raise ValueError("Units must be METRIC or ENGLISH")
+            ans = None
+            while ans not in ['y', 'n']:
+                print ("Station units is", self.driver.station.get_units())
+                if prompt:
+                    ans = input("Set station units to %s (y/n)? " % units)
+                else:
+                    print ("Setting station units to %s" % units)
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.set_units(units)
+                    print ("Station units is now", self.driver.station.get_units())
+                elif ans == 'n':
+                    print ("Set units cancelled.")
+
+        def set_dst(self, dst, prompt):
+            if dst != '0' and len(dst.split(',')) != 3:
+                raise ValueError("DST must be 0 (disabled) or start, stop, amount "
+                                 "with the format mm/dd HH:MM, mm/dd HH:MM, [MM]M")
+            ans = None
+            while ans not in ['y', 'n']:
+                print ("Station DST is", self.driver.station.get_dst())
+                if prompt:
+                    ans = input("Set DST to %s (y/n)? " % dst)
+                else:
+                    print ("Setting station DST to %s" % dst)
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.set_dst(dst)
+                    print ("Station DST is now", self.driver.station.get_dst())
+                elif ans == 'n':
+                    print ("Set DST cancelled.")
+
+        def set_channel(self, ch, prompt):
+            if ch not in [0, 1, 2, 3]:
+                raise ValueError("Channel must be one of 0, 1, 2, or 3")
+            ans = None
+            while ans not in ['y', 'n']:
+                print ("Station channel is", self.driver.station.get_channel())
+                if prompt:
+                    ans = input("Set channel to %s (y/n)? " % ch)
+                else:
+                    print ("Setting station channel to %s" % ch)
+                    ans = 'y'
+                if ans == 'y':
+                    self.driver.station.set_channel(ch)
+                    print ("Station channel is now", self.driver.station.get_ch())
+                elif ans == 'n':
+                    print ("Set channel cancelled.")
+
+
+    class CC3000Driver(weewx.drivers.AbstractDevice):
+        """weewx driver that communicates with a RainWise CC3000 data logger."""
+
+        # map rainwise names to database schema names
+        DEFAULT_SENSOR_MAP = {
+            'dateTime': 'TIMESTAMP',
+            'outTemp': 'TEMP OUT',
+            'outHumidity': 'HUMIDITY',
+            'windDir': 'WIND DIRECTION',
+            'windSpeed': 'WIND SPEED',
+            'windGust': 'WIND GUST',
+            'pressure': 'PRESSURE',
+            'inTemp': 'TEMP IN',
+            'extraTemp1': 'TEMP 1',
+            'extraTemp2': 'TEMP 2',
+            'day_rain_total': 'RAIN',
+            'consBatteryVoltage': 'STATION BATTERY',
+            'bkupBatteryVoltage': 'BATTERY BACKUP',
+            'radiation': 'SOLAR RADIATION',
+            'UV': 'UV INDEX',
+        }
+
+        def __init__(self, **stn_dict):
+            loginf('driver version is %s' % DRIVER_VERSION)
+
+            global DEBUG_SERIAL
+            DEBUG_SERIAL = int(stn_dict.get('debug_serial', 0))
+            global DEBUG_CHECKSUM
+            DEBUG_CHECKSUM = int(stn_dict.get('debug_checksum', 0))
+            global DEBUG_OPENCLOSE
+            DEBUG_OPENCLOSE = int(stn_dict.get('debug_openclose', 0))
+
+            self.model = stn_dict.get('model', 'CC3000')
+            port = stn_dict.get('port', CC3000.DEFAULT_PORT)
+            loginf('using serial port %s' % port)
+            self.polling_interval = float(stn_dict.get('polling_interval', 1))
+            loginf('polling interval is %s seconds' % self.polling_interval)
+            self.use_station_time = weeutil.weeutil.to_bool(
+                stn_dict.get('use_station_time', True))
+            loginf('using %s time for loop packets' %
+                   ('station' if self.use_station_time else 'computer'))
+            self.max_tries = int(stn_dict.get('max_tries', 5))
+            self.retry_wait = int(stn_dict.get('retry_wait', 60))
+            # start with the default sensormap, then augment with user-specified
+            self.sensor_map = dict(self.DEFAULT_SENSOR_MAP)
+            if 'sensor_map' in stn_dict:
+                self.sensor_map.update(stn_dict['sensor_map'])
+            loginf('sensor map is %s' % self.sensor_map)
+            self.last_rain = None
+
+            self.station = CC3000(port)
+            self.station.open()
+
+            # report the station configuration
+            settings = self._init_station_with_retries(
+                self.station, self.max_tries, self.retry_wait)
+            loginf('firmware: %s' % settings['firmware'])
+            self.arcint = settings['arcint']
+            loginf('archive_interval: %s' % self.arcint)
+            self.header = settings['header']
+            loginf('header: %s' % self.header)
+            self.units = weewx.METRICWX if settings['units'] == 'METRIC' else weewx.US
+            loginf('units: %s' % settings['units'])
+            loginf('channel: %s' % settings['channel'])
+            loginf('charger status: %s' % settings['charger'])
+
+        def genLoopPackets(self):
+            cmd_mode = True
+            if self.polling_interval == 0:
+                self.station.set_auto()
+                cmd_mode = False
+            # if logger loses contact with sensors, log it periodically
+            last_data_ts = int(time.time())
+            nodata_cnt = -1
+            nodata_interval = 1800 # seconds
+            # get data from the logger, with retries
+            ntries = 0
+            while ntries < self.max_tries:
+                ntries += 1
+                try:
+                    values = self.station.get_current_data(cmd_mode)
+                    now = int(time.time())
+                    ntries = 0
+                    logdbg("values: %s" % values)
+                    if values:
+                        last_data_ts = now
+                        nodata_cnt = -1
+                        packet = self._parse_current(
+                            values, self.header, self.sensor_map)
+                        logdbg("parsed: %s" % packet)
+                        if packet and 'dateTime' in packet:
+                            if not self.use_station_time:
+                                packet['dateTime'] = int(time.time() + 0.5)
+                            packet['usUnits'] = self.units
+                            if 'day_rain_total' in packet:
+                                packet['rain'] = self._rain_total_to_delta(
+                                    packet['day_rain_total'], self.last_rain)
+                                self.last_rain = packet['day_rain_total']
+                            else:
+                                logdbg("no rain in packet: %s" % packet)
+                            logdbg("packet: %s" % packet)
+                            yield packet
+                    else:
+                        cnt = (now - last_data_ts) / nodata_interval
+                        if cnt > nodata_cnt:
+                            loginf("no data from sensors since %s" %
+                                   weeutil.weeutil.timestamp_to_string(last_data_ts))
+                        nodata_cnt = cnt
+                    if self.polling_interval:
+                        time.sleep(self.polling_interval)
+                except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
+                    logerr("Failed attempt %d of %d to get data: %s" %
+                           (ntries, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
                 time.sleep(self.retry_wait)
         else:
@@ -506,7 +506,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
         try:
             v = self.station.get_time()
             return _to_ts(v)
-        except ValueError, e:
+        except ValueError as e:
             logerr("getTime failed: %s" % e)
         return 0
 
@@ -518,7 +518,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
         for cnt in xrange(max_tries):
             try:
                 return CC3000Driver._init_station(station)
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to initialize station: %s" %
                        (cnt + 1, max_tries, e))
                 logdbg("Waiting %d seconds before retry" % retry_wait)
@@ -588,7 +588,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
                     pkt[label] = _to_ts(v, fmt)
                 else:
                     pkt[label] = float(v)
-            except ValueError, e:
+            except ValueError as e:
                 logerr("parse failed for '%s' '%s': %s (idx=%s values=%s)" %
                        (header[i], v, e, i, values))
                 return dict()
@@ -651,7 +651,7 @@ def _check_crc(buf):
         b = int(cs, 16) # checksum provided in data
         if a != b:
             raise ChecksumMismatch(a, b, buf)
-    except ValueError, e:
+    except ValueError as e:
         raise BadCRC(a, cs, buf)
 
 # for some reason we sometimes get null characters randomly mixed in with the
@@ -932,7 +932,7 @@ class CC3000(object):
                 else:
                     logerr("bad record %s '%s' (%s)" %
                            (n, _fmt(values[0]), _fmt(data)))
-            except ChecksumError, e:
+            except ChecksumError as e:
                 logerr("download failed for record %s: %s" % (n, e))
 
 
@@ -954,8 +954,8 @@ class CC3000ConfEditor(weewx.drivers.AbstractConfEditor):
 """ % (CC3000.DEFAULT_PORT,)
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print ("Specify the serial port on which the station is connected, for")
+        print ("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', CC3000.DEFAULT_PORT)
         return {'port': port}
 
@@ -1027,7 +1027,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "CC3000 driver version %s" % DRIVER_VERSION
+        print ("CC3000 driver version %s" % DRIVER_VERSION)
         exit(0)
 
     if options.debug:
@@ -1049,18 +1049,18 @@ if __name__ == '__main__':
         if options.getver:
             print s.get_version()
         if options.status:
-            print "firmware:", s.get_version()
-            print "time:", s.get_time()
-            print "dst:", s.get_dst()
-            print "units:", s.get_units()
-            print "memory:", s.get_memory_status()
-            print "interval:", s.get_interval() * 60
-            print "channel:", s.get_channel()
-            print "charger:", s.get_charger()
-            print "baro:", s.get_baro()
-            print "rain:", s.get_rain()
+            print ("firmware:", s.get_version())
+            print ("time:", s.get_time())
+            print ("dst:", s.get_dst())
+            print ("units:", s.get_units())
+            print ("memory:", s.get_memory_status())
+            print ("interval:", s.get_interval() * 60)
+            print ("channel:", s.get_channel())
+            print ("charger:", s.get_charger())
+            print ("baro:", s.get_baro())
+            print ("rain:", s.get_rain())
         if options.getch:
-            print s.get_channel()
+            print (s.get_channel())
         if options.setch is not None:
             s.set_channel(int(options.setch))
         if options.getbat:

--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -270,21 +270,21 @@ def getvalues(station, name, value):
     return values
 
 def raw_dump(date, pos, data):
-    print date,
-    print "%04x" % pos,
+    print (date),
+    print ("%04x" % pos),
     for item in data:
-        print "%02x" % item,
+        print ("%02x" % item),
     print
 
 def table_dump(date, data, showlabels=False):
     if showlabels:
-        print '# date time',
+        print ('# date time'),
         for key in data.keys():
-            print key,
+            print (key),
         print
-    print date,
+    print (date),
     for key in data.keys():
-        print data[key],
+        print (data[key]),
     print
 
 
@@ -311,22 +311,22 @@ class FOUSBConfEditor(weewx.drivers.AbstractConfEditor):
         import configobj
         stanza = configobj.ConfigObj(orig_stanza.splitlines())
         if 'pressure_offset' in stanza[DRIVER_NAME]:
-            print """
+            print ("""
 The pressure_offset is no longer supported by the FineOffsetUSB driver.  Move
-the pressure calibration constant to [StdCalibrate] instead."""
+the pressure calibration constant to [StdCalibrate] instead.""")
         if ('polling_mode' in stanza[DRIVER_NAME] and
             stanza[DRIVER_NAME]['polling_mode'] == 'ADAPTIVE'):
-            print """
-Using ADAPTIVE as the polling_mode can lead to USB lockups."""
+            print ("""
+Using ADAPTIVE as the polling_mode can lead to USB lockups.""")
         if ('polling_interval' in stanza[DRIVER_NAME] and
             int(stanza[DRIVER_NAME]['polling_interval']) < 48):
-            print """
-A polling_interval of anything less than 48 seconds is not recommened."""
+            print ("""
+A polling_interval of anything less than 48 seconds is not recommened.""")
         return orig_stanza
 
     def modify_config(self, config_dict):
-        print """
-Setting record_generation to software."""
+        print ("""
+Setting record_generation to software.""")
         config_dict['StdArchive']['record_generation'] = 'software'
 
 
@@ -403,14 +403,14 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
     def show_info(self):
         """Query the station then display the settings."""
 
-        print "Querying the station..."
+        print ("Querying the station...")
         val = getvalues(self.station, '', fixed_format)
 
-        print 'Fine Offset station settings:'
-        print '%s: %s' % ('local time'.rjust(30),
+        print ('Fine Offset station settings:')
+        print ('%s: %s' % ('local time'.rjust(30),
                           time.strftime('%Y.%m.%d %H:%M:%S %Z',
-                                        time.localtime()))
-        print '%s: %s' % ('polling mode'.rjust(30), self.station.polling_mode)
+                                        time.localtime())))
+        print ('%s: %s' % ('polling mode'.rjust(30), self.station.polling_mode))
 
         slist = {'values':[], 'minmax_values':[], 'settings':[],
                  'display_settings':[], 'alarm_settings':[]}
@@ -425,17 +425,17 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
                 slist = stash(slist, s)
         for k in ('values', 'minmax_values', 'settings',
                   'display_settings', 'alarm_settings'):
-            print ''
+            print ('')
             for s in slist[k]:
-                print s
+                print (s)
 
     def check_usb(self):
         """Run diagnostics on the USB connection."""
-        print "This will read from the station console repeatedly to see if"
-        print "there are errors in the USB communications.  Leave this running"
-        print "for an hour or two to see if any bad reads are encountered."
-        print "Bad reads will be reported in the system log.  A few bad reads"
-        print "per hour is usually acceptable."
+        print ("This will read from the station console repeatedly to see if")
+        print ("there are errors in the USB communications.  Leave this running")
+        print ("for an hour or two to see if any bad reads are encountered.")
+        print ("Bad reads will be reported in the system log.  A few bad reads")
+        print ("per hour is usually acceptable.")
         ptr = data_start
         total_count = 0
         bad_count = 0
@@ -456,25 +456,25 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
                 syslog.syslog(syslog.LOG_INFO, '  %s' % str(result_2))
                 bad_count += 1
             total_count += 1
-            print "\rbad/total: %d/%d " % (bad_count, total_count),
+            print ("\rbad/total: %d/%d " % (bad_count, total_count)),
             sys.stdout.flush()
 
     def check_fixedblock(self):
         """Display changes to fixed block as they occur."""
-        print 'This will read the fixed block then display changes as they'
-        print 'occur.  Typically the most common change is the incrementing'
-        print 'of the data pointer, which happens whenever readings are saved'
-        print 'to the station memory.  For example, if the logging interval'
-        print 'is set to 5 minutes, the fixed block should change at least'
-        print 'every 5 minutes.'
+        print ('This will read the fixed block then display changes as they')
+        print ('occur.  Typically the most common change is the incrementing')
+        print ('of the data pointer, which happens whenever readings are saved')
+        print ('to the station memory.  For example, if the logging interval')
+        print ('is set to 5 minutes, the fixed block should change at least')
+        print ('every 5 minutes.')
         raw_fixed = self.station.get_raw_fixed_block()
         while True:
             new_fixed = self.station.get_raw_fixed_block(unbuffered=True)
             for ptr in range(len(new_fixed)):
                 if new_fixed[ptr] != raw_fixed[ptr]:
-                    print datetime.datetime.now().strftime('%H:%M:%S'),
-                    print ' %04x (%d) %02x -> %02x' % (
-                        ptr, ptr, raw_fixed[ptr], new_fixed[ptr])
+                    print (datetime.datetime.now().strftime('%H:%M:%S')),
+                    print (' %04x (%d) %02x -> %02x' % (
+                        ptr, ptr, raw_fixed[ptr], new_fixed[ptr]))
                     raw_fixed = new_fixed
                     time.sleep(0.5)
 
@@ -482,22 +482,22 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
         """Display the raw fixed block contents."""
         fb = self.station.get_raw_fixed_block(unbuffered=True)
         for i, ptr in enumerate(range(len(fb))):
-            print '%02x' % fb[ptr],
+            print ('%02x' % fb[ptr],)
             if (i+1) % 16 == 0:
                 print
 
     def show_readings(self, logged_only):
         """Display live readings from the station."""
         for data,ptr,_ in self.station.live_data(logged_only):
-            print '%04x' % ptr,
-            print data['idx'].strftime('%H:%M:%S'),
+            print ('%04x' % ptr),
+            print (data['idx'].strftime('%H:%M:%S')),
             del data['idx']
-            print data
+            print (data)
 
     def show_current(self):
         """Display latest readings from the station."""
         for packet in self.station.genLoopPackets():
-            print packet
+            print (packet)
             break
 
     def show_history(self, ts=0, count=0, fmt='raw'):
@@ -510,59 +510,59 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
             elif fmt.lower() == 'table':
                 table_dump(r['datetime'], r['data'], i==0)
             else:
-                print r['datetime'], r['data']
+                print (r['datetime'], r['data'])
 
     def clear_history(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.get_fixed_block(['data_count'], True)
-            print "Records in memory:", v
+            print ("Records in memory:", v)
             if prompt:
-                ans = raw_input("Clear console memory (y/n)? ")
+                ans = input("Clear console memory (y/n)? ")
             else:
-                print 'Clearing console memory'
+                print ('Clearing console memory')
                 ans = 'y'
             if ans == 'y' :
                 self.station.clear_history()
                 v = self.station.get_fixed_block(['data_count'], True)
-                print "Records in memory:", v
+                print ("Records in memory:", v)
             elif ans == 'n':
-                print "Clear memory cancelled."
+                print ("Clear memory cancelled.")
 
     def set_interval(self, interval, prompt):
         v = self.station.get_fixed_block(['read_period'], True)
         ans = None
         while ans not in ['y', 'n']:
-            print "Interval is", v
+            print ("Interval is", v)
             if prompt:
-                ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
+                ans = input("Set interval to %d minutes (y/n)? " % interval)
             else:
-                print "Setting interval to %d minutes" % interval
+                print ("Setting interval to %d minutes" % interval)
                 ans = 'y'
             if ans == 'y' :
                 self.station.set_read_period(interval)
                 v = self.station.get_fixed_block(['read_period'], True)
-                print "Interval is now", v
+                print ("Interval is now", v)
             elif ans == 'n':
-                print "Set interval cancelled."
+                print ("Set interval cancelled.")
 
     def set_clock(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.get_fixed_block(['date_time'], True)
-            print "Station clock is", v
+            print ("Station clock is", v)
             now = datetime.datetime.now()
             if prompt:
-                ans = raw_input("Set station clock to %s (y/n)? " % now)
+                ans = input("Set station clock to %s (y/n)? " % now)
             else:
-                print "Setting station clock to %s" % now
+                print ("Setting station clock to %s" % now)
                 ans = 'y'
             if ans == 'y' :
                 self.station.set_clock()
                 v = self.station.get_fixed_block(['date_time'], True)
-                print "Station clock is now", v
+                print ("Station clock is now", v)
             elif ans == 'n':
-                print "Set clock cancelled."
+                print ("Set clock cancelled.")
 
 
 # these are the raw data we get from the station:
@@ -1014,7 +1014,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
             try:
                 ival = self.get_fixed_block(['read_period'])
                 break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 logcrt("get archive interval failed attempt %d of %d: %s"
                        % (i+1, self.max_tries, e))
         else:
@@ -1045,7 +1045,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
         # attempt to claim the interface
         try:
             self.devh.claimInterface(self.usb_interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.closePort()
             logcrt("Unable to claim USB interface %s: %s" %
                    (self.usb_interface, e))
@@ -1165,7 +1165,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                 else:
                     raise Exception("unknown polling mode '%s'" % self.polling_mode)
 
-            except (IndexError, usb.USBError, ObservationError), e:
+            except (IndexError, usb.USBError, ObservationError) as e:
                 logerr('get_observations failed: %s' % e)
                 nerr += 1
                 if nerr > self.max_tries:
@@ -1334,7 +1334,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                         dts -= datetime.timedelta(minutes=data['delay'])
                     ptr = self.dec_ptr(ptr)
                 return records
-            except (IndexError, usb.USBError, ObservationError), e:
+            except (IndexError, usb.USBError, ObservationError) as e:
                 logerr('get_records failed: %s' % e)
                 nerr += 1
                 if nerr > self.max_tries:

--- a/bin/weewx/drivers/simulator.py
+++ b/bin/weewx/drivers/simulator.py
@@ -276,4 +276,4 @@ class SimulatorConfEditor(weewx.drivers.AbstractConfEditor):
 if __name__ == "__main__":
     station = Simulator(mode='simulator',loop_interval=2.0)
     for packet in station.genLoopPackets():
-        print weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet
+        print (weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet)

--- a/bin/weewx/drivers/te923.py
+++ b/bin/weewx/drivers/te923.py
@@ -572,7 +572,7 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
     }
     
     city_dict = {
-        0: ["ADD", 3, 0, 9, 01, "N", 38, 44, "E", "Addis Ababa, Ethiopia"],
+        0: ["ADD", 3, 0, 9, "01", "N", 38, 44, "E", "Addis Ababa, Ethiopia"],
         1: ["ADL", 9.5, 1, 34, 55, "S", 138, 36, "E", "Adelaide, Australia"],
         2: ["AKR", 2, 4, 39, 55, "N", 32, 55, "E", "Ankara, Turkey"],
         3: ["ALG", 1, 0, 36, 50, "N", 3, 0, "E", "Algiers, Algeria"],
@@ -807,50 +807,50 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
 
     @staticmethod
     def show_info(station, fmt='dict'):
-        print 'Querying the station for the configuration...'
+        print ('Querying the station for the configuration...')
         data = station.get_config()
         TE923Configurator.print_data(data, fmt)
 
     @staticmethod
     def show_current(station, fmt='dict'):
-        print 'Querying the station for current weather data...'
+        print ('Querying the station for current weather data...')
         data = station.get_readings()
         TE923Configurator.print_data(data, fmt)
 
     @staticmethod
     def show_history(station, ts=0, count=None, fmt='dict'):
-        print "Querying the station for historical records..."
+        print ("Querying the station for historical records...")
         for r in station.gen_records(ts, count):
             TE923Configurator.print_data(r, fmt)
 
     @staticmethod
     def show_minmax(station):
-        print "Querying the station for historical min/max data"
+        print ("Querying the station for historical min/max data")
         data = station.get_minmax()
-        print "Console Temperature Min : %s" % data['t_in_min']
-        print "Console Temperature Max : %s" % data['t_in_max']
-        print "Console Humidity Min    : %s" % data['h_in_min']
-        print "Console Humidity Max    : %s" % data['h_in_max']
+        print ("Console Temperature Min : %s" % data['t_in_min'])
+        print ("Console Temperature Max : %s" % data['t_in_max'])
+        print ("Console Humidity Min    : %s" % data['h_in_min'])
+        print ("Console Humidity Max    : %s" % data['h_in_max'])
         for i in range(1, 6):
-            print "Channel %d Temperature Min : %s" % (i, data['t_%d_min' % i])
-            print "Channel %d Temperature Max : %s" % (i, data['t_%d_max' % i])
-            print "Channel %d Humidity Min    : %s" % (i, data['h_%d_min' % i])
-            print "Channel %d Humidity Max    : %s" % (i, data['h_%d_max' % i])
-        print "Wind speed max since midnight : %s" % data['windspeed_max']
-        print "Wind gust max since midnight  : %s" % data['windgust_max']
-        print "Rain yesterday  : %s" % data['rain_yesterday']
-        print "Rain this week  : %s" % data['rain_week']
-        print "Rain this month : %s" % data['rain_month']
-        print "Last Barometer reading : %s" % time.strftime(
-            "%Y %b %d %H:%M", time.localtime(data['barometer_ts']))
+            print ("Channel %d Temperature Min : %s" % (i, data['t_%d_min' % i]))
+            print ("Channel %d Temperature Max : %s" % (i, data['t_%d_max' % i]))
+            print ("Channel %d Humidity Min    : %s" % (i, data['h_%d_min' % i]))
+            print ("Channel %d Humidity Max    : %s" % (i, data['h_%d_max' % i]))
+        print ("Wind speed max since midnight : %s" % data['windspeed_max'])
+        print ("Wind gust max since midnight  : %s" % data['windgust_max'])
+        print ("Rain yesterday  : %s" % data['rain_yesterday'])
+        print ("Rain this week  : %s" % data['rain_week'])
+        print ("Rain this month : %s" % data['rain_month'])
+        print ("Last Barometer reading : %s" % time.strftime(
+            "%Y %b %d %H:%M", time.localtime(data['barometer_ts'])))
         for i in range(25):
-            print "   T-%02d Hours : %.1f" % (i, data['barometer_%d' % i])
+            print ("   T-%02d Hours : %.1f" % (i, data['barometer_%d' % i]))
 
     @staticmethod
     def show_date(station):
         ts = station.get_date()
         tt = time.localtime(ts)
-        print "Date: %02d/%02d/%d" % (tt[2], tt[1], tt[0])
+        print ("Date: %02d/%02d/%d" % (tt[2], tt[1], tt[0]))
         TE923Configurator.print_alignment()
 
     @staticmethod
@@ -858,16 +858,16 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
         if datestr is not None:
             date_list = datestr.split(',')
             if len(date_list) != 3:
-                print "Bad date '%s', format is YEAR,MONTH,DAY" % datestr
+                print ("Bad date '%s', format is YEAR,MONTH,DAY" % datestr)
                 return
             if int(date_list[0]) < 2000 or int(date_list[0]) > 2099:
-                print "Year must be between 2000 and 2099 inclusive"
+                print ("Year must be between 2000 and 2099 inclusive")
                 return
             if int(date_list[1]) < 1 or int(date_list[1]) > 12:
-                print "Month must be between 1 and 12 inclusive"
+                print ("Month must be between 1 and 12 inclusive")
                 return
             if int(date_list[2]) < 1 or int(date_list[2]) > 31:
-                print "Day must be between 1 and 31 inclusive"
+                print ("Day must be between 1 and 31 inclusive")
                 return
             tt = time.localtime()
             offset = 1 if tt[3] < 12 else 0
@@ -879,17 +879,17 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
 
     def show_location(self, station, loc_type):
         data = station.get_loc(loc_type)
-        print "City     : %s (%s)" % (self.city_dict[data['city_time']][9],
-                                      self.city_dict[data['city_time']][0])
+        print ("City     : %s (%s)" % (self.city_dict[data['city_time']][9],
+                                      self.city_dict[data['city_time']][0]))
         degree_sign= u'\N{DEGREE SIGN}'.encode('iso-8859-1')
-        print "Location : %03d%s%02d'%s %02d%s%02d'%s" % (
+        print ("Location : %03d%s%02d'%s %02d%s%02d'%s" % (
             data['long_deg'], degree_sign, data['long_min'], data['long_dir'],
-            data['lat_deg'], degree_sign, data['lat_min'], data['lat_dir'])
+            data['lat_deg'], degree_sign, data['lat_min'], data['lat_dir']))
         if data['dst_always_on']:
-            print "DST      : Always on"
+            print ("DST      : Always on")
         else:
-            print "DST      : %s (%s)" % (self.dst_dict[data['dst']][1],
-                                          self.dst_dict[data['dst']][0])
+            print ("DST      : %s (%s)" % (self.dst_dict[data['dst']][1],
+                                          self.dst_dict[data['dst']][0]))
 
     def set_location(self, station, loc_type, location):
         dst_on = 1
@@ -902,7 +902,7 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
                     city_index = idx
                     break
             if city_index is None:
-                print "City code '%s' not recognized - consult station manual for valid city codes" % location_list[0]
+                print ("City code '%s' not recognized - consult station manual for valid city codes" % location_list[0])
                 return
             long_deg = self.city_dict[city_index][6]
             long_min = self.city_dict[city_index][7]
@@ -916,32 +916,32 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             dst_index = self.city_dict[city_index][2]
         elif len(location_list) == 9 and location_list[0] == "USR":
             if int(location_list[1]) < 0 or int(location_list[1]) > 180:
-                print "Longitude degrees must be between 0 and 180 inclusive"
+                print ("Longitude degrees must be between 0 and 180 inclusive")
                 return
             if int(location_list[2]) < 0 or int(location_list[2]) > 180:
-                print "Longitude minutes must be between 0 and 59 inclusive"
+                print ("Longitude minutes must be between 0 and 59 inclusive")
                 return
             if location_list[3] != "E" and location_list[3] != "W":
-                print "Longitude direction must be E or W"
+                print ("Longitude direction must be E or W")
                 return
             if int(location_list[4]) < 0 or int(location_list[4]) > 180:
-                print "Latitude degrees must be between 0 and 90 inclusive"
+                print ("Latitude degrees must be between 0 and 90 inclusive")
                 return
             if int(location_list[5]) < 0 or int(location_list[5]) > 180:
-                print "Latitude minutes must be between 0 and 59 inclusive"
+                print ("Latitude minutes must be between 0 and 59 inclusive")
                 return
             if location_list[6] != "N" and location_list[6] != "S":
-                print "Longitude direction must be N or S"
+                print ("Longitude direction must be N or S")
                 return
             tz_list = location_list[7].split(':')
             if len(tz_list) != 2:
-                print "Bad timezone '%s', format is HOUR:MINUTE" % location_list[7]
+                print ("Bad timezone '%s', format is HOUR:MINUTE" % location_list[7])
                 return
             if int(tz_list[0]) < -12 or int(tz_list[0]) > 12:
-                print "Timezone hour must be between -12 and 12 inclusive"
+                print ("Timezone hour must be between -12 and 12 inclusive")
                 return
             if int(tz_list[1]) != 0 and int(tz_list[1]) != 30:
-                print "Timezone minute must be 0 or 30"
+                print ("Timezone minute must be 0 or 30")
                 return
             if location_list[8].lower() != 'on':
                 dst_on = 0
@@ -951,7 +951,7 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
                         dst_index = idx
                         break
                 if dst_index is None:
-                    print "DST code '%s' not recognized - consult station manual for valid DST codes" % location_list[8]
+                    print ("DST code '%s' not recognized - consult station manual for valid DST codes" % location_list[8])
                     return
             else:
                 dst_on = 1
@@ -966,8 +966,8 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             tz_hr = int(tz_list[0])
             tz_min = int(tz_list[1])
         else:
-            print "Bad location '%s'" % location
-            print "Location format is: %s" % self.LOCSTR
+            print ("Bad location '%s'" % location)
+            print ("Location format is: %s" % self.LOCSTR)
             return
         station.set_loc(loc_type, city_index, dst_on, dst_index, tz_hr, tz_min,
                         lat_deg, lat_min, lat_dir,
@@ -976,98 +976,98 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
     @staticmethod
     def show_altitude(station):
         altitude = station.get_alt()
-        print "Altitude: %d meters" % altitude
+        print ("Altitude: %d meters" % altitude)
 
     @staticmethod
     def set_altitude(station, altitude):
         if altitude < -200 or altitude > 5000:
-            print "Altitude must be between -200 and 5000 inclusive"
+            print ("Altitude must be between -200 and 5000 inclusive")
             return
         station.set_alt(altitude)
 
     @staticmethod
     def show_alarms(station):
         data = station.get_alarms()
-        print "Weekday alarm : %02d:%02d (%s)" % (
-            data['weekday_hour'], data['weekday_min'], data['weekday_active'])
-        print "Single  alarm : %02d:%02d (%s)" % (
-            data['single_hour'], data['single_min'], data['single_active'])
-        print "Pre-alarm     : %s (%s)" % (
-            data['prealarm_period'], data['prealarm_active'])
+        print ("Weekday alarm : %02d:%02d (%s)" % (
+            data['weekday_hour'], data['weekday_min'], data['weekday_active']))
+        print ("Single  alarm : %02d:%02d (%s)" % (
+            data['single_hour'], data['single_min'], data['single_active']))
+        print ("Pre-alarm     : %s (%s)" % (
+            data['prealarm_period'], data['prealarm_active']))
         if data['snooze'] > 0:
-            print "Snooze        : %d mins" % data['snooze']
+            print ("Snooze        : %d mins" % data['snooze'])
         else:
-            print "Snooze        : Invalid"
-        print "Max Temperature Alarm : %s" % data['max_temp']
-        print "Min Temperature Alarm : %s" % data['min_temp']
-        print "Rain Alarm            : %d mm (%s)" % (
-            data['rain'], data['rain_active'])
-        print "Wind Speed Alarm      : %s (%s)" % (
-            data['windspeed'], data['windspeed_active'])
-        print "Wind Gust  Alarm      : %s (%s)" % (
-            data['windgust'], data['windgust_active'])
+            print ("Snooze        : Invalid")
+        print ("Max Temperature Alarm : %s" % data['max_temp'])
+        print ("Min Temperature Alarm : %s" % data['min_temp'])
+        print ("Rain Alarm            : %d mm (%s)" % (
+            data['rain'], data['rain_active']))
+        print ("Wind Speed Alarm      : %s (%s)" % (
+            data['windspeed'], data['windspeed_active']))
+        print ("Wind Gust  Alarm      : %s (%s)" % (
+            data['windgust'], data['windgust_active']))
 
     @staticmethod
     def set_alarms(station, alarm):
         alarm_list = alarm.split(',')
         if len(alarm_list) != 9:
-            print "Bad alarm '%s'" % alarm
-            print "Alarm format is: %s" % TE923Configurator.ALMSTR
+            print ("Bad alarm '%s'" % alarm)
+            print ("Alarm format is: %s" % TE923Configurator.ALMSTR)
             return
         weekday = alarm_list[0]
         if weekday.lower() != 'off':
             weekday_list = weekday.split(':')
             if len(weekday_list) != 2:
-                print "Bad alarm '%s', expected HOUR:MINUTE or OFF" % weekday
+                print ("Bad alarm '%s', expected HOUR:MINUTE or OFF" % weekday)
                 return
             if int(weekday_list[0]) < 0 or int(weekday_list[0]) > 23:
-                print "Alarm hours must be between 0 and 23 inclusive"
+                print ("Alarm hours must be between 0 and 23 inclusive")
                 return
             if int(weekday_list[1]) < 0 or int(weekday_list[1]) > 59:
-                print "Alarm minutes must be between 0 and 59 inclusive"
+                print ("Alarm minutes must be between 0 and 59 inclusive")
                 return
         single = alarm_list[1]
         if single.lower() != 'off':
             single_list = single.split(':')
             if len(single_list) != 2:
-                print "Bad alarm '%s', expected HOUR:MINUTE or OFF" % single
+                print ("Bad alarm '%s', expected HOUR:MINUTE or OFF" % single)
                 return
             if int(single_list[0]) < 0 or int(single_list[0]) > 23:
-                print "Alarm hours must be between 0 and 23 inclusive"
+                print ("Alarm hours must be between 0 and 23 inclusive")
                 return
             if int(single_list[1]) < 0 or int(single_list[1]) > 59:
-                print "Alarm minutes must be between 0 and 59 inclusive"
+                print ("Alarm minutes must be between 0 and 59 inclusive")
                 return
         if alarm_list[2].lower() != 'off' and alarm_list[2] not in ['15', '30', '45', '60', '90']:
-            print "Prealarm must be 15, 30, 45, 60, 90 or OFF"
+            print ("Prealarm must be 15, 30, 45, 60, 90 or OFF")
             return
         if int(alarm_list[3]) < 1 or int(alarm_list[3]) > 15:
-            print "Snooze must be between 1 and 15 inclusive"
+            print ("Snooze must be between 1 and 15 inclusive")
             return
         if float(alarm_list[4]) < -50 or float(alarm_list[4]) > 70:
-            print "Temperature alarm must be between -50 and 70 inclusive"
+            print ("Temperature alarm must be between -50 and 70 inclusive")
             return
         if float(alarm_list[5]) < -50 or float(alarm_list[5]) > 70:
-            print "Temperature alarm must be between -50 and 70 inclusive"
+            print ("Temperature alarm must be between -50 and 70 inclusive")
             return
         if alarm_list[6].lower() != 'off' and (int(alarm_list[6]) < 1 or int(alarm_list[6]) > 9999):
-            print "Rain alarm must be between 1 and 999 inclusive or OFF"
+            print ("Rain alarm must be between 1 and 999 inclusive or OFF")
             return
         if alarm_list[7].lower() != 'off' and (float(alarm_list[7]) < 1 or float(alarm_list[7]) > 199):
-            print "Wind alarm must be between 1 and 199 inclusive or OFF"
+            print ("Wind alarm must be between 1 and 199 inclusive or OFF")
             return
         if alarm_list[8].lower() != 'off' and (float(alarm_list[8]) < 1 or float(alarm_list[8]) > 199):
-            print "Wind alarm must be between 1 and 199 inclusive or OFF"
+            print ("Wind alarm must be between 1 and 199 inclusive or OFF")
             return
         station.set_alarms(alarm_list[0], alarm_list[1], alarm_list[2],
                            alarm_list[3], alarm_list[4], alarm_list[5],
                            alarm_list[6], alarm_list[7], alarm_list[8])
-        print "Temperature alarms can only be modified via station controls"
+        print ("Temperature alarms can only be modified via station controls")
 
     @staticmethod
     def show_interval(station):
         idx = station.get_interval()
-        print "Interval: %s" % TE923Configurator.idx_to_interval.get(idx, 'unknown')
+        print ("Interval: %s" % TE923Configurator.idx_to_interval.get(idx, 'unknown'))
 
     @staticmethod
     def set_interval(station, interval):
@@ -1082,8 +1082,8 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             except ValueError:
                 pass
         if idx is None:
-            print "Bad interval '%s'" % interval
-            print "Valid intervals are %s" % ','.join(TE923Configurator.interval_to_idx.keys())
+            print ("Bad interval '%s'" % interval)
+            print ("Valid intervals are %s" % ','.join(TE923Configurator.interval_to_idx.keys()))
             return
         station.set_interval(idx)
 
@@ -1092,17 +1092,17 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
         if fmt.lower() == 'table':
             TE923Configurator.print_table(data)
         else:
-            print data
+            print (data)
 
     @staticmethod
     def print_table(data):
         for key in sorted(data):
-            print "%s: %s" % (key.rjust(16), data[key])
+            print ("%s: %s" % (key.rjust(16), data[key]))
 
     @staticmethod
     def print_alignment():
-        print "  If computer time is not aligned to station time then date"
-        print "  may be incorrect by 1 day"
+        print ("  If computer time is not aligned to station time then date")
+        print ("  may be incorrect by 1 day")
 
 
 class TE923Driver(weewx.drivers.AbstractDevice):
@@ -1555,7 +1555,7 @@ class TE923Station(object):
         try:
             self.devh.claimInterface(interface)
             self.devh.setAltInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             logcrt("Unable to claim USB interface %s: %s" % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -1569,7 +1569,7 @@ class TE923Station(object):
     def close(self):
         try:
             self.devh.releaseInterface()
-        except (ValueError, usb.USBError), e:
+        except (ValueError, usb.USBError) as e:
             logerr("release interface failed: %s" % e)
         self.devh = None
 
@@ -1614,7 +1614,7 @@ class TE923Station(object):
                     rbuf.extend(buf[1:1 + nbytes])
                 if len(rbuf) >= 34:
                     break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 errmsg = repr(e)
                 if not ('No data available' in errmsg or 'No error' in errmsg):
                     raise
@@ -1704,7 +1704,7 @@ class TE923Station(object):
                     rbuf.extend(tmpbuf[1:1 + nbytes])
                 if len(rbuf) >= 1:
                     break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 errmsg = repr(e)
                 if not ('No data available' in errmsg or 'No error' in errmsg):
                     raise
@@ -1733,7 +1733,7 @@ class TE923Station(object):
                 if DEBUG_READ:
                     logdbg("read: %s" % _fmt(buf))
                 return buf
-            except (BadRead, BadHeader, usb.USBError), e:
+            except (BadRead, BadHeader, usb.USBError) as e:
                 logerr("Failed attempt %d of %d to read data: %s" %
                        (cnt + 1, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -1749,7 +1749,7 @@ class TE923Station(object):
             try:
                 self._raw_write(addr, buf)
                 return
-            except (BadWrite, BadHeader, usb.USBError), e:
+            except (BadWrite, BadHeader, usb.USBError) as e:
                 logerr("Failed attempt %d of %d to write data: %s" %
                        (cnt + 1, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -2339,7 +2339,7 @@ if __name__ == '__main__':
         (options, _) = parser.parse_args()
 
         if options.version:
-            print "te923 driver version %s" % DRIVER_VERSION
+            print ("te923 driver version %s" % DRIVER_VERSION)
             exit(1)
 
         if options.debug is not None:
@@ -2350,8 +2350,8 @@ if __name__ == '__main__':
         if (options.format.lower() != FMT_TE923TOOL and
             options.format.lower() != FMT_TABLE and
             options.format.lower() != FMT_DICT):
-            print "Unknown format '%s'.  Known formats include: %s" % (
-                options.format, ','.join([FMT_TE923TOOL, FMT_TABLE, FMT_DICT]))
+            print ("Unknown format '%s'.  Known formats include: %s" % (
+                options.format, ','.join([FMT_TE923TOOL, FMT_TABLE, FMT_DICT])))
             exit(1)
 
         with TE923Station() as station:
@@ -2382,23 +2382,23 @@ if __name__ == '__main__':
         if fmt.lower() == FMT_TABLE:
             print_table(data)
         else:
-            print data
+            print (data)
 
     def print_hex(ptr, data):
-        print "0x%06x %s" % (ptr, _fmt(data))
+        print ("0x%06x %s" % (ptr, _fmt(data)))
 
     def print_table(data):
         """output entire dictionary contents in two columns"""
         for key in sorted(data):
-            print "%s: %s" % (key.rjust(16), data[key])
+            print ("%s: %s" % (key.rjust(16), data[key]))
 
     def print_status(data):
         """output status fields in te923tool format"""
-        print "0x%x:0x%x:0x%x:0x%x:0x%x:%d:%d:%d:%d:%d:%d:%d:%d" % (
+        print ("0x%x:0x%x:0x%x:0x%x:0x%x:%d:%d:%d:%d:%d:%d:%d:%d" % (
             data['version_sys'], data['version_bar'], data['version_uv'],
             data['version_rcc'], data['version_wind'],
             data['bat_rain'], data['bat_uv'], data['bat_wind'], data['bat_5'],
-            data['bat_4'], data['bat_3'], data['bat_2'], data['bat_1'])
+            data['bat_4'], data['bat_3'], data['bat_2'], data['bat_1']))
 
     def print_readings(data):
         """output sensor readings in te923tool format"""
@@ -2417,7 +2417,7 @@ if __name__ == '__main__':
         output.append(getvalue(data, 'windgust', '%0.1f'))
         output.append(getvalue(data, 'windchill', '%0.1f'))
         output.append(getvalue(data, 'rain', '%d'))
-        print ':'.join(output)
+        print (':').join(output)
 
     def getvalue(data, label, fmt):
         if label + '_state' in data:

--- a/bin/weewx/drivers/ultimeter.py
+++ b/bin/weewx/drivers/ultimeter.py
@@ -193,7 +193,7 @@ class Station(object):
             logdbg("station time: day:%s min:%s (%s)" %
                    (d, m, timestamp_to_string(ts)))
             return ts
-        except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+        except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
             logerr("get_time failed: %s" % e)
         return int(time.time())
 
@@ -248,7 +248,7 @@ class Station(object):
                 buf = self.get_readings()
                 self.validate_string(buf)
                 return buf
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 loginf("Failed attempt %d of %d to get readings: %s" %
                        (ntries + 1, max_tries, e))
                 time.sleep(retry_wait)
@@ -323,7 +323,7 @@ class Station(object):
                     v -= (1 << bits)
             if multiplier is not None:
                 v *= multiplier
-        except ValueError, e:
+        except ValueError as e:
             if s != '----':
                 logdbg("decode failed for '%s': %s" % (s, e))
         return v
@@ -347,8 +347,8 @@ class UltimeterConfEditor(weewx.drivers.AbstractConfEditor):
 """ % Station.DEFAULT_PORT
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example: /dev/ttyUSB0 or /dev/ttyS0 or /dev/cua0."
+        print ("Specify the serial port on which the station is connected, for")
+        print ("example: /dev/ttyUSB0 or /dev/ttyS0 or /dev/cua0.")
         port = self._prompt('port', Station.DEFAULT_PORT)
         return {'port': port}
 
@@ -376,10 +376,10 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ultimeter driver version %s" % DRIVER_VERSION
+        print ("ultimeter driver version %s" % DRIVER_VERSION)
         exit(0)
 
     with Station(options.port, debug_serial=options.debug) as station:
         station.set_logger_mode()
         while True:
-            print time.time(), _fmt(station.get_readings())
+            print (time.time(), _fmt(station.get_readings()))

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -20,8 +20,8 @@ import weewx.drivers
 import weewx.units
 import weewx.engine
 
-DRIVER_NAME = 'Vantage'
-DRIVER_VERSION = '3.0.10'
+DRIVER_NAME = "Vantage"
+DRIVER_VERSION = "3.0.10"
 
 def loader(config_dict, engine):
     return VantageService(engine, config_dict)
@@ -83,9 +83,9 @@ class BaseWrapper(object):
                 if _resp == '\n\r':
                     syslog.syslog(syslog.LOG_DEBUG, "vantage: Rude wake up of console successful")
                     return
-                print "Unable to wake up console... sleeping"
+                print ("Unable to wake up console... sleeping")
                 time.sleep(self.wait_before_retry)
-                print "Unable to wake up console... retrying"
+                print ("Unable to wake up console... retrying")
             except weewx.WeeWxIOError:
                 pass
             syslog.syslog(syslog.LOG_DEBUG, "vantage: Retry  #%d failed" % count)
@@ -220,7 +220,7 @@ def guard_termios(fn):
         def guarded_fn(*args, **kwargs):
             try:
                 return fn(*args, **kwargs)
-            except termios.error, e:
+            except termios.error as e:
                 raise weewx.WeeWxIOError(e)
     except ImportError:
         def guarded_fn(*args, **kwargs):
@@ -253,7 +253,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             _buffer = self.serial_port.read(chars)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on read.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             syslog.syslog(syslog.LOG_ERR, "   ****  Is there a competing process running??")
@@ -268,7 +268,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             N = self.serial_port.write(data)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on write.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             # Reraise as a Weewx error I/O error:
@@ -315,7 +315,7 @@ class EthernetWrapper(BaseWrapper):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(self.timeout)
             self.socket.connect((self.host, self.port))
-        except (socket.error, socket.timeout, socket.herror), ex:
+        except (socket.error, socket.timeout, socket.herror) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: Socket error while opening port %d to ethernet host %s." % (self.port, self.host))
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -378,7 +378,7 @@ class EthernetWrapper(BaseWrapper):
             _N = min(4096, _remaining)
             try:
                 _recv = self.socket.recv(_N)
-            except (socket.timeout, socket.error), ex:
+            except (socket.timeout, socket.error) as ex:
                 syslog.syslog(syslog.LOG_ERR, "vantage: ip-read error: %s" % ex)
                 # Reraise as a weewx I/O error:
                 raise weewx.WeeWxIOError(ex)
@@ -397,7 +397,7 @@ class EthernetWrapper(BaseWrapper):
             # A delay of 0.0 gives socket write error; 0.01 gives no ack error; 0.05 is OK for weewx program
             # Note: a delay of 0.5 s is required for wee_device --logger=logger_info
             time.sleep(self.tcp_send_delay)
-        except (socket.timeout, socket.error), ex:
+        except (socket.timeout, socket.error) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: ip-write error: %s" % ex)
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -506,7 +506,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     # on the VP (somewhere around 220).
                     for _loop_packet in self.genDavisLoopPackets(200):
                         yield _loop_packet
-                except weewx.WeeWxIOError, e:
+                except weewx.WeeWxIOError as e:
                     syslog.syslog(syslog.LOG_ERR, "vantage: LOOP try #%d; error: %s" % (count + 1, e))
                     break
 
@@ -559,7 +559,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     yield _record
                 # The generator loop exited. We're done.
                 return
-            except weewx.WeeWxIOError, e:
+            except weewx.WeeWxIOError as e:
                 # Problem. Increment retry count
                 count += 1
                 syslog.syslog(syslog.LOG_ERR, "vantage: DMPAFT try #%d; error: %s" % (count, e))
@@ -904,7 +904,7 @@ class Vantage(weewx.drivers.AbstractDevice):
         """
         latitude = int(round((latitude_dg * 10), 0))
         if latitude not in range(-900, 901):
-            raise weewx.ViolatedPrecondition, "vantage: Invalid latitude %.1f degree" % (latitude_dg,)
+            raise weewx.ViolatedPrecondition("vantage: Invalid latitude %.1f degree" % (latitude_dg,))
 
         # Tell the console to put one byte in hex location 0x0B
         self.port.send_data("EEBWR 0B 02\n")
@@ -922,7 +922,7 @@ class Vantage(weewx.drivers.AbstractDevice):
         """
         longitude = int(round((longitude_dg * 10), 0))
         if longitude not in range(-1800, 1801):
-            raise weewx.ViolatedPrecondition, "vantage: Invalid longitude %.1f degree" % (longitude_dg,)
+            raise weewx.ViolatedPrecondition("vantage: Invalid longitude %.1f degree" % (longitude_dg,))
 
         # Tell the console to put one byte in hex location 0x0D
         self.port.send_data("EEBWR 0D 02\n")
@@ -940,7 +940,7 @@ class Vantage(weewx.drivers.AbstractDevice):
         60, 300, 600, 900, 1800, 3600, or 7200 
         """
         if archive_interval_seconds not in (60, 300, 600, 900, 1800, 3600, 7200):
-            raise weewx.ViolatedPrecondition, "vantage: Invalid archive interval (%d)" % (archive_interval_seconds,)
+            raise weewx.ViolatedPrecondition("vantage: Invalid archive interval (%d)" % (archive_interval_seconds,))
 
         # The console expects the interval in minutes. Divide by 60.
         command = 'SETPER %d\n' % (archive_interval_seconds / 60)
@@ -2018,7 +2018,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         """Query the configuration of the Vantage, printing out status
         information"""
 
-        print "Querying..."
+        print ("Querying...")
         try:
             _firmware_date = station.getFirmwareDate()
         except Exception:
@@ -2184,28 +2184,28 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         """Set the console archive interval."""
     
         old_interval_minutes = station.archive_interval/60
-        print "Old archive interval is %d minutes, new one will be %d minutes." % (station.archive_interval/60, new_interval_minutes)
+        print ("Old archive interval is %d minutes, new one will be %d minutes." % (station.archive_interval/60, new_interval_minutes))
         if old_interval_minutes == new_interval_minutes:
-            print "Old and new archive intervals are the same. Nothing done."
+            print ("Old and new archive intervals are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the archive interval as well as erase all old archive records."
-                ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will change the archive interval as well as erase all old archive records.")
+                ans = input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setArchiveInterval(new_interval_minutes * 60)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new archive interval. Reason:\n\t****", e
                     else:
-                        print "Archive interval now set to %d seconds." % (station.archive_interval,)
+                        print ("Archive interval now set to %d seconds." % (station.archive_interval,))
                         # The Davis documentation implies that the log is
                         # cleared after changing the archive interval, but that
                         # doesn't seem to be the case. Clear it explicitly:
                         station.clearLog()
-                        print "Archive records cleared."
+                        print ("Archive records cleared.")
                 elif ans == 'n':
-                    print "Nothing done."
+                    print ("Nothing done.")
 
     @staticmethod
     def set_latitude(station, latitude_dg):
@@ -2213,17 +2213,17 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set the latitude value to %.1f degree." % latitude_dg
-            ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+            print ("Proceeding will set the latitude value to %.1f degree." % latitude_dg)
+            ans = input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setLatitude(latitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new latitude. Reason:\n\t****", e
                 else:
-                    print "Station latitude set to %.1f degree." % latitude_dg
+                    print ("Station latitude set to %.1f degree." % latitude_dg)
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_longitude(station, longitude_dg):
@@ -2231,25 +2231,25 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set the longitude value to %.1f degree." % longitude_dg
-            ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+            print ("Proceeding will set the longitude value to %.1f degree." % longitude_dg)
+            ans = input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setLongitude(longitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new longitude. Reason:\n\t****", e
                 else:
-                    print "Station longitude set to %.1f degree." % longitude_dg
+                    print ("Station longitude set to %.1f degree." % longitude_dg)
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod    
     def set_altitude(station, altitude_ft):
         """Set the console station altitude"""
         ans = None
         while ans not in ['y', 'n']:    
-            print "Proceeding will set the station altitude to %.0f feet." % altitude_ft
-            ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+            print ("Proceeding will set the station altitude to %.0f feet." % altitude_ft)
+            ans = input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 # Hit the console to get the current barometer calibration data and preserve it:
                 _bardata = station.getBarData()
@@ -2262,7 +2262,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     # Set previous _barcal value
                     station.setBarData(_bardata[0] + _barcal, altitude_ft)
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_barometer(station, barometer_inHg):
@@ -2273,14 +2273,14 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         ans = None
         while ans not in ['y', 'n']:
             if barometer_inHg:
-                print "Proceeding will set the barometer value to %.3f and the station altitude to %.0f feet." % (barometer_inHg, _bardata[1])
+                print ("Proceeding will set the barometer value to %.3f and the station altitude to %.0f feet." % (barometer_inHg, _bardata[1]))
             else:
-                print "Proceeding will have the console pick a sensible barometer calibration and set the station altitude to %.0f feet," % (_bardata[1],)
-            ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+                print ("Proceeding will have the console pick a sensible barometer calibration and set the station altitude to %.0f feet," % (_bardata[1],))
+            ans = input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 station.setBarData(barometer_inHg, _bardata[1])
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def clear_memory(station):
@@ -2288,14 +2288,14 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
     
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will erase old archive records."
-            ans = raw_input("Are you sure you wish to proceed (y/n)? ")
+            print ("Proceeding will erase old archive records.")
+            ans = input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
-                print "Clearing the archive memory ..."
+                print ("Clearing the archive memory ...")
                 station.clearLog()
-                print "Archive records cleared."
+                print ("Archive records cleared.")
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_wind_cup(station, new_wind_cup_type):
@@ -2307,75 +2307,75 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
     """
             return
 
-        print "Old rain wind cup type is %d (%s), new one is %d (%s)." % (
+        print ("Old rain wind cup type is %d (%s), new one is %d (%s)." % (
             station.wind_cup_type,
             station.wind_cup_size,
             new_wind_cup_type,
-            Vantage.wind_cup_dict[new_wind_cup_type])
+            Vantage.wind_cup_dict[new_wind_cup_type]))
         if station.wind_cup_type == new_wind_cup_type:
-            print "Old and new wind cup types are the same. Nothing done."
+            print ("Old and new wind cup types are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the wind cup type."
-                ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will change the wind cup type.")
+                ans = input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setWindCupType(new_wind_cup_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new wind cup type. Reason:\n\t****", e
                     else:
-                        print "Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size)
+                        print ("Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print ("Nothing done.")
 
     @staticmethod
     def set_bucket(station, new_bucket_type):
         """Set the bucket type on the console."""
 
-        print "Old rain bucket type is %d (%s), new one is %d (%s)." % (
+        print ("Old rain bucket type is %d (%s), new one is %d (%s)." % (
             station.rain_bucket_type,
             station.rain_bucket_size,
             new_bucket_type,
-            Vantage.rain_bucket_dict[new_bucket_type])
+            Vantage.rain_bucket_dict[new_bucket_type]))
         if station.rain_bucket_type == new_bucket_type:
-            print "Old and new bucket types are the same. Nothing done."
+            print ("Old and new bucket types are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the rain bucket type."
-                ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will change the rain bucket type.")
+                ans = input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setBucketType(new_bucket_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new bucket type. Reason:\n\t****", e
                     else:
-                        print "Bucket type now set to %d." % (station.rain_bucket_type,)
+                        print ("Bucket type now set to %d." % (station.rain_bucket_type,))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print ("Nothing done.")
 
     @staticmethod
     def set_rain_year_start(station, rain_year_start):
 
-        print "Old rain season start is %d, new one is %d." % (station.rain_year_start, rain_year_start)
+        print ("Old rain season start is %d, new one is %d." % (station.rain_year_start, rain_year_start))
 
         if station.rain_year_start == rain_year_start:
-            print "Old and new rain season starts are the same. Nothing done."
+            print ("Old and new rain season starts are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the rain season start."
-                ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will change the rain season start.")
+                ans = input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setRainYearStart(rain_year_start)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new rain year start. Reason:\n\t****", e
                     else:
-                        print "Rain year start now set to %d." % (station.rain_year_start,)
+                        print ("Rain year start now set to %d." % (station.rain_year_start,))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print ("Nothing done.")
 
     @staticmethod
     def set_offset(station, offset_list):
@@ -2398,15 +2398,15 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for wind direction to %+d." % (offset)
-                    ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                    print ("Proceeding will set offset for wind direction to %+d." % (offset))
+                    ans = input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationWindDir(offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new wind offset. Reason:\n\t****", e
                         else:
-                            print "Wind direction offset now set to %+d." % (offset)
+                            print ("Wind direction offset now set to %+d." % (offset))
         elif variable in temp_variables:
             offset = float(offset_str)
             if not -12.8 <= offset <= 12.7:
@@ -2414,15 +2414,15 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for temperature %s to %.1f." % (variable, offset)
-                    ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                    print ("Proceeding will set offset for temperature %s to %.1f." % (variable, offset))
+                    ans = input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationTemp(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new temperature offset. Reason:\n\t****", e
                         else:
-                            print "Temperature offset %s now set to %+.1f." % (variable, offset)
+                            print ("Temperature offset %s now set to %+.1f." % (variable, offset))
         elif variable in humid_variables:
             offset = int(offset_str)
             if not 0 <= offset <= 100:
@@ -2430,15 +2430,15 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for humidity %s to %+d." % (variable, offset)
-                    ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                    print ("Proceeding will set offset for humidity %s to %+d." % (variable, offset))
+                    ans = input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationHumid(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new humidity offset. Reason:\n\t****", e
                         else:
-                            print "Humidity offset %s now set to %+d." % (variable, offset)
+                            print ("Humidity offset %s now set to %+d." % (variable, offset))
         else:
             print >> sys.stderr, "Unknown variable %s" % (variable)
 
@@ -2449,14 +2449,14 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         transmitter_list = map((lambda x: int(x) if x.isdigit() else x if x != "" else None), transmitter_list.split(','))
         channel = transmitter_list[0]
         if not 1 <= channel <= 8:
-            print "Channel number must be between 1 and 8."
+            print ("Channel number must be between 1 and 8.")
             return
         
         # Check new channel against retransmit channel.
         # Warn and stop if new channel is used as retransmit channel.
         retransmit_channel = station._getEEPROM_value(0x18)[0]
         if retransmit_channel == channel:
-            print "This channel is used as retransmit channel. Please turn off retransmit function or choose another channel."
+            print ("This channel is used as retransmit channel. Please turn off retransmit function or choose another channel.")
             return
         
         # Init repeater to 'no repeater'
@@ -2472,7 +2472,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                         repeater = key
                         break
                 if repeater == 0:
-                    print "Repeater ID must be between 'A' and 'H'."
+                    print ("Repeater ID must be between 'A' and 'H'.")
                     return
         except:
             # No repeater letter
@@ -2486,32 +2486,32 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         try:
             transmitter_type_name = station.transmitter_type_dict[transmitter_type]
         except KeyError:
-            print "Unknown transmitter type (%s)" % transmitter_type
+            print ("Unknown transmitter type (%s)" % transmitter_type)
             return
         
         if transmitter_type_name in ['temp', 'temp_hum'] and extra_temp not in range(1, 8):
-            print "Transmitter type %s requires extra_temp in range 1-7'" % transmitter_type_name
+            print ("Transmitter type %s requires extra_temp in range 1-7'" % transmitter_type_name)
             return
         
         if transmitter_type_name in ['hum', 'temp_hum'] and extra_hum not in range(1, 8):
-            print "Transmitter type %s requires extra_hum in range 1-7'" % transmitter_type_name
+            print ("Transmitter type %s requires extra_hum in range 1-7'" % transmitter_type_name)
             return
         
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set channel %d to type %d (%s), repeater: %s, %s." % (
-                channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx])
-            ans = raw_input("Are you sure you want to proceed (y/n)? ")
+            print ("Proceeding will set channel %d to type %d (%s), repeater: %s, %s." % (
+                channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx]))
+            ans = input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setTransmitterType(channel, transmitter_type, extra_temp, extra_hum, repeater)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set transmitter type. Reason:\n\t****", e
                 else:
-                    print "Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
-                        channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx])
+                    print ("Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
+                        channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx]))
             else:
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_retransmit(station, channel_on_off):
@@ -2525,13 +2525,13 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if len(channel_on_off_list) > 1:
                 channel = map((lambda x: int(x) if x != "" else None), channel_on_off_list[1])[0]
                 if not 0 < channel < 9:
-                    print "Channel out of range 1..8. Nothing done."
+                    print ("Channel out of range 1..8. Nothing done.")
                     return
         
             transmitter_list = station.getStnTransmitters()
             if channel != 0:
                 if transmitter_list[channel-1]["listen"] == "active":
-                    print "Channel %d in use. Please select another channel. Nothing done." % channel
+                    print ("Channel %d in use. Please select another channel. Nothing done." % channel)
                     return
             else:
                 for i in range(0, 7):
@@ -2539,33 +2539,33 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                         channel = i+1
                         break
             if channel == 0:
-                print "All Channels in use. Retransmit can't be enabled. Nothing done."
+                print ("All Channels in use. Retransmit can't be enabled. Nothing done.")
                 return
     
         old_channel = station._getEEPROM_value(0x18)[0]
         if old_channel == channel:
-            print "Old and new retransmit settings are the same. Nothing done."
+            print ("Old and new retransmit settings are the same. Nothing done.")
             return
         
         ans = None
         while ans not in ['y', 'n']:
             if channel != 0:
-                print "Proceeding will set retransmit to 'ON' at channel: %d." % channel
+                print ("Proceeding will set retransmit to 'ON' at channel: %d." % channel)
             else:
-                print "Proceeding will set retransmit to 'OFF'."
-            ans = raw_input("Are you sure you want to proceed (y/n)? ")
+                print ("Proceeding will set retransmit to 'OFF'.")
+            ans = input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setRetransmit(channel)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set retransmit. Reason:\n\t****", e
                 else:
                     if channel != 0:
-                        print "Retransmit set to 'ON' at channel: %d." % channel
+                        print ("Retransmit set to 'ON' at channel: %d." % channel)
                     else:
-                        print "Retransmit set to 'OFF'."
+                        print ("Retransmit set to 'OFF'.")
             else:
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_temp_logging(station, tempLogging):
@@ -2573,36 +2573,36 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will change the console temperature logging to '%s'." % (tempLogging.upper())
-            ans = raw_input("Are you sure you want to proceed (y/n)? ")
+            print ("Proceeding will change the console temperature logging to '%s'." % (tempLogging.upper()))
+            ans = input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setTempLogging(tempLogging)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new console temperature logging. Reason:\n\t****", e
                 else:
-                    print "Console temperature logging set to '%s'." % (tempLogging.upper())
+                    print ("Console temperature logging set to '%s'." % (tempLogging.upper()))
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def set_time(station):
-        print "Setting time on console..."
+        print ("Setting time on console...")
         station.setTime()
         newtime_ts = station.getTime()
-        print "Current console time is %s" % weeutil.weeutil.timestamp_to_string(newtime_ts)
+        print ("Current console time is %s" % weeutil.weeutil.timestamp_to_string(newtime_ts))
 
     @staticmethod
     def set_dst(station, dst):
         station.setDST(dst) 
-        print "Set DST on console to '%s'" % dst
+        print ("Set DST on console to '%s'" % dst)
 
     @staticmethod
     def set_tz_code(station, tz_code):
-        print "Setting time zone code to %d..." % tz_code
+        print ("Setting time zone code to %d..." % tz_code)
         station.setTZcode(tz_code)
         new_tz_code = station.getStnInfo()[5]
-        print "Set time zone code to %s" % new_tz_code
+        print ("Set time zone code to %s" % new_tz_code)
 
     @staticmethod
     def set_tz_offset(station, tz_offset):
@@ -2616,32 +2616,32 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             offset = -offset
         station.setTZoffset(offset)
         new_offset = station.getStnInfo()[6]
-        print "Set time zone offset to %+.1f hours" % new_offset
+        print ("Set time zone offset to %+.1f hours" % new_offset)
 
     @staticmethod
     def set_lamp(station, onoff):
-        print "Setting lamp on console..."
+        print ("Setting lamp on console...")
         station.setLamp(onoff)
 
     @staticmethod
     def start_logger(station):
-        print "Starting logger ..."
+        print ("Starting logger ...")
         station.startLogger()
-        print "Logger started"
+        print ("Logger started")
 
     @staticmethod
     def stop_logger(station):
-        print "Stopping logger ..."
+        print ("Stopping logger ...")
         station.stopLogger()
-        print "Logger stopped"
+        print ("Logger stopped")
 
     @staticmethod
     def dump_logger(station, config_dict):
         import weewx.manager
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will dump all data in the logger."
-            ans = raw_input("Are you sure you want to proceed (y/n)? ")
+            print ("Proceeding will dump all data in the logger.")
+            ans = input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 with weewx.manager.open_manager_with_config(config_dict, 'wx_binding',
                                                             initialize=True) as archive:
@@ -2649,29 +2649,29 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     # Wrap the Vantage generator function in a converter, which will convert the units to the
                     # same units used by the database:
                     converted_generator = weewx.units.GenWithConvert(station.genArchiveDump(), archive.std_unit_system)
-                    print "Starting dump ..."
+                    print ("Starting dump ...")
                     for record in converted_generator:
                         archive.addRecord(record)
                         nrecs += 1
                         if nrecs % 10 == 0:
                             print >> sys.stdout, "Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(record['dateTime'])),
                             sys.stdout.flush()
-                    print "\nFinished dump. %d records added" % (nrecs,)
+                    print ("\nFinished dump. %d records added" % (nrecs,))
             elif ans == 'n':
-                print "Nothing done."
+                print ("Nothing done.")
 
     @staticmethod
     def logger_summary(station, dest_path):
         try:
             dest = open(dest_path, mode="w")
-        except IOError, e:
+        except IOError as e:
             print >> sys.stderr, "Unable to open destination '%s' for write" % dest_path
             print >> sys.stderr, "Reason: %s" % e
             return
 
         VantageConfigurator.show_info(station, dest)
     
-        print "Starting download of logger summary..."
+        print ("Starting download of logger summary...")
     
         nrecs = 0
         for (page, index, y, mo, d, h, mn, time_ts) in station.genLoggerSummary():
@@ -2683,7 +2683,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if nrecs % 10 == 0:
                 print >> sys.stdout, "Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(time_ts)),
                 sys.stdout.flush()
-        print "\nFinished download of logger summary to file '%s'. %d records processed." % (dest_path, nrecs)
+        print ("\nFinished download of logger summary to file '%s'. %d records processed." % (dest_path, nrecs))
 
 
 # =============================================================================
@@ -2750,18 +2750,18 @@ class VantageConfEditor(weewx.drivers.AbstractConfEditor):
 
     def prompt_for_settings(self):
         settings = dict()
-        print "Specify the hardware interface, either 'serial' or 'ethernet'."
-        print "If the station is connected by serial, USB, or serial-to-USB"
-        print "adapter, specify serial.  Specify ethernet for stations with"
-        print "WeatherLinkIP interface."
+        print ("Specify the hardware interface, either 'serial' or 'ethernet'.")
+        print ("If the station is connected by serial, USB, or serial-to-USB")
+        print ("adapter, specify serial.  Specify ethernet for stations with")
+        print ("WeatherLinkIP interface.")
         settings['type'] = self._prompt('type', 'serial', ['serial', 'ethernet'])
         if settings['type'] == 'serial':
-            print "Specify a port for stations with a serial interface, for"
-            print "example /dev/ttyUSB0 or /dev/ttyS0."
+            print ("Specify a port for stations with a serial interface, for")
+            print ("example /dev/ttyUSB0 or /dev/ttyS0.")
             settings['port'] = self._prompt('port', '/dev/ttyUSB0')
         else:
-            print "Specify the IP address (e.g., 192.168.0.10) or hostname"
-            print "(e.g., console or console.example.com) for stations with"
-            print "an ethernet interface."
+            print ("Specify the IP address (e.g., 192.168.0.10) or hostname")
+            print ("(e.g., console or console.example.com) for stations with")
+            print ("an ethernet interface.")
             settings['host'] = self._prompt('host')
         return settings

--- a/bin/weewx/drivers/wmr100.py
+++ b/bin/weewx/drivers/wmr100.py
@@ -178,7 +178,7 @@ class WMR100(weewx.drivers.AbstractDevice):
             pass
         try:
             self.devh.claimInterface(self.interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.closePort()
             logerr("Unable to claim USB interface: %s" % e)
             raise weewx.WeeWxIOError(e)
@@ -246,7 +246,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                 # Compute its checksum. This can throw an exception if the packet is empty.
                 try:
                     computed_checksum = reduce(operator.iadd, buff[:-2])
-                except TypeError, e:
+                except TypeError as e:
                     logdbg("Exception while calculating checksum: %s" % e)
                 else:
                     actual_checksum = (buff[-1] << 8) + buff[-2]
@@ -288,7 +288,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                                  0x0000200,                                  # value
                                  0x0000000,                                  # index
                                  1000)                                       # timeout
-        except usb.USBError, e:
+        except usb.USBError as e:
             logerr("Unable to send USB control message: %s" % e)
             # Convert to a Weewx error:
             raise weewx.WakeupError(e)
@@ -306,7 +306,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                 for i in range(1, report[0] + 1):
                     yield report[i]
                 nerrors = 0
-            except (IndexError, usb.USBError), e:
+            except (IndexError, usb.USBError) as e:
                 logdbg("Bad USB report received: %s" % e)
                 nerrors += 1
                 if nerrors > self.max_tries:
@@ -439,8 +439,8 @@ class WMR100ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate calculation to hardware."""
+        print ("""
+Setting rainRate calculation to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'

--- a/bin/weewx/drivers/wmr200.py
+++ b/bin/weewx/drivers/wmr200.py
@@ -197,11 +197,11 @@ class UsbDevice(object):
         A specific device must have been found."""
         try:
             self.handle = self.dev.open()
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt(('open_device() Unable to open USB interface.'
                     ' Reason: %s' % exception))
             raise weewx.WakeupError(exception)
-        except AttributeError, exception:
+        except AttributeError as exception:
             logcrt('open_device() Device not specified.')
             raise weewx.WakeupError(exception)
 
@@ -213,7 +213,7 @@ class UsbDevice(object):
 
         try:
             self.handle.claimInterface(self.interface)
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt(('open_device() Unable to'
                     ' claim USB interface. Reason: %s' % exception))
             raise weewx.WakeupError(exception)
@@ -227,7 +227,7 @@ class UsbDevice(object):
         not be cross platform."""
         try:
             self.handle.releaseInterface()
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt('close_device() Unable to'
                    ' release device interface. Reason: %s' % exception)
 
@@ -266,11 +266,11 @@ class UsbDevice(object):
                 logdbg('read_device(): %s' % buf)
             return report[1:report[0] + 1]
 
-        except IndexError, e:
+        except IndexError as e:
             # This indicates we failed an index range above.
             logerr('read_device() Failed the index rage %s: %s' % (report, e))
 
-        except usb.USBError, ex:
+        except usb.USBError as ex:
             # No data presented on the bus.  This is a normal part of
             # the process that indicates that the current live records
             # have been exhausted.  We have to send a heartbeat command
@@ -309,7 +309,7 @@ class UsbDevice(object):
                 value,                                # value
                 0x0000000,                            # index
                 _WMR200_USB_RESET_TIMEOUT)            # timeout
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = ('write_device() Unable to'
                    ' send USB control message %s' % exception)
             logerr(msg)
@@ -485,7 +485,7 @@ class Packet(object):
                    % len(self._pkt_data))
             raise WMR200ProtocolError(msg)
 
-        except (OverflowError, ValueError), exception:
+        except (OverflowError, ValueError) as exception:
             msg = ('Packet timestamp with bogus fields min:%d hr:%d day:%d'
                    ' m:%d y:%d %s' % (pkt_data[0], pkt_data[1],
                    pkt_data[2], pkt_data[3], pkt_data[4], exception))
@@ -1341,7 +1341,7 @@ class PollUsbDevice(threading.Thread):
             self._ok_to_read = True
             time.sleep(1)
 
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = ('reset_console() Unable to send USB control'
                    'message %s' % exception)
             logerr(msg)
@@ -1634,7 +1634,7 @@ class WMR200(weewx.drivers.AbstractDevice):
         buf = [0x01, cmd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         try:
             self.usb_device.write_device(buf)
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = (('_write_cmd() Unable to send USB cmd:0x%02x control'
                     ' message' % cmd))
             logerr(msg)
@@ -1752,7 +1752,7 @@ class WMR200(weewx.drivers.AbstractDevice):
             else:
                 logdbg(('  Acknowledged control packet'
                         ' rx:%d') % PacketControl.pkt_rx)
-        except WMR200PacketParsingError, e:
+        except WMR200PacketParsingError as e:
             # Drop any bogus packets.
             logerr(self._pkt.to_string_raw('Discarding bogus packet: %s ' 
                    % e.msg))
@@ -2067,8 +2067,8 @@ class WMR200ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate and windchill calculations to hardware."""
+        print ("""
+Setting rainRate and windchill calculations to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'

--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -912,7 +912,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
 #                    cmd = [0x73, 0xe5, 0x0a, 0x26, 0x0e, 0xc1]
                     self.station.write(cmd)
                     self.last_7x = time.time()
-            except usb.USBError, e:
+            except usb.USBError as e:
                 if DEBUG_COMM:
                     logdbg("loop: "
                            "e.errno=%s e.strerror=%s e.message=%s repr=%s" %
@@ -920,7 +920,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                 if not known_usb_err(e):
                     logerr("usb failure: %s" % e)
                     raise weewx.WeeWxIOError(e)
-            except (WrongLength, BadChecksum), e:
+            except (WrongLength, BadChecksum) as e:
                 loginf(e)
             time.sleep(0.001)
 
@@ -982,7 +982,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                     cmd = [0x65, 0x19, 0xe5, 0x04, 0x52, _lo(self.last_record)]
                     self.station.write(cmd)
                     self.last_65 = time.time()
-            except usb.USBError, e:
+            except usb.USBError as e:
                 if DEBUG_COMM:
                     logdbg("history: "
                            "e.errno=%s e.strerror=%s e.message=%s repr=%s" %
@@ -990,7 +990,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                 if not known_usb_err(e):
                     logerr("usb failure: %s" % e)
                     raise weewx.WeeWxIOError(e)
-            except (WrongLength, BadChecksum), e:
+            except (WrongLength, BadChecksum) as e:
                 loginf(e)
             time.sleep(0.001)        
 
@@ -1114,7 +1114,7 @@ class Station(object):
         # attempt to claim the interface
         try:
             self.handle.claimInterface(self.interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             raise WMR300Error("Unable to claim interface %s: %s" %
                               (self.interface, e))
@@ -1123,7 +1123,7 @@ class Station(object):
         if self.handle is not None:
             try:
                 self.handle.releaseInterface()
-            except (ValueError, usb.USBError), e:
+            except (ValueError, usb.USBError) as e:
                 logdbg("Release interface failed: %s" % e)
             self.handle = None
 
@@ -1139,7 +1139,7 @@ class Station(object):
                 logdbg("read: %s" % _fmt_bytes(buf))
             if DEBUG_COUNTS and count:
                 self.update_count(buf, self.recv_counts)
-        except usb.USBError, e:
+        except usb.USBError as e:
             if DEBUG_COMM:
                 logdbg("read: e.errno=%s e.strerror=%s e.message=%s repr=%s" %
                        (e.errno, e.strerror, e.message, repr(e)))
@@ -1208,7 +1208,7 @@ class Station(object):
             if cs1 != cs2:
                 raise BadChecksum("%s: bad checksum: %04x != %04x" %
                                   (label, cs1, cs2))
-        except IndexError, e:
+        except IndexError as e:
             raise BadChecksum("%s: not enough bytes for checksum: %s" %
                               (label, e))
 
@@ -1239,7 +1239,7 @@ class Station(object):
             return time.mktime((year, month, day, hour, minute, 0, -1, -1, -1))
         except IndexError:
             raise WMR300Error("buffer too short for timestamp")
-        except (OverflowError, ValueError), e:
+        except (OverflowError, ValueError) as e:
             raise WMR300Error(
                 "cannot create timestamp from y:%s m:%s d:%s H:%s M:%s: %s" %
                 (buf[0], buf[1], buf[2], buf[3], buf[4], e))
@@ -1291,7 +1291,7 @@ class Station(object):
             if DEBUG_DECODE:
                 logdbg('decode: %s %s' % (_fmt_bytes(buf), pkt))
             return pkt
-        except IndexError, e:
+        except IndexError as e:
             raise WMR300Error("cannot decode buffer: %s" % e)
         except AttributeError:
             raise WMR300Error("unknown packet type %02x: %s" %
@@ -1448,8 +1448,8 @@ class WMR300ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate, windchill, heatindex, and dewpoint calculations to hardware."""
+        print ("""
+Setting rainRate, windchill, heatindex, and dewpoint calculations to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'
@@ -1476,7 +1476,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "wmr300 driver version %s" % DRIVER_VERSION
+        print ("wmr300 driver version %s" % DRIVER_VERSION)
         exit(0)
 
     driver_dict = {
@@ -1487,4 +1487,4 @@ if __name__ == '__main__':
     stn = WMR300Driver(**driver_dict)
 
     for packet in stn.genLoopPackets():
-        print packet
+        print (packet)

--- a/bin/weewx/drivers/wmr9x8.py
+++ b/bin/weewx/drivers/wmr9x8.py
@@ -339,7 +339,7 @@ class WMR9x8(weewx.drivers.AbstractDevice):
 
     def log_packet(self, packet):
         packet_str = ','.join(["x%x" % v for v in packet])
-        print "%d, %s, %s" % (int(time.time() + 0.5), time.asctime(), packet_str)
+        print ("%d, %s, %s" % (int(time.time() + 0.5), time.asctime(), packet_str))
 
     @wmr9x8_registerpackettype(typecode=0x00, size=11)
     def _wmr9x8_wind_packet(self, packet):
@@ -708,14 +708,14 @@ class WMR9x8ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print ("Specify the serial port on which the station is connected, for")
+        print ("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', '/dev/ttyUSB0')
         return {'port': port}
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate, windchill, and dewpoint calculations to hardware."""
+        print ("""
+Setting rainRate, windchill, and dewpoint calculations to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'
@@ -750,7 +750,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "WMR9x8 driver version %s" % DRIVER_VERSION
+        print ("WMR9x8 driver version %s" % DRIVER_VERSION)
         exit(0)
 
     if options.gen_packets:
@@ -759,4 +759,4 @@ if __name__ == '__main__':
         stn = WMR9x8(**stn_dict)
         
         for packet in stn.genLoopPackets():
-            print packet
+            print (packet)

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -207,7 +207,7 @@ class StationData(object):
                     v -= (1 << bits)
             if multiplier is not None:
                 v *= multiplier
-        except ValueError, e:
+        except ValueError as e:
             if s != '----':
                 logdbg("decode failed for '%s': %s" % (s, e))
         return v
@@ -261,7 +261,7 @@ class StationSerial(object):
                 buf = self.get_readings()
                 StationData.validate_string(buf)
                 return buf
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 loginf("Failed attempt %d of %d to get readings: %s" %
                        (ntries + 1, max_tries, e))
                 time.sleep(wait_before_retry)
@@ -304,7 +304,7 @@ class StationSocket(object):
             elif protocol == 'udp':
                 self.net_socket = socket.socket(
                     socket.AF_INET, socket.SOCK_DGRAM)
-        except (socket.error, socket.herror), ex:
+        except (socket.error, socket.herror) as ex:
             logerr("Cannot create socket for some reason: %s" % ex)
             raise weewx.WeeWxIOError(ex)
 
@@ -322,7 +322,7 @@ class StationSocket(object):
                     logdbg("Retrying connection...")
                 self.net_socket.connect(self.conn_info)
                 break
-            except (socket.error, socket.timeout, socket.herror), ex:
+            except (socket.error, socket.timeout, socket.herror) as ex:
                 logerr("Cannot connect to %s:%d for some reason: %s. "
                        "%d tries left." % (
                            self.conn_info[0], self.conn_info[1], ex,
@@ -341,7 +341,7 @@ class StationSocket(object):
                (self.conn_info[0], self.conn_info[1]))
         try:
             self.net_socket.close()
-        except (socket.error, socket.herror, socket.timeout), ex:
+        except (socket.error, socket.herror, socket.timeout) as ex:
             logerr("Cannot close connection to %s:%d. Reason: %s" % (
                 self.conn_info[0], self.conn_info[1], ex))
             raise weewx.WeeWxIOError(ex)
@@ -356,7 +356,7 @@ class StationSocket(object):
             while True:
                 try:
                     buf += self.net_socket.recv(8, socket.MSG_WAITALL)
-                except (socket.error, socket.timeout), ex:
+                except (socket.error, socket.timeout) as ex:
                     raise weewx.WeeWxIOError(ex)
                 if DEBUG_READ >= 1:
                     logdbg("(searching...) buf: %s" % buf)
@@ -373,13 +373,13 @@ class StationSocket(object):
             try:
                 buf += self.net_socket.recv(
                     PACKET_SIZE - len(buf), socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
         else:
             # Keep receiving data until we find an exclamation point or two
             try:
                 buf = self.net_socket.recv(2, socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
             while True:
                 if buf == '\r\n':
@@ -398,7 +398,7 @@ class StationSocket(object):
                 else:
                     try:
                         buf = self.net_socket.recv(2, socket.MSG_WAITALL)
-                    except (socket.error, socket.timeout), ex:
+                    except (socket.error, socket.timeout) as ex:
                         raise weewx.WeeWxIOError(ex)
                     if DEBUG_READ >= 2:
                             logdbg("buf: %s" % ' '.join(
@@ -406,7 +406,7 @@ class StationSocket(object):
             try:
                 buf += self.net_socket.recv(
                     PACKET_SIZE - len(buf), socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
         if DEBUG_READ >= 2:
             logdbg("buf: %s" % buf)
@@ -421,7 +421,7 @@ class StationSocket(object):
                 buf = self.get_readings()
                 StationData.validate_string(buf)
                 return buf
-            except (weewx.WeeWxIOError), e:
+            except (weewx.WeeWxIOError) as e:
                 logdbg("Failed to get data. Reason: %s" % e)
                 self.rec_start = False
 
@@ -464,20 +464,20 @@ class WS1ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "How is the station connected? tcp, udp, or serial."
+        print ("How is the station connected? tcp, udp, or serial.")
         con_mode = self._prompt('mode', 'serial')
         con_mode = con_mode.lower()
 
         if con_mode == 'serial':
-            print "Specify the serial port on which the station is connected, "
-            "for example: /dev/ttyUSB0 or /dev/ttyS0."
+            print ("Specify the serial port on which the station is connected, "
+            "for example: /dev/ttyUSB0 or /dev/ttyS0.")
             port = self._prompt('port', '/dev/ttyUSB0')
         elif con_mode == 'tcp' or con_mode == 'udp':
-            print "Specify the IP address and port of the station. For "
-            "example: 192.168.36.40:3000."
+            print ("Specify the IP address and port of the station. For "
+            "example: 192.168.36.40:3000.")
             port = self._prompt('port', '192.168.36.40:3000')
 
-        print "Specify how long to wait for a response, in seconds."
+        print ("Specify how long to wait for a response, in seconds.")
         timeout = self._prompt('timeout', 3)
 
         return {'mode': con_mode, 'port': port, 'timeout': timeout}
@@ -504,9 +504,9 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ADS WS1 driver version %s" % DRIVER_VERSION
+        print ("ADS WS1 driver version %s" % DRIVER_VERSION)
         exit(0)
 
     with StationSerial(options.port) as s:
         while True:
-            print time.time(), s.get_readings()
+            print (time.time(), s.get_readings())

--- a/bin/weewx/drivers/ws23xx.py
+++ b/bin/weewx/drivers/ws23xx.py
@@ -328,24 +328,24 @@ class WS23xxConfigurator(weewx.drivers.AbstractConfigurator):
 
     def show_info(self):
         """Query the station then display the settings."""
-        print 'Querying the station for the configuration...'
+        print ('Querying the station for the configuration...')
         config = self.station.getConfig()
         for key in sorted(config):
-            print '%s: %s' % (key, config[key])
+            print ('%s: %s' % (key, config[key]))
 
     def show_current(self):
         """Get current weather observation."""
-        print 'Querying the station for current weather data...'
+        print ('Querying the station for current weather data...')
         for packet in self.station.genLoopPackets():
-            print packet
+            print (packet)
             break
 
     def show_history(self, ts=None, count=0):
         """Show the indicated number of records or records since timestamp"""
-        print "Querying the station for historical records..."
+        print ("Querying the station for historical records...")
         for i, r in enumerate(self.station.genStartupRecords(since_ts=ts,
                                                              count=count)):
-            print r
+            print (r)
             if count and i > count:
                 break
 
@@ -355,54 +355,54 @@ class WS23xxConfigurator(weewx.drivers.AbstractConfigurator):
         while ans not in ['y', 'n']:
             v = self.station.getTime()
             vstr = weeutil.weeutil.timestamp_to_string(v)
-            print "Station clock is", vstr
+            print ("Station clock is", vstr)
             if prompt:
-                ans = raw_input("Set station clock (y/n)? ")
+                ans = input("Set station clock (y/n)? ")
             else:
-                print "Setting station clock"
+                print ("Setting station clock")
                 ans = 'y'
             if ans == 'y':
                 self.station.setTime()
                 v = self.station.getTime()
                 vstr = weeutil.weeutil.timestamp_to_string(v)
-                print "Station clock is now", vstr
+                print ("Station clock is now", vstr)
             elif ans == 'n':
-                print "Set clock cancelled."
+                print ("Set clock cancelled.")
 
     def set_interval(self, interval, prompt):
-        print "Changing the interval will clear the station memory."
+        print ("Changing the interval will clear the station memory.")
         v = self.station.getArchiveInterval()
         ans = None
         while ans not in ['y', 'n']:
-            print "Interval is", v
+            print ("Interval is", v)
             if prompt:
-                ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
+                ans = input("Set interval to %d minutes (y/n)? " % interval)
             else:
-                print "Setting interval to %d minutes" % interval
+                print ("Setting interval to %d minutes" % interval)
                 ans = 'y'
             if ans == 'y':
                 self.station.setArchiveInterval(interval)
                 v = self.station.getArchiveInterval()
-                print "Interval is now", v
+                print ("Interval is now", v)
             elif ans == 'n':
-                print "Set interval cancelled."
+                print ("Set interval cancelled.")
 
     def clear_history(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.getRecordCount()
-            print "Records in memory:", v
+            print ("Records in memory:", v)
             if prompt:
-                ans = raw_input("Clear console memory (y/n)? ")
+                ans = input("Clear console memory (y/n)? ")
             else:
-                print 'Clearing console memory'
+                print ('Clearing console memory')
                 ans = 'y'
             if ans == 'y':
                 self.station.clearHistory()
                 v = self.station.getRecordCount()
-                print "Records in memory:", v
+                print ("Records in memory:", v)
             elif ans == 'n':
-                print "Clear memory cancelled."
+                print ("Clear memory cancelled.")
 
 
 class WS23xxDriver(weewx.drivers.AbstractDevice):
@@ -491,7 +491,7 @@ class WS23xxDriver(weewx.drivers.AbstractDevice):
                                (conn_info[1], conn_info[0]))
                         self._poll_wait = conn_info[1]
                 time.sleep(self._poll_wait)
-            except Ws2300.Ws2300Exception, e:
+            except Ws2300.Ws2300Exception as e:
                 logerr("Failed attempt %d of %d to get LOOP data: %s" %
                        (ntries, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -901,7 +901,7 @@ class LinuxSerialPort(SerialPort):
         #
         try:
             self.serial_port = os.open(self.device, os.O_RDWR)
-        except EnvironmentError, e:
+        except EnvironmentError as e:
             raise FatalError(self.device, "can't open tty device - %s." % str(e))
         try:
             fcntl.flock(self.serial_port, fcntl.LOCK_EX)
@@ -2064,14 +2064,14 @@ class WS23xxConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print ("Specify the serial port on which the station is connected, for")
+        print ("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', '/dev/ttyUSB0')
         return {'port': port}
 
     def modify_config(self, config_dict):
-        print """
-Setting record_generation to software."""
+        print ("""
+Setting record_generation to software.""")
         config_dict['StdArchive']['record_generation'] = 'software'
 
 
@@ -2107,7 +2107,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ws23xx driver version %s" % DRIVER_VERSION
+        print ("ws23xx driver version %s" % DRIVER_VERSION)
         exit(1)
 
     if options.debug is not None:
@@ -2118,13 +2118,13 @@ if __name__ == '__main__':
     with WS23xx(port) as s:
         if options.readings:
             data = s.get_raw_data(SENSOR_IDS)
-            print data
+            print (data)
         if options.records is not None:
             for ts,record in s.gen_records(count=options.records):
-                print ts,record
+                print (ts,record)
         if options.measure:
             data = s.get_raw_data([options.measure])
-            print data
+            print (data)
         if options.hm:
             for m in Measure.IDS:
-                print "%s\t%s" % (m, Measure.IDS[m].name)
+                print ("%s\t%s" % (m, Measure.IDS[m].name))

--- a/bin/weewx/drivers/ws28xx.py
+++ b/bin/weewx/drivers/ws28xx.py
@@ -925,7 +925,10 @@ Step 8. Go to step 1 to wait for state 0xde16 again.
 
 from datetime import datetime
 
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import sys
 import syslog
 import threading
@@ -1040,9 +1043,9 @@ def index_to_addr(idx):
 def print_dict(data):
     for x in sorted(data.keys()):
         if x == 'dateTime':
-            print '%s: %s' % (x, weeutil.weeutil.timestamp_to_string(data[x]))
+            print ('%s: %s' % (x, weeutil.weeutil.timestamp_to_string(data[x])))
         else:
-            print '%s: %s' % (x, data[x])
+            print ('%s: %s' % (x, data[x]))
 
 
 class WS28xxConfEditor(weewx.drivers.AbstractConfEditor):
@@ -1064,8 +1067,8 @@ class WS28xxConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the frequency used between the station and the"
-        print "transceiver, either 'US' (915 MHz) or 'EU' (868.3 MHz)."
+        print ("Specify the frequency used between the station and the")
+        print ("transceiver, either 'US' (915 MHz) or 'EU' (868.3 MHz).")
         freq = self._prompt('frequency', 'US', ['US', 'EU'])
         return {'transceiver_frequency': freq}
 
@@ -1115,30 +1118,30 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
 
     def check_transceiver(self, maxtries):
         """See if the transceiver is installed and operational."""
-        print 'Checking for transceiver...'
+        print ('Checking for transceiver...')
         ntries = 0
         while ntries < maxtries:
             ntries += 1
             if self.station.transceiver_is_present():
-                print 'Transceiver is present'
+                print ('Transceiver is present')
                 sn = self.station.get_transceiver_serial()
-                print 'serial: %s' % sn
+                print ('serial: %s' % sn)
                 tid = self.station.get_transceiver_id()
-                print 'id: %d (0x%04x)' % (tid, tid)
+                print ('id: %d (0x%04x)' % (tid, tid))
                 break
-            print 'Not found (attempt %d of %d) ...' % (ntries, maxtries)
+            print ('Not found (attempt %d of %d) ...' % (ntries, maxtries))
             time.sleep(5)
         else:
-            print 'Transceiver not responding.'
+            print ('Transceiver not responding.')
 
     def pair(self, maxtries):
         """Pair the transceiver with the station console."""
-        print 'Pairing transceiver with console...'
+        print ('Pairing transceiver with console...')
         maxwait = 90 # how long to wait between button presses, in seconds
         ntries = 0
         while ntries < maxtries or maxtries == 0:
             if self.station.transceiver_is_paired():
-                print 'Transceiver is paired to console'
+                print ('Transceiver is paired to console')
                 break
             ntries += 1
             msg = 'Press and hold the [v] key until "PC" appears'
@@ -1146,14 +1149,14 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 msg += ' (attempt %d of %d)' % (ntries, maxtries)
             else:
                 msg += ' (attempt %d)' % ntries
-            print msg
+            print (msg)
             now = start_ts = int(time.time())
             while (now - start_ts < maxwait and
                    not self.station.transceiver_is_paired()):
                 time.sleep(5)
                 now = int(time.time())
         else:
-            print 'Transceiver not paired to console.'
+            print ('Transceiver not paired to console.')
 
     def get_interval(self, maxtries):
         cfg = self.get_config(maxtries)
@@ -1173,24 +1176,24 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 start_ts = int(time.time())
             else:
                 dur = int(time.time()) - start_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print ('No data after %d seconds (press SET to sync)' % dur)
             time.sleep(30)
         return None
 
     def set_interval(self, maxtries, interval, prompt):
         """Set the station archive interval"""
-        print "This feature is not yet implemented"
+        print ("This feature is not yet implemented")
 
     def show_info(self, maxtries):
         """Query the station then display the settings."""
-        print 'Querying the station for the configuration...'
+        print ('Querying the station for the configuration...')
         cfg = self.get_config(maxtries)
         if cfg is not None:
             print_dict(cfg)
 
     def show_current(self, maxtries):
         """Get current weather observation."""
-        print 'Querying the station for current weather data...'
+        print ('Querying the station for current weather data...')
         start_ts = None
         ntries = 0
         while ntries < maxtries or maxtries == 0:
@@ -1203,20 +1206,20 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 start_ts = int(time.time())
             else:
                 dur = int(time.time()) - start_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print ('No data after %d seconds (press SET to sync)' % dur)
             time.sleep(30)
 
     def show_history(self, maxtries, ts=0, count=0):
         """Display the indicated number of records or the records since the 
         specified timestamp (local time, in seconds)"""
-        print "Querying the station for historical records..."
+        print ("Querying the station for historical records...")
         ntries = 0
         last_n = nrem = None
         last_ts = int(time.time())
         self.station.start_caching_history(since_ts=ts, num_rec=count)
         while nrem is None or nrem > 0:
             if ntries >= maxtries:
-                print 'Giving up after %d tries' % ntries
+                print ('Giving up after %d tries' % ntries)
                 break
             time.sleep(30)
             ntries += 1
@@ -1224,7 +1227,7 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
             n = self.station.get_num_history_scanned()
             if n == last_n:
                 dur = now - last_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print ('No data after %d seconds (press SET to sync)' % dur)
             else:
                 ntries = 0
                 last_ts = now
@@ -1239,9 +1242,9 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
         records = self.station.get_history_cache_records()
         self.station.clear_history_cache()
         print
-        print 'Found %d records' % len(records)
+        print ('Found %d records' % len(records))
         for r in records:
-            print r
+            print (r)
 
 
 class WS28xxDriver(weewx.drivers.AbstractDevice):
@@ -2115,7 +2118,7 @@ class USBHardware(object):
                            (label, minutes, hours, days, month, year))
         if result is None:
             # FIXME: use None instead of a really old date to indicate invalid
-            result = datetime(1900, 01, 01, 00, 00)
+            result = datetime(1900, 1, 1, 0, 0)
         return result
 
     @staticmethod
@@ -3140,7 +3143,7 @@ class sHID(object):
             logdbg('claiming USB interface %d' % interface)
             self.devh.claimInterface(interface)
             self.devh.setAltInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self._close_device()
             logcrt('Unable to claim USB interface %s: %s' % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -4110,7 +4113,7 @@ class CCommunicationService(object):
             logdbg('starting rf communication')
             while self.running:
                 self.doRFCommunication()
-        except Exception, e:
+        except Exception as e:
             logerr('exception in doRF: %s' % e)
             log_traceback(dst=syslog.LOG_INFO)
             self.running = False
@@ -4155,9 +4158,9 @@ class CCommunicationService(object):
         try:
             self.generateResponse(FrameBuffer, DataLength)
             self.shid.setFrame(FrameBuffer[0], DataLength[0])
-        except BadResponse, e:
+        except BadResponse as e:
             logerr('generateResponse failed: %s' % e)
-        except DataWritten, e:
+        except DataWritten as e:
             logdbg('SetTime/SetConfig data written')
         self.shid.setTX()
 

--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -104,7 +104,7 @@ class StdEngine(object):
             loader_function = getattr(driver_module, 'loader')
             # Call it with the configuration dictionary as the only argument:
             self.console = loader_function(config_dict, self)
-        except Exception, ex:
+        except Exception as ex:
             syslog.syslog(syslog.LOG_ERR,
                           "import of driver failed: %s (%s)" % (ex, type(ex)))
             # Signal that we have an initialization error:
@@ -374,9 +374,9 @@ class StdCalibrate(StdService):
             if obs_type == 'foo': continue
             try:
                 event.packet[obs_type] = eval(self.corrections[obs_type], None, event.packet)
-            except (TypeError, NameError), e:
+            except (TypeError, NameError) as e:
                 pass
-            except ValueError, e:
+            except ValueError as e:
                 syslog.syslog(syslog.LOG_ERR, "engine: StdCalibration loop error %s" % e)
 
     def new_archive_record(self, event):
@@ -388,9 +388,9 @@ class StdCalibrate(StdService):
                 if obs_type == 'foo': continue
                 try:
                     event.record[obs_type] = eval(self.corrections[obs_type], None, event.record)
-                except (TypeError, NameError), e:
+                except (TypeError, NameError) as e:
                     pass
-                except ValueError, e:
+                except ValueError as e:
                     syslog.syslog(syslog.LOG_ERR, "engine: StdCalibration archive error %s" % e)
 
 #==============================================================================
@@ -620,7 +620,7 @@ class StdArchive(StdService):
                 self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
                                                       record=record,
                                                       origin='hardware'))
-        except weewx.HardwareError, e:
+        except weewx.HardwareError as e:
             syslog.syslog(syslog.LOG_ERR, "engine: Internal error detected. Catchup abandoned")
             syslog.syslog(syslog.LOG_ERR, "**** %s" % e)
         
@@ -707,11 +707,11 @@ class StdPrint(StdService):
         
     def new_loop_packet(self, event):
         """Print out the new LOOP packet"""
-        print "LOOP:  ", weeutil.weeutil.timestamp_to_string(event.packet['dateTime']), to_sorted_string(event.packet)
+        print ("LOOP:  ", weeutil.weeutil.timestamp_to_string(event.packet['dateTime']), to_sorted_string(event.packet))
     
     def new_archive_record(self, event):
         """Print out the new archive record."""
-        print "REC:   ", weeutil.weeutil.timestamp_to_string(event.record['dateTime']), to_sorted_string(event.record)
+        print ("REC:   ", weeutil.weeutil.timestamp_to_string(event.record['dateTime']), to_sorted_string(event.record))
 
 
 #==============================================================================
@@ -872,7 +872,7 @@ def main(options, args, engine_class=StdEngine):
             syslog.syslog(syslog.LOG_CRIT, "engine: Unexpected exit from main loop. Program exiting.")
     
         # Catch any console initialization error:
-        except InitializationError, e:
+        except InitializationError as e:
             # Log it:
             syslog.syslog(syslog.LOG_CRIT, "engine: Unable to load driver: %s" % e)
             # See if we should loop, waiting for the console to be ready.
@@ -886,7 +886,7 @@ def main(options, args, engine_class=StdEngine):
                 sys.exit(weewx.IO_ERROR)
 
         # Catch any recoverable weewx I/O errors:
-        except weewx.WeeWxIOError, e:
+        except weewx.WeeWxIOError as e:
             # Caught an I/O error. Log it, wait 60 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught WeeWxIOError: %s" % e)
             if options.exit:
@@ -896,7 +896,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(60)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             # Caught a database error. Log it, wait 120 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Database OperationalError exception: %s" % e)
             if options.exit:
@@ -906,7 +906,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(120)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except weedb.CannotConnect, e:
+        except weedb.CannotConnect as e:
             # Unable to connect to the database server. Log it, wait 120 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Database CannotConnect exception: %s" % e)
             if options.exit:
@@ -916,7 +916,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(120)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except OSError, e:
+        except OSError as e:
             # Caught an OS error. Log it, wait 10 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught OSError: %s" % e)
             weeutil.weeutil.log_traceback("    ****  ", syslog.LOG_DEBUG)
@@ -940,7 +940,7 @@ def main(options, args, engine_class=StdEngine):
             raise
     
         # Catch any non-recoverable errors. Log them, exit
-        except Exception, ex:
+        except Exception as ex:
             # Caught unrecoverable error. Log it, exit
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught unrecoverable exception in engine:")
             syslog.syslog(syslog.LOG_CRIT, "    ****  %s" % ex)
@@ -961,7 +961,7 @@ def getConfiguration(config_path):
         syslog.syslog(syslog.LOG_CRIT, "engine: Unable to open configuration file %s" % config_path)
         # Reraise the exception (this should cause the program to exit)
         raise
-    except configobj.ConfigObjError, e:
+    except configobj.ConfigObjError as e:
         syslog.syslog(syslog.LOG_CRIT, "engine: Error while parsing configuration file %s" % config_path)
         syslog.syslog(syslog.LOG_CRIT, "****    Reason: '%s'" % e)
         raise

--- a/bin/weewx/imagegenerator.py
+++ b/bin/weewx/imagegenerator.py
@@ -242,7 +242,7 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
                     # Now save the image
                     image.save(img_file)
                     ngen += 1
-                except IOError, e:
+                except IOError as e:
                     syslog.syslog(syslog.LOG_CRIT, "imagegenerator: Unable to save to file '%s' %s:" % (img_file, e))
         t2 = time.time()
 

--- a/bin/weewx/manager.py
+++ b/bin/weewx/manager.py
@@ -176,7 +176,7 @@ class Manager(object):
         try:
             with weedb.Transaction(self.connection) as _cursor:
                 _cursor.execute("CREATE TABLE %s (%s);" % (self.table_name, _sqltypestr, ))
-        except weedb.DatabaseError, e:
+        except weedb.DatabaseError as e:
             syslog.syslog(syslog.LOG_ERR, "manager: "
                           "Unable to create table '%s' in database '%s': %s" % 
                           (self.table_name, self.database_name, e))
@@ -246,7 +246,7 @@ class Manager(object):
 
                     min_ts = min(min_ts, record['dateTime']) if min_ts is not None else record['dateTime']
                     max_ts = max(max_ts, record['dateTime'])
-                except (weedb.IntegrityError, weedb.OperationalError), e:
+                except (weedb.IntegrityError, weedb.OperationalError) as e:
                     syslog.syslog(syslog.LOG_ERR, "manager: "
                                   "Unable to add record %s to database '%s': %s" %
                                   (weeutil.weeutil.timestamp_to_string(record['dateTime']), 
@@ -919,7 +919,7 @@ def get_database_dict_from_config(config_dict, database):
     """
     try:
         database_dict = dict(config_dict['Databases'][database])
-    except KeyError, e:
+    except KeyError as e:
         raise weewx.UnknownDatabase("Unknown database '%s'" % e)
     
     # See if a 'database_type' is specified. This is something
@@ -957,7 +957,7 @@ def get_manager_dict_from_config(config_dict, data_binding,
     # will be adding to it):
     try:
         manager_dict = dict(config_dict['DataBindings'][data_binding])
-    except KeyError, e:
+    except KeyError as e:
         raise weewx.UnknownBinding("Unknown data binding '%s'" % e)
 
     # If anything is missing, substitute from the default dictionary:
@@ -969,7 +969,7 @@ def get_manager_dict_from_config(config_dict, data_binding,
             database = manager_dict.pop('database')
             manager_dict['database_dict'] = get_database_dict_from_config(config_dict,
                                                                           database)
-        except KeyError, e:
+        except KeyError as e:
             raise weewx.UnknownDatabase("Unknown database '%s'" % e)
         
     # The schema may be specified as a string, in which case we resolve the
@@ -1257,7 +1257,7 @@ class DaySummaryManager(Manager):
 
         # Check to see if this is a valid daily summary type:
         if obs_type not in self.daykeys:
-            raise AttributeError, "Unknown daily summary type %s" % (obs_type,)
+            raise AttributeError("Unknown daily summary type %s" % (obs_type,))
 
         val = option_dict.get('val')
         if val is None:
@@ -1547,7 +1547,7 @@ class DaySummaryManager(Manager):
             # be prepared to catch an exception:
             try:
                 cursor.execute(_sql_replace_str, _write_tuple)
-            except weedb.OperationalError, e:
+            except weedb.OperationalError as e:
                 syslog.syslog(syslog.LOG_ERR, "manager: "
                               "Replace failed for database %s: %s"
                               % (self.database_name, e))
@@ -1598,7 +1598,7 @@ class DaySummaryManager(Manager):
                         _cursor.execute("DROP TABLE %s" % _table_name)
 
             del self.daykeys
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             syslog.syslog(syslog.LOG_ERR, "manager: "
                           "Drop summaries failed for database '%s': %s"
                           % (self.connection.database_name, e))
@@ -1617,7 +1617,7 @@ if __name__ == '__main__':
 #     nrecs, ndays = mgr.backfill_day_summary(start_d, stop_d)
     nrecs, ndays = mgr.backfill_day_summary(None, None)
     t2 = time.time()
-    print nrecs, ndays, t2-t1
+    print (nrecs, ndays, t2-t1)
     
     import doctest
 

--- a/bin/weewx/reportengine.py
+++ b/bin/weewx/reportengine.py
@@ -145,14 +145,14 @@ class StdReportEngine(threading.Thread):
                     syslog.LOG_DEBUG,
                     "reportengine: Found configuration file %s for report %s" %
                     (skin_config_path, report))
-            except IOError, e:
+            except IOError as e:
                 syslog.syslog(
                     syslog.LOG_ERR, "reportengine: "
                     "Cannot read skin configuration file %s for report %s: %s"
                     % (skin_config_path, report, e))
                 syslog.syslog(syslog.LOG_ERR, "        ****  Report ignored")
                 continue
-            except SyntaxError, e:
+            except SyntaxError as e:
                 syslog.syslog(
                     syslog.LOG_ERR, "reportengine: "
                     "Failed to read skin configuration file %s for report %s: %s"
@@ -224,7 +224,7 @@ class StdReportEngine(threading.Thread):
                         self.first_run,
                         self.stn_info,
                         self.record)
-                except Exception, e:
+                except Exception as e:
                     syslog.syslog(
                         syslog.LOG_CRIT, "reportengine: "
                         "Unable to instantiate generator %s" % generator)
@@ -238,7 +238,7 @@ class StdReportEngine(threading.Thread):
                     # Call its start() method
                     obj.start()
 
-                except Exception, e:
+                except Exception as e:
                     # Caught unrecoverable error. Log it, continue on to the
                     # next generator.
                     syslog.syslog(
@@ -323,7 +323,7 @@ class FtpGenerator(ReportGenerator):
 
         try:
             n = ftp_data.run()
-        except (socket.timeout, socket.gaierror, ftplib.all_errors, IOError), e:
+        except (socket.timeout, socket.gaierror, ftplib.all_errors, IOError) as e:
             (cl, unused_ob, unused_tr) = sys.exc_info()
             syslog.syslog(syslog.LOG_ERR, "ftpgenerator: "
                           "Caught exception %s: %s" % (cl, e))
@@ -372,7 +372,7 @@ class RsyncGenerator(ReportGenerator):
 
         try:
             rsync_data.run()
-        except IOError, e:
+        except IOError as e:
             (cl, unused_ob, unused_tr) = sys.exc_info()
             syslog.syslog(syslog.LOG_ERR, "rsyncgenerator: "
                           "Caught exception %s: %s" % (cl, e))
@@ -553,7 +553,7 @@ class ReportTiming(object):
             # if we are this far then our line is valid so return True and no
             # error message
             return (True, None)
-        except ValueError, e:
+        except ValueError as e:
             # we picked up a ValueError in self.parse_field() so return False
             # and the error message
             return (False, e)

--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -297,7 +297,7 @@ class RESTThread(threading.Thread):
                 else:
                     _datadict['dayRain'] = None
 
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             syslog.syslog(syslog.LOG_DEBUG,
                           "restx: %s: Database OperationalError '%s'" %
                           (self.protocol_name, e))
@@ -352,13 +352,13 @@ class RESTThread(threading.Thread):
                                               "waiting %s minutes then retrying" %
                               (self.protocol_name, self.retry_login / 60.0))
                 time.sleep(self.retry_login)
-            except FailedPost, e:
+            except FailedPost as e:
                 if self.log_failure:
                     _time_str = timestamp_to_string(_record['dateTime'])
                     syslog.syslog(syslog.LOG_ERR,
                                   "restx: %s: Failed to publish record %s: %s"
                                   % (self.protocol_name, _time_str, e))
-            except Exception, e:
+            except Exception as e:
                 # Some unknown exception occurred. This is probably a serious
                 # problem. Exit.
                 syslog.syslog(syslog.LOG_CRIT,
@@ -442,7 +442,7 @@ class RESTThread(threading.Thread):
                 # Provide method for derived classes to behave otherwise if
                 # necessary.
                 self.handle_code(_response.code, _count + 1)
-            except (urllib2.URLError, socket.error, httplib.HTTPException), e:
+            except (urllib2.URLError, socket.error, httplib.HTTPException) as e:
                 # An exception was thrown. By default, log it and try again.
                 # Provide method for derived classes to behave otherwise if
                 # necessary.
@@ -942,7 +942,7 @@ class WOWThread(AmbientThread):
                 _response = urllib2.urlopen(request, timeout=self.timeout)
             except TypeError:
                 _response = urllib2.urlopen(request)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             # WOW signals a bad login with a HTML Error 400 or 403 code:
             if e.code == 400 or e.code == 403:
                 raise BadLogin(e)
@@ -1192,12 +1192,12 @@ class CWOPThread(RESTThread):
                         return
                     finally:
                         _sock.close()
-                except ConnectError, e:
+                except ConnectError as e:
                     syslog.syslog(
                         syslog.LOG_DEBUG,
                         "restx: %s: Attempt %d to %s:%d. Connection error: %s"
                         % (self.protocol_name, _count + 1, _server, _port, e))
-                except SendError, e:
+                except SendError as e:
                     syslog.syslog(
                         syslog.LOG_DEBUG,
                         "restx: %s: Attempt %d to %s:%d. Socket send error: %s"
@@ -1215,11 +1215,11 @@ class CWOPThread(RESTThread):
         try:
             _sock = socket.socket()
             _sock.connect((server, port))
-        except IOError, e:
+        except IOError as e:
             # Unsuccessful. Close it in case it was open:
             try:
                 _sock.close()
-            except AttributeError, socket.error:
+            except AttributeError(socket.error):
                 pass
             raise ConnectError(e)
 
@@ -1230,7 +1230,7 @@ class CWOPThread(RESTThread):
 
         try:
             sock.send(msg)
-        except IOError, e:
+        except IOError as e:
             # Unsuccessful. Log it and go around again for another try
             raise SendError("Packet %s; Error %s" % (dbg_msg, e))
         else:
@@ -1238,7 +1238,7 @@ class CWOPThread(RESTThread):
             try:
                 _resp = sock.recv(1024)
                 return _resp
-            except IOError, e:
+            except IOError as e:
                 syslog.syslog(
                     syslog.LOG_DEBUG,
                     "restx: %s: Exception %s (%s) when looking for response to %s packet" %
@@ -1729,7 +1729,7 @@ def get_site_dict(config_dict, service, *args):
         for option in args:
             if site_dict[option] == 'replace_me':
                 raise KeyError(option)
-    except KeyError, e:
+    except KeyError as e:
         syslog.syslog(syslog.LOG_DEBUG, "restx: %s: "
                                         "Data will not be posted: Missing option %s" %
                       (service, e))

--- a/bin/weewx/station.py
+++ b/bin/weewx/station.py
@@ -33,7 +33,7 @@ class StationInfo(object):
             altitude_t = weeutil.weeutil.option_as_list(stn_dict.get('altitude', (None, None)))
             try:
                 self.altitude_vt = weewx.units.ValueTuple(float(altitude_t[0]), altitude_t[1], "group_altitude")
-            except KeyError, e:
+            except KeyError as e:
                 raise weewx.ViolatedPrecondition("Value 'altitude' needs a unit (%s)" % e)
 
         if console and hasattr(console, 'hardware_name'):

--- a/bin/weewx/test/test_daily.py
+++ b/bin/weewx/test/test_daily.py
@@ -67,7 +67,7 @@ class Common(unittest.TestCase):
         try:
             test_html_dir = os.path.join(self.config_dict['WEEWX_ROOT'], self.config_dict['StdReport']['HTML_ROOT'])
             shutil.rmtree(test_html_dir)
-        except OSError, e:
+        except OSError as e:
             if os.path.exists(test_html_dir):
                 print >>sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
                 print >>sys.stderr, "Reason:", e

--- a/bin/weewx/test/test_templates.py
+++ b/bin/weewx/test/test_templates.py
@@ -89,7 +89,7 @@ class Common(unittest.TestCase):
         try:
             test_html_dir = os.path.join(self.config_dict['WEEWX_ROOT'], self.config_dict['StdReport']['HTML_ROOT'])
             shutil.rmtree(test_html_dir)
-        except OSError, e:
+        except OSError as e:
             if os.path.exists(test_html_dir):
                 print >> sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
                 print >> sys.stderr, "Reason:", e

--- a/bin/weewx/uwxutils.py
+++ b/bin/weewx/uwxutils.py
@@ -525,4 +525,4 @@ if __name__ == "__main__":
     import doctest
 
     if not doctest.testmod().failed:
-        print "PASSED"
+        print ("PASSED")

--- a/bin/weewx/wxmanager.py
+++ b/bin/weewx/wxmanager.py
@@ -61,7 +61,7 @@ class WXDaySummaryManager(weewx.manager.DaySummaryManager):
 
         # Only summation (total) or average heating or cooling degree days is supported:
         if aggregateType not in ['sum', 'avg']:
-            raise weewx.ViolatedPrecondition, "Aggregate type %s for %s not supported." % (aggregateType, obs_type)
+            raise weewx.ViolatedPrecondition("Aggregate type %s for %s not supported." % (aggregateType, obs_type))
 
         # Get the base for heating and cooling degree-days
         units_dict = option_dict['skin_dict'].get('Units', {})

--- a/bin/weewx/wxservices.py
+++ b/bin/weewx/wxservices.py
@@ -380,7 +380,7 @@ class WXCalculate(object):
             # The formula returns inches/hour. We need the total ET over the archive
             # interval, so multiply by the length of the archive interval in hours.
             data['ET'] = ET_rate * interval / 3600.0 if ET_rate is not None else None
-        except ValueError, e:
+        except ValueError as e:
             weeutil.weeutil.log_traceback()
             syslog.syslog(syslog.LOG_ERR, "wxservices: Calculation of evapotranspiration failed: %s" % e)
         except weedb.DatabaseError:

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -131,7 +131,7 @@ def main() :
     
     # get our config file
     config_fn, config_dict = weecfg.read_config(options.config, args)
-    print "Using configuration file %s." % config_fn
+    print ("Using configuration file %s." % config_fn)
     wlog.slog(syslog.LOG_INFO, "Using weewx configuration file %s." % config_fn)
 
     # Retrieve the station ID and password from the config file
@@ -146,15 +146,15 @@ def main() :
     
     # exit if any essential arguments are not present
     if not options.station or (not options.password and not options.simulate):
-        print "Missing argument(s).\n"
-        print parser.parse_args(["--help"])
+        print ("Missing argument(s).\n")
+        print (parser.parse_args(["--help"]))
         wlog.slog(syslog.LOG_ERR, "Missing argument(s). Wunderfixer exiting.")
         exit()
 
     # get our binding and database and say what we are using
     db_binding = options.binding
     database = config_dict['DataBindings'][db_binding]['database']
-    print "Using database binding '%s', which is bound to database '%s'" % (db_binding, database)
+    print ("Using database binding '%s', which is bound to database '%s'" % (db_binding, database))
     wlog.slog(syslog.LOG_INFO, "Using database binding '%s', which is bound to database '%s'" % (db_binding, database))
 
     # get the manager object for our db_binding
@@ -178,8 +178,8 @@ def main() :
     epsilon = options.epsilon
     
     if options.verbose:
-        print "Weather Underground Station:  ", options.station
-        print "Date to check:                ", date_date
+        print ("Weather Underground Station:  ", options.station)
+        print ("Date to check:                ", date_date)
         wlog.slog(syslog.LOG_INFO, "Checking Weather Underground station '%s' data for date %s" % (options.station, date_date))
 
 
@@ -187,7 +187,7 @@ def main() :
     archive_results = getArchiveDayTimeStamps(dbmanager_t, date_date)
 
     if options.verbose :
-        print "Number of archive records:    ", len(archive_results)
+        print ("Number of archive records:    ", len(archive_results))
 
     # Get a WunderStation object so we can interact with Weather Underground
     wunder = WunderStation(queue=None,  # Bogus queue. We will not be using it.
@@ -206,7 +206,7 @@ def main() :
         exit("Could not get Weather Underground data. Exiting.")
         
     if options.verbose :
-        print "Number of WU records:         ", len(wunder_results)
+        print ("Number of WU records:         ", len(wunder_results))
     wlog.slog(syslog.LOG_DEBUG, "Found %d archive records and %d WU records" % (len(archive_results), len(wunder_results)))
 
     #===========================================================================
@@ -227,9 +227,9 @@ def main() :
     missing_records = sorted([x for x in archive_results if not x in wunder_results])
     
     if options.verbose :
-        print "Number of missing records:    ", len(missing_records)
+        print ("Number of missing records:    ", len(missing_records))
         if missing_records:
-            print "\nMissing records:"
+            print ("\nMissing records:")
     wlog.slog(syslog.LOG_INFO, "%d Weather Underground records missing." % len(missing_records))
     
     no_published = 0
@@ -247,7 +247,7 @@ def main() :
         if options.query :
             _ans=input("...fix? (y/n/a/q):")
             if _ans == "q" :
-                print "Quitting."
+                print ("Quitting.")
                 wlog.slog(syslog.LOG_DEBUG, "... exiting")
                 exit()
             if _ans == "a" :
@@ -272,7 +272,7 @@ def main() :
                 exit("Failed post")
             except IOError, e:
                 print >>sys.stderr, " ... not published."
-                print "Reason: ", e
+                print ("Reason: ", e)
                 wlog.slog(syslog.LOG_ERR, "%s ...not published. Reason '%s'" % (timestamp_to_string(record['dateTime']), e))
                 if hasattr(e, 'reason'):
                     print >>sys.stderr, "Failed to reach server. Reason: %s" % e.reason
@@ -284,7 +284,7 @@ def main() :
                               (timestamp_to_string(record['dateTime']), e.code))
 
         else :
-            print " ... skipped."
+            print (" ... skipped.")
             wlog.slog(syslog.LOG_DEBUG, "%s ...skipped" % timestamp_to_string(record['dateTime']))
     wlog.slog(syslog.LOG_INFO, "%s out of %s missing records published to '%s' for date %s."
               " Wunderfixer exiting." % (no_published, len(missing_records), options.station, date_date))

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -245,7 +245,7 @@ def main() :
         # If this is an interactive session (option "-q") see if the
         # user wants to change it:
         if options.query :
-            _ans=raw_input("...fix? (y/n/a/q):")
+            _ans=input("...fix? (y/n/a/q):")
             if _ans == "q" :
                 print "Quitting."
                 wlog.slog(syslog.LOG_DEBUG, "... exiting")

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -261,16 +261,16 @@ def main() :
                 no_published += 1
                 print >>sys.stdout, " ...published."
                 wlog.slog(syslog.LOG_DEBUG, "%s ...published" % timestamp_to_string(record['dateTime']))
-            except weewx.restx.BadLogin, e:
+            except weewx.restx.BadLogin as e:
                 print >>sys.stderr, "Bad login"
                 print >>sys.stderr, e
                 exit("Bad login")                
-            except weewx.restx.FailedPost, e:
+            except weewx.restx.FailedPost as e:
                 print >>sys.stderr, e
                 print >>sys.stderr, "Aborted."
                 wlog.slog(syslog.LOG_ERR, "%s ...error %s. Aborting." % (timestamp_to_string(record['dateTime']), e))
                 exit("Failed post")
-            except IOError, e:
+            except IOError as e:
                 print >>sys.stderr, " ... not published."
                 print ("Reason: ", e)
                 wlog.slog(syslog.LOG_ERR, "%s ...not published. Reason '%s'" % (timestamp_to_string(record['dateTime']), e))
@@ -314,11 +314,11 @@ class WunderStation(weewx.restx.AmbientThread):
         try :
             # Hit the weather underground site:
             _wudata = urllib2.urlopen(_url)
-        except urllib2.URLError, e :
+        except urllib2.URLError as e :
             print >>sys.stderr, "Unable to open Weather Underground station " + self.station, " or ", e
             wlog.slog(syslog.LOG_ERR, "Unable to open Weather Underground station %s or %s" % (self.station, e))
             raise
-        except socket.timeout, e:
+        except socket.timeout as e:
             print >>sys.stderr, "Socket timeout for Weather Underground station " + self.station
             wlog.slog(syslog.LOG_ERR, "Socket timeout for Weather Underground station %s" % self.station)
             raise

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,7 +1,7 @@
 weewx change history
 --------------------
 
-3.8.0a3 10/xx/2017
+3.8.0 11/22/2017
 
 The `stats.py` example now works with heating and cooling degree days.
 Fixes issue #224.

--- a/examples/alarm.py
+++ b/examples/alarm.py
@@ -95,7 +95,7 @@ class MyAlarm(StdService):
             
             # If we got this far, it's ok to start intercepting events:
             self.bind(weewx.NEW_ARCHIVE_RECORD, self.newArchiveRecord)    # NOTE 1
-        except KeyError, e:
+        except KeyError as e:
             syslog.syslog(syslog.LOG_INFO, "alarm: No alarm set.  Missing parameter: %s" % e)
             
     def newArchiveRecord(self, event):
@@ -120,7 +120,7 @@ class MyAlarm(StdService):
                     t.start()
                     # Record when the message went out:
                     self.last_msg_ts = time.time()
-            except NameError, e:
+            except NameError as e:
                 # The record was missing a named variable. Write a debug message, then keep going
                 syslog.syslog(syslog.LOG_DEBUG, "alarm: %s" % e)
 
@@ -166,7 +166,7 @@ class MyAlarm(StdService):
             s.sendmail(msg['From'], self.TO,  msg.as_string())
             # Log out of the server:
             s.quit()
-        except Exception, e:
+        except Exception as e:
             syslog.syslog(syslog.LOG_ERR, "alarm: SMTP mailer refused message with error %s" % (e,))
             raise
         

--- a/examples/alarm.py
+++ b/examples/alarm.py
@@ -202,7 +202,7 @@ if __name__ == '__main__':
     try :
         config_dict = configobj.ConfigObj(config_path, file_error=True)
     except IOError:
-        print "Unable to open configuration file ", config_path
+        print ("Unable to open configuration file ", config_path)
         exit()
         
     if 'Alarm' not in config_dict:

--- a/examples/fileparse/bin/user/fileparse.py
+++ b/examples/fileparse/bin/user/fileparse.py
@@ -73,7 +73,7 @@ def _get_as_float(d, s):
     if s in d:
         try:
             v = float(d[s])
-        except ValueError, e:
+        except ValueError as e:
             logerr("cannot read value for '%s': %s" % (s, e))
     return v
 
@@ -106,7 +106,7 @@ class FileParseDriver(weewx.drivers.AbstractDevice):
                         name = line[:eq_index].strip()
                         value = line[eq_index + 1:].strip()
                         data[name] = value
-            except Exception, e:
+            except Exception as e:
                 logerr("read failed: %s" % e)
 
             # map the data into a weewx loop packet

--- a/examples/lowBattery.py
+++ b/examples/lowBattery.py
@@ -101,7 +101,7 @@ class BatteryAlarm(StdService):
             # If we got this far, it's ok to start intercepting events:
             self.bind(weewx.NEW_LOOP_PACKET,    self.newLoopPacket)
             self.bind(weewx.NEW_ARCHIVE_RECORD, self.newArchiveRecord)
-        except KeyError, e:
+        except KeyError as e:
             syslog.syslog(syslog.LOG_INFO, "lowBattery: No alarm set.  Missing parameter: %s" % e)
 
     def newLoopPacket(self, event):
@@ -201,7 +201,7 @@ Low battery indicators:
             s.sendmail(msg['From'], self.TO,  msg.as_string())
             # Log out of the server:
             s.quit()
-        except Exception, e:
+        except Exception as e:
             syslog.syslog(syslog.LOG_ERR,
                           "lowBattery: send email failed: %s" % (e,))
             raise

--- a/examples/pmon/bin/user/pmon.py
+++ b/examples/pmon/bin/user/pmon.py
@@ -139,7 +139,7 @@ class ProcessMonitor(StdService):
                     if m:
                         record['mem_vsz'] = int(m.group(1))
                         record['mem_rss'] = int(m.group(2))
-        except (ValueError, IOError, KeyError), e:
+        except (ValueError, IOError, KeyError) as e:
             logerr('apcups_info failed: %s' % e)
         return record
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class weewx_install_lib(install_lib):
         # Save any existing 'bin' subdirectory:
         if os.path.exists(self.install_dir):
             bin_savedir = weeutil.weeutil.move_with_timestamp(self.install_dir)
-            print "Saved bin subdirectory as %s" % bin_savedir
+            print ("Saved bin subdirectory as %s" % bin_savedir)
         else:
             bin_savedir = None
 
@@ -159,9 +159,9 @@ class weewx_install_data(install_data):
         # Open up and parse the distribution config file:
         try:        
             dist_config_dict = configobj.ConfigObj(f, file_error=True)
-        except IOError, e:
+        except IOError as e:
             sys.exit(str(e))
-        except SyntaxError, e:
+        except SyntaxError as e:
             sys.exit("Syntax error in distribution configuration file '%s': %s"
                      % (f, e))
 
@@ -173,7 +173,7 @@ class weewx_install_data(install_data):
             # Yes. Read it
             config_path, config_dict = weecfg.read_config(install_path, None)
             if DEBUG:
-                print "Old configuration file found at", config_path
+                print ("Old configuration file found at", config_path)
 
             # Update the old configuration file to the current version,
             # then merge it into the distribution file
@@ -189,7 +189,7 @@ class weewx_install_data(install_data):
                 stn_info['driver'] = driver
                 stn_info.update(weecfg.prompt_for_driver_settings(driver))
                 if DEBUG:
-                    print "Station info =", stn_info
+                    print ("Station info =", stn_info)
             weecfg.modify_config(config_dict, stn_info, DEBUG)
 
         # Set the WEEWX_ROOT
@@ -214,7 +214,7 @@ class weewx_install_data(install_data):
         # Save the old config file if it exists:
         if not self.dry_run and os.path.exists(install_path):
             backup_path = weeutil.weeutil.move_with_timestamp(install_path)
-            print "Saved old configuration file as %s" % backup_path
+            print ("Saved old configuration file as %s" % backup_path)
 
         # Now install the temporary file (holding the merged config data)
         # into the proper place:

--- a/weewx.conf
+++ b/weewx.conf
@@ -17,7 +17,7 @@ WEEWX_ROOT = /home/weewx
 socket_timeout = 20
 
 # Do not modify this. It is used when installing and updating weewx.
-version = 3.8.0a2
+version = 3.8.0
 
 ##############################################################################
 


### PR DESCRIPTION
(this is fyi only - do not merge)

This should be the aggregate differences from v3.8.0 - intent is to get the same version of the software to compile and run similarly.  Obviously catching up to master would be an adventure in itself, as that is a moving target.

Diffs from v3.8.0 can be viewed easier if you navigate to:
    https://github.com/weewx/weewx/compare/v3.8.0...vinceskahan:v3.8.0_python3

Changes in python syntax that I recall:

- print "whatever" statements need to be wrapped in parens
- exceptions ala "except NameHere, e" need to be "except NameHere as e"
- bare "print whatever" needs to be similarly wrapped in parens ala "print (whatever)"
- os.umask(0022) needs to have an integer specified.  I tried "os.umask(0o022)" which seems to do the same thing in minimal testing
- "import StringIO" needs to be "from io import StringIO"
- raw_input is now "input"
- datetime( ) calls with bare elements with leading zeroes don't compile (ie, 01 for 1), removing the leading zero seems to work ok

I'm opening issues on my forked branch at https://github.com/vinceskahan/weewx/issues to keep track of where I have found things already.

