### PR TITLE
update 'except' calls for python2+3 compatibility

### DIFF
--- a/bin/daemon.py
+++ b/bin/daemon.py
@@ -49,7 +49,7 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
     try:
         pid = os.fork()
         if pid > 0: sys.exit(0) # Exit first parent.
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #1 failed: (%d) %s\n" % (e.errno, e.strerror))
         sys.exit(1)
 
@@ -62,7 +62,7 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
     try:
         pid = os.fork()
         if pid > 0: sys.exit(0) # Exit second parent.
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror))
         sys.exit(1)
 

--- a/bin/wee_database
+++ b/bin/wee_database
@@ -201,7 +201,7 @@ def dropDaily(config_dict, db_binding):
                 with weewx.manager.open_manager_with_config(config_dict, db_binding) as dbmanager:
                     try:
                         dbmanager.drop_daily()
-                    except weedb.OperationalError, e:
+                    except weedb.OperationalError as e:
                         print "Got error '%s'\nPerhaps there was no daily summary?" % e
                     else:
                         tdiff = time.time() - t1
@@ -589,7 +589,7 @@ def _fix_wind(config_dict, db_binding, options):
     # perform the recalculation, wrap in a try..except to catch any db errors
     try:
         wind_obj.run()
-    except weedb.NoTableError, e:
+    except weedb.NoTableError as e:
         msg = "Maximum windSpeed Fix applied: no windSpeed found"
         syslog.syslog(syslog.LOG_INFO, msg)
         print msg

--- a/bin/wee_debug
+++ b/bin/wee_debug
@@ -230,10 +230,10 @@ def generateDebugInfo(config_dict, config_path, db_binding_wx, verbosity):
     # weewx archive info
     try:
         manager_info_dict = getManagerInfo(config_dict, db_binding_wx)
-    except weedb.CannotConnect, e:
+    except weedb.CannotConnect as e:
         print "Unable to connect to database:", e
         print
-    except weedb.OperationalError, e:
+    except weedb.OperationalError as e:
         print "Error hitting database. It may not be properly initialized:"
         print e
         print

--- a/bin/wee_device
+++ b/bin/wee_device
@@ -23,7 +23,7 @@ def main():
         # Find the device type
         device_type = config_dict['Station']['station_type']
         driver = config_dict[device_type]['driver']
-    except KeyError, e:
+    except KeyError as e:
         sys.exit("No configuration for device %s" % e)
 
     # Try to load the driver
@@ -38,11 +38,11 @@ def main():
             if hasattr(driver_module, 'DRIVER_VERSION') else '?'
         print 'Using %s driver version %s (%s)' % (
             driver_name, driver_vers, driver)
-    except AttributeError, e:
+    except AttributeError as e:
         msg = "The driver %s does not include a configuration tool" % driver
         syslog.syslog(syslog.LOG_INFO, "%s: %s" % (msg, e))
         exit(0)
-    except Exception, e:
+    except Exception as e:
         msg = "Cannot load configurator for %s" % device_type
         syslog.syslog(syslog.LOG_ERR, "%s: %s" % (msg, e))
         print msg

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -651,47 +651,47 @@ def main():
                                                               args,
                                                               wlog)
         source_obj.run()
-    except weeimport.weeimport.WeeImportOptionError, e:
+    except weeimport.weeimport.WeeImportOptionError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Command line option error.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportIOError, e:
+    except weeimport.weeimport.WeeImportIOError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load source file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportFieldError, e:
+    except weeimport.weeimport.WeeImportFieldError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to map source data.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except weeimport.weeimport.WeeImportMapError, e:
+    except weeimport.weeimport.WeeImportMapError as e:
         wlog.printlog(syslog.LOG_INFO,
                       "**** Unable to parse source-to-weewx field map.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature), e:
+    except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         print
         parser.print_help()
         exit(1)
-    except SystemExit, e:
+    except SystemExit as e:
         print e
         exit(0)
-    except (ValueError, weewx.UnitError), e:
+    except (ValueError, weewx.UnitError) as e:
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."
         wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
         exit(1)
-    except IOError, e:
+    except IOError as e:
         wlog.printlog(syslog.LOG_INFO, "**** Unable to load config file.")
         wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
         print "**** Nothing done, exiting."

--- a/bin/weecfg/__init__.py
+++ b/bin/weecfg/__init__.py
@@ -275,7 +275,7 @@ def modify_config(config_dict, stn_info, logger, debug=False):
             # Look up driver info:
             driver_editor, driver_name, driver_version = \
                 load_driver_editor(driver)
-        except Exception, e:
+        except Exception as e:
             sys.exit("Driver %s failed to load: %s" % (driver, e))
         stn_info['station_type'] = driver_name
         if debug:
@@ -997,14 +997,14 @@ def get_driver_infos(driver_pkg_name='weewx.drivers', excludes=['__init__.py']):
                     'driver_name': driver_module.DRIVER_NAME,
                     'version': driver_module_version,
                     'status': ''}
-        except ImportError, e:
+        except ImportError as e:
             # If the import fails, report it in the status
             driver_info_dict[driver_module_name] = {
                 'module_name': driver_module_name,
                 'driver_name': '?',
                 'version': '?',
                 'status': e}
-        except Exception, e:
+        except Exception as e:
             # Ignore anything else.  This might be a python file that is not
             # a driver, a python file with errors, or who knows what.
             pass
@@ -1277,7 +1277,7 @@ def mkdir_p(path):
     """equivalent to 'mkdir -p'"""
     try:
         os.makedirs(path)
-    except OSError, e:
+    except OSError as e:
         if e.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:

--- a/bin/weecfg/config.py
+++ b/bin/weecfg/config.py
@@ -67,9 +67,9 @@ class ConfigEngine(object):
             try:        
                 dist_config_dict = configobj.ConfigObj(options.dist_config,
                                                        file_error=True)
-            except IOError, e:
+            except IOError as e:
                 sys.exit("Unable to open distribution configuration file: %s" % e)
-            except SyntaxError, e:
+            except SyntaxError as e:
                 sys.exit("Syntax error in distribution configuration file '%s': %s" %
                          (options.dist_config, e))
 
@@ -81,9 +81,9 @@ class ConfigEngine(object):
             try:
                 config_path, config_dict = weecfg.read_config(
                     options.config_path, args)
-            except SyntaxError, e:
+            except SyntaxError as e:
                 sys.exit("Syntax error in configuration file: %s" % e)
-            except IOError, e:
+            except IOError as e:
                 sys.exit("Unable to open configuration file: %s" % e)
             self.logger.log("Using configuration file %s" % config_path)
 

--- a/bin/weecfg/database.py
+++ b/bin/weecfg/database.py
@@ -196,7 +196,7 @@ class WindSpeedRecalculation(DatabaseFix):
             self.do_fix()
         except weedb.NoTableError:
             raise
-        except weewx.ViolatedPrecondition, e:
+        except weewx.ViolatedPrecondition as e:
             syslog.syslog(syslog.LOG_ERR,
                           "maxwindspeed: %s not applied: %s" % (self.name, e))
             # raise the error so caller can deal with it if they want
@@ -447,7 +447,7 @@ class IntervalWeighting(DatabaseFix):
                     if not self.dry_run:
                         with weedb.Transaction(self.dbm.connection) as _cursor:
                             self.dbm._write_metadata('Version', '2.0', _cursor)
-                except weewx.ViolatedPrecondition, e:
+                except weewx.ViolatedPrecondition as e:
                     syslog.syslog(syslog.LOG_INFO,
                                   "intervalweighting: %s not applied: %s"
                                   % (self.name, e))
@@ -518,7 +518,7 @@ class IntervalWeighting(DatabaseFix):
                                     _day_accum[_day_key].xsum *= _weight
                                     _day_accum[_day_key].ysum *= _weight
                                     _day_accum[_day_key].dirsumtime *= _weight
-                        except Exception, e:
+                        except Exception as e:
                             # log the exception and re-raise it
                             syslog.syslog(syslog.LOG_INFO,
                                           "intervalweighting: Interval weighting of '%s' daily summary "

--- a/bin/weecfg/extension.py
+++ b/bin/weecfg/extension.py
@@ -419,7 +419,7 @@ class ExtensionEngine(object):
             if not self.dry_run:
                 os.remove(filename)
                 return 1
-        except OSError, e:
+        except OSError as e:
             if report_errors:
                 self.logger.log("Delete failed: %s" % e, level=4)
         return 0
@@ -439,7 +439,7 @@ class ExtensionEngine(object):
                 self.logger.log("Deleting directory %s" % directory, level=2)
                 if not self.dry_run:
                     shutil.rmtree(directory)
-        except OSError, e:
+        except OSError as e:
             if report_errors:
                 self.logger.log("Delete failed on directory '%s': %s" %
                                 (directory, e), level=2)

--- a/bin/weedb/mysql.py
+++ b/bin/weedb/mysql.py
@@ -38,7 +38,7 @@ def guard(fn):
     def guarded_fn(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except DatabaseError, e:
+        except DatabaseError as e:
             # Default exception is weedb.DatabaseError
             try:
                 errno = e[0]

--- a/bin/weedb/sqlite.py
+++ b/bin/weedb/sqlite.py
@@ -27,9 +27,9 @@ def guard(fn):
     def guarded_fn(*args, **kwargs):
         try:
             return fn(*args, **kwargs)
-        except sqlite3.IntegrityError, e:
+        except sqlite3.IntegrityError as e:
             raise weedb.IntegrityError(e)
-        except sqlite3.OperationalError, e:
+        except sqlite3.OperationalError as e:
             msg = str(e).lower()
             if msg.startswith("unable to open"):
                 raise weedb.PermissionError(e)
@@ -41,7 +41,7 @@ def guard(fn):
                 raise weedb.NoColumnError(e)
             else:
                 raise weedb.OperationalError(e)
-        except sqlite3.ProgrammingError, e:
+        except sqlite3.ProgrammingError as e:
             raise weedb.ProgrammingError(e)
 
     return guarded_fn
@@ -77,7 +77,7 @@ def drop(database_name='', SQLITE_ROOT='', driver='', **argv):  # @UnusedVariabl
     file_path = _get_filepath(SQLITE_ROOT, database_name, **argv)
     try:
         os.remove(file_path)
-    except OSError, e:
+    except OSError as e:
         errno = getattr(e, 'errno', 2)
         if errno == 13:
             raise weedb.PermissionError("No permission to drop database %s" % file_path)

--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -166,7 +166,7 @@ class Source(object):
                 altitude_vt = weewx.units.ValueTuple(float(altitude_t[0]),
                                                      altitude_t[1],
                                                      "group_altitude")
-            except KeyError, e:
+            except KeyError as e:
                 raise weewx.ViolatedPrecondition(
                     "Value 'altitude' needs a unit (%s)" % e)
             latitude_f = float(stn_dict['latitude'])

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -193,12 +193,12 @@ class WUSource(weeimport.Source):
         # hit the WU site, wrap in a try..except so we can catch any errors
         try:
             _wudata = urllib2.urlopen(_url)
-        except urllib2.URLError, e:
+        except urllib2.URLError as e:
             self.wlog.printlog(syslog.LOG_ERR,
                           "Unable to open Weather Underground station %s" % self.station_id)
             self.wlog.printlog(syslog.LOG_ERR, "   **** %s" % e)
             raise
-        except socket.timeout, e:
+        except socket.timeout as e:
             self.wlog.printlog(syslog.LOG_ERR,
                           "Socket timeout for Weather Underground station %s" % self.station_id)
             raise

--- a/bin/weeutil/ftpupload.py
+++ b/bin/weeutil/ftpupload.py
@@ -112,7 +112,7 @@ class FtpUpload(object):
                     else:
                         syslog.syslog(syslog.LOG_DEBUG, "ftpupload: Connected to %s" % self.server)
                     break
-                except ftplib.all_errors, e:
+                except ftplib.all_errors as e:
                     syslog.syslog(syslog.LOG_NOTICE, "ftpupload: Unable to connect or log into server : %s" % e)
             else:
                 # This is executed only if the loop terminates naturally (without a break statement),
@@ -153,7 +153,7 @@ class FtpUpload(object):
                             # Hence, the open is in the inner loop:
                             fd = open(full_local_path, "r")
                             ftp_server.storbinary(STOR_cmd, fd)
-                        except ftplib.all_errors, e:
+                        except ftplib.all_errors as e:
                             # Unsuccessful. Log it and go around again.
                             syslog.syslog(syslog.LOG_ERR, "ftpupload: Attempt #%d. Failed uploading %s to %s. Reason: %s" %
                                                           (count+1, full_remote_path, self.server, e))
@@ -221,7 +221,7 @@ class FtpUpload(object):
         for unused_count in range(self.max_tries):
             try:
                 ftp_server.mkd(remote_dir_path)
-            except ftplib.all_errors, e:
+            except ftplib.all_errors as e:
                 # Got an exception. It might be because the remote directory already exists:
                 if sys.exc_info()[0] is ftplib.error_perm:
                     msg =str(e).strip()

--- a/bin/weeutil/rsyncupload.py
+++ b/bin/weeutil/rsyncupload.py
@@ -94,7 +94,7 @@ class RsyncUpload(object):
         
             stdout = rsynccmd.communicate()[0]
             stroutput = stdout.encode("utf-8").strip()
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 syslog.syslog(syslog.LOG_ERR, "rsyncupload: rsync does not appear to be installed on this system. (errno %d, \"%s\")" % (e.errno, e.strerror))
             raise

--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -329,7 +329,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                 with open(tmpname, mode='w') as _file:
                     print >> _file, compiled_template
                 os.rename(tmpname, _fullname)
-            except Exception, e:
+            except Exception as e:
                 # We would like to get better feedback when there are cheetah
                 # compiler failures, but there seem to be no hooks for this.
                 # For example, if we could get make cheetah emit the source

--- a/bin/weewx/drivers/acurite.py
+++ b/bin/weewx/drivers/acurite.py
@@ -505,7 +505,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                             self.polling_interval)
                 logdbg("next read in %s seconds" % delay)
                 time.sleep(delay)
-            except (usb.USBError, weewx.WeeWxIOError), e:
+            except (usb.USBError, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to get LOOP data: %s" %
                        (ntries, self.max_tries, e))
                 time.sleep(self.retry_wait)
@@ -561,7 +561,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                 for i in range(17):
                     r3.append(station.read_R3())
                 self.last_r3 = time.time()
-            except usb.USBError, e:
+            except usb.USBError as e:
                 self.r3_fail_count += 1
                 logdbg("R3: read failed %d of %d: %s" %
                        (self.r3_fail_count, self.r3_max_fail, e))
@@ -627,13 +627,13 @@ class Station(object):
         # FIXME: is it necessary to set the configuration?
         try:
             self.handle.setConfiguration(dev.configurations[0])
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
         # attempt to claim the interface
         try:
             self.handle.claimInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             logcrt("Unable to claim USB interface %s: %s" % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -641,14 +641,14 @@ class Station(object):
         # FIXME: is it necessary to set the alt interface?
         try:
             self.handle.setAltInterface(interface)
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
     def close(self):
         if self.handle is not None:
             try:
                 self.handle.releaseInterface()
-            except (ValueError, usb.USBError), e:
+            except (ValueError, usb.USBError) as e:
                 logerr("release interface failed: %s" % e)
             self.handle = None
 
@@ -754,7 +754,7 @@ class Station(object):
                 try:
                     for b in r:
                         buf.append(int(b, 16))
-                except ValueError, e:
+                except ValueError as e:
                     logerr("R3: bad value in row %d: %s" % (i, _fmt_bytes(r)))
                     fail = True
             elif len(r) != 33:
@@ -1005,7 +1005,7 @@ if __name__ == '__main__':
                     for i in range(0, 17):
                         r3 = s.read_R3()
                         print tstr, _fmt_bytes(r3)
-                except usb.USBError, e:
+                except usb.USBError as e:
                     print tstr, e
                 delay = min(delay, 12*60)
             time.sleep(delay)

--- a/bin/weewx/drivers/cc3000.py
+++ b/bin/weewx/drivers/cc3000.py
@@ -476,7 +476,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
 
                 if self.polling_interval:
                     time.sleep(self.polling_interval)
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to get data: %s" %
                        (ntries, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -537,7 +537,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
         try:
             v = self.station.get_time()
             return _to_ts(v)
-        except ValueError, e:
+        except ValueError as e:
             logerr("getTime failed: %s" % e)
         return 0
 
@@ -549,7 +549,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
         for cnt in xrange(max_tries):
             try:
                 return CC3000Driver._init_station(station)
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to initialize station: %s" %
                        (cnt + 1, max_tries, e))
                 logdbg("Waiting %d seconds before retry" % retry_wait)
@@ -619,7 +619,7 @@ class CC3000Driver(weewx.drivers.AbstractDevice):
                     pkt[label] = _to_ts(v, fmt)
                 else:
                     pkt[label] = float(v)
-            except ValueError, e:
+            except ValueError as e:
                 logerr("parse failed for '%s' '%s': %s (idx=%s values=%s)" %
                        (header[i], v, e, i, values))
                 return dict()
@@ -681,7 +681,7 @@ def _check_crc(buf):
         b = int(cs, 16) # checksum provided in data
         if a != b:
             raise ChecksumMismatch(a, b, buf)
-    except ValueError, e:
+    except ValueError as e:
         raise BadCRC(a, cs, buf)
 
 # for some reason we sometimes get null characters randomly mixed in with the
@@ -1012,7 +1012,7 @@ class CC3000(object):
                 else:
                     logerr("unexpected response to DOWNLOAD: '%s'" % data)
                     need_cmd = True
-            except ChecksumError, e:
+            except ChecksumError as e:
                 logerr("download failed for record %s: %s" % (n, e))
 
 

--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -1014,7 +1014,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
             try:
                 ival = self.get_fixed_block(['read_period'])
                 break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 logcrt("get archive interval failed attempt %d of %d: %s"
                        % (i+1, self.max_tries, e))
         else:
@@ -1045,7 +1045,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
         # attempt to claim the interface
         try:
             self.devh.claimInterface(self.usb_interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.closePort()
             logcrt("Unable to claim USB interface %s: %s" %
                    (self.usb_interface, e))
@@ -1165,7 +1165,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                 else:
                     raise Exception("unknown polling mode '%s'" % self.polling_mode)
 
-            except (IndexError, usb.USBError, ObservationError), e:
+            except (IndexError, usb.USBError, ObservationError) as e:
                 logerr('get_observations failed: %s' % e)
                 nerr += 1
                 if nerr > self.max_tries:
@@ -1334,7 +1334,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                         dts -= datetime.timedelta(minutes=data['delay'])
                     ptr = self.dec_ptr(ptr)
                 return records
-            except (IndexError, usb.USBError, ObservationError), e:
+            except (IndexError, usb.USBError, ObservationError) as e:
                 logerr('get_records failed: %s' % e)
                 nerr += 1
                 if nerr > self.max_tries:

--- a/bin/weewx/drivers/te923.py
+++ b/bin/weewx/drivers/te923.py
@@ -1555,7 +1555,7 @@ class TE923Station(object):
         try:
             self.devh.claimInterface(interface)
             self.devh.setAltInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             logcrt("Unable to claim USB interface %s: %s" % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -1569,7 +1569,7 @@ class TE923Station(object):
     def close(self):
         try:
             self.devh.releaseInterface()
-        except (ValueError, usb.USBError), e:
+        except (ValueError, usb.USBError) as e:
             logerr("release interface failed: %s" % e)
         self.devh = None
 
@@ -1614,7 +1614,7 @@ class TE923Station(object):
                     rbuf.extend(buf[1:1 + nbytes])
                 if len(rbuf) >= 34:
                     break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 errmsg = repr(e)
                 if not ('No data available' in errmsg or 'No error' in errmsg):
                     raise
@@ -1704,7 +1704,7 @@ class TE923Station(object):
                     rbuf.extend(tmpbuf[1:1 + nbytes])
                 if len(rbuf) >= 1:
                     break
-            except usb.USBError, e:
+            except usb.USBError as e:
                 errmsg = repr(e)
                 if not ('No data available' in errmsg or 'No error' in errmsg):
                     raise
@@ -1733,7 +1733,7 @@ class TE923Station(object):
                 if DEBUG_READ:
                     logdbg("read: %s" % _fmt(buf))
                 return buf
-            except (BadRead, BadHeader, usb.USBError), e:
+            except (BadRead, BadHeader, usb.USBError) as e:
                 logerr("Failed attempt %d of %d to read data: %s" %
                        (cnt + 1, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -1749,7 +1749,7 @@ class TE923Station(object):
             try:
                 self._raw_write(addr, buf)
                 return
-            except (BadWrite, BadHeader, usb.USBError), e:
+            except (BadWrite, BadHeader, usb.USBError) as e:
                 logerr("Failed attempt %d of %d to write data: %s" %
                        (cnt + 1, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)

--- a/bin/weewx/drivers/ultimeter.py
+++ b/bin/weewx/drivers/ultimeter.py
@@ -193,7 +193,7 @@ class Station(object):
             logdbg("station time: day:%s min:%s (%s)" %
                    (d, m, timestamp_to_string(ts)))
             return ts
-        except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+        except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
             logerr("get_time failed: %s" % e)
         return int(time.time())
 
@@ -248,7 +248,7 @@ class Station(object):
                 buf = self.get_readings()
                 self.validate_string(buf)
                 return buf
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 loginf("Failed attempt %d of %d to get readings: %s" %
                        (ntries + 1, max_tries, e))
                 time.sleep(retry_wait)
@@ -323,7 +323,7 @@ class Station(object):
                     v -= (1 << bits)
             if multiplier is not None:
                 v *= multiplier
-        except ValueError, e:
+        except ValueError as e:
             if s != '----':
                 logdbg("decode failed for '%s': %s" % (s, e))
         return v

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -220,7 +220,7 @@ def guard_termios(fn):
         def guarded_fn(*args, **kwargs):
             try:
                 return fn(*args, **kwargs)
-            except termios.error, e:
+            except termios.error as e:
                 raise weewx.WeeWxIOError(e)
     except ImportError:
         def guarded_fn(*args, **kwargs):
@@ -253,7 +253,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             _buffer = self.serial_port.read(chars)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on read.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             syslog.syslog(syslog.LOG_ERR, "   ****  Is there a competing process running??")
@@ -268,7 +268,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             N = self.serial_port.write(data)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on write.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             # Reraise as a Weewx error I/O error:
@@ -315,7 +315,7 @@ class EthernetWrapper(BaseWrapper):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(self.timeout)
             self.socket.connect((self.host, self.port))
-        except (socket.error, socket.timeout, socket.herror), ex:
+        except (socket.error, socket.timeout, socket.herror) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: Socket error while opening port %d to ethernet host %s." % (self.port, self.host))
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -378,7 +378,7 @@ class EthernetWrapper(BaseWrapper):
             _N = min(4096, _remaining)
             try:
                 _recv = self.socket.recv(_N)
-            except (socket.timeout, socket.error), ex:
+            except (socket.timeout, socket.error) as ex:
                 syslog.syslog(syslog.LOG_ERR, "vantage: ip-read error: %s" % ex)
                 # Reraise as a weewx I/O error:
                 raise weewx.WeeWxIOError(ex)
@@ -397,7 +397,7 @@ class EthernetWrapper(BaseWrapper):
             # A delay of 0.0 gives socket write error; 0.01 gives no ack error; 0.05 is OK for weewx program
             # Note: a delay of 0.5 s is required for wee_device --logger=logger_info
             time.sleep(self.tcp_send_delay)
-        except (socket.timeout, socket.error), ex:
+        except (socket.timeout, socket.error) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: ip-write error: %s" % ex)
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -506,7 +506,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     # on the VP (somewhere around 220).
                     for _loop_packet in self.genDavisLoopPackets(200):
                         yield _loop_packet
-                except weewx.WeeWxIOError, e:
+                except weewx.WeeWxIOError as e:
                     syslog.syslog(syslog.LOG_ERR, "vantage: LOOP try #%d; error: %s" % (count + 1, e))
                     break
 
@@ -559,7 +559,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     yield _record
                 # The generator loop exited. We're done.
                 return
-            except weewx.WeeWxIOError, e:
+            except weewx.WeeWxIOError as e:
                 # Problem. Increment retry count
                 count += 1
                 syslog.syslog(syslog.LOG_ERR, "vantage: DMPAFT try #%d; error: %s" % (count, e))
@@ -2195,7 +2195,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setArchiveInterval(new_interval_minutes * 60)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new archive interval. Reason:\n\t****", e
                     else:
                         print "Archive interval now set to %d seconds." % (station.archive_interval,)
@@ -2218,7 +2218,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setLatitude(latitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new latitude. Reason:\n\t****", e
                 else:
                     print "Station latitude set to %.1f degree." % latitude_dg
@@ -2236,7 +2236,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setLongitude(longitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new longitude. Reason:\n\t****", e
                 else:
                     print "Station longitude set to %.1f degree." % longitude_dg
@@ -2322,7 +2322,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setWindCupType(new_wind_cup_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new wind cup type. Reason:\n\t****", e
                     else:
                         print "Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size)
@@ -2348,7 +2348,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setBucketType(new_bucket_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new bucket type. Reason:\n\t****", e
                     else:
                         print "Bucket type now set to %d." % (station.rain_bucket_type,)
@@ -2370,7 +2370,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setRainYearStart(rain_year_start)
-                    except StandardError, e:
+                    except StandardError as e:
                         print >> sys.stderr, "Unable to set new rain year start. Reason:\n\t****", e
                     else:
                         print "Rain year start now set to %d." % (station.rain_year_start,)
@@ -2403,7 +2403,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationWindDir(offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new wind offset. Reason:\n\t****", e
                         else:
                             print "Wind direction offset now set to %+d." % (offset)
@@ -2419,7 +2419,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationTemp(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new temperature offset. Reason:\n\t****", e
                         else:
                             print "Temperature offset %s now set to %+.1f." % (variable, offset)
@@ -2435,7 +2435,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationHumid(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print >> sys.stderr, "Unable to set new humidity offset. Reason:\n\t****", e
                         else:
                             print "Humidity offset %s now set to %+d." % (variable, offset)
@@ -2505,7 +2505,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setTransmitterType(channel, transmitter_type, extra_temp, extra_hum, repeater)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set transmitter type. Reason:\n\t****", e
                 else:
                     print "Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
@@ -2557,7 +2557,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setRetransmit(channel)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set retransmit. Reason:\n\t****", e
                 else:
                     if channel != 0:
@@ -2578,7 +2578,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setTempLogging(tempLogging)
-                except StandardError, e:
+                except StandardError as e:
                     print >> sys.stderr, "Unable to set new console temperature logging. Reason:\n\t****", e
                 else:
                     print "Console temperature logging set to '%s'." % (tempLogging.upper())
@@ -2664,7 +2664,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
     def logger_summary(station, dest_path):
         try:
             dest = open(dest_path, mode="w")
-        except IOError, e:
+        except IOError as e:
             print >> sys.stderr, "Unable to open destination '%s' for write" % dest_path
             print >> sys.stderr, "Reason: %s" % e
             return

--- a/bin/weewx/drivers/wmr100.py
+++ b/bin/weewx/drivers/wmr100.py
@@ -178,7 +178,7 @@ class WMR100(weewx.drivers.AbstractDevice):
             pass
         try:
             self.devh.claimInterface(self.interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.closePort()
             logerr("Unable to claim USB interface: %s" % e)
             raise weewx.WeeWxIOError(e)
@@ -246,7 +246,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                 # Compute its checksum. This can throw an exception if the packet is empty.
                 try:
                     computed_checksum = reduce(operator.iadd, buff[:-2])
-                except TypeError, e:
+                except TypeError as e:
                     logdbg("Exception while calculating checksum: %s" % e)
                 else:
                     actual_checksum = (buff[-1] << 8) + buff[-2]
@@ -288,7 +288,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                                  0x0000200,                                  # value
                                  0x0000000,                                  # index
                                  1000)                                       # timeout
-        except usb.USBError, e:
+        except usb.USBError as e:
             logerr("Unable to send USB control message: %s" % e)
             # Convert to a Weewx error:
             raise weewx.WakeupError(e)
@@ -306,7 +306,7 @@ class WMR100(weewx.drivers.AbstractDevice):
                 for i in range(1, report[0] + 1):
                     yield report[i]
                 nerrors = 0
-            except (IndexError, usb.USBError), e:
+            except (IndexError, usb.USBError) as e:
                 logdbg("Bad USB report received: %s" % e)
                 nerrors += 1
                 if nerrors > self.max_tries:

--- a/bin/weewx/drivers/wmr200.py
+++ b/bin/weewx/drivers/wmr200.py
@@ -197,11 +197,11 @@ class UsbDevice(object):
         A specific device must have been found."""
         try:
             self.handle = self.dev.open()
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt(('open_device() Unable to open USB interface.'
                     ' Reason: %s' % exception))
             raise weewx.WakeupError(exception)
-        except AttributeError, exception:
+        except AttributeError as exception:
             logcrt('open_device() Device not specified.')
             raise weewx.WakeupError(exception)
 
@@ -213,7 +213,7 @@ class UsbDevice(object):
 
         try:
             self.handle.claimInterface(self.interface)
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt(('open_device() Unable to'
                     ' claim USB interface. Reason: %s' % exception))
             raise weewx.WakeupError(exception)
@@ -227,7 +227,7 @@ class UsbDevice(object):
         not be cross platform."""
         try:
             self.handle.releaseInterface()
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             logcrt('close_device() Unable to'
                    ' release device interface. Reason: %s' % exception)
 
@@ -266,11 +266,11 @@ class UsbDevice(object):
                 logdbg('read_device(): %s' % buf)
             return report[1:report[0] + 1]
 
-        except IndexError, e:
+        except IndexError as e:
             # This indicates we failed an index range above.
             logerr('read_device() Failed the index rage %s: %s' % (report, e))
 
-        except usb.USBError, ex:
+        except usb.USBError as ex:
             # No data presented on the bus.  This is a normal part of
             # the process that indicates that the current live records
             # have been exhausted.  We have to send a heartbeat command
@@ -309,7 +309,7 @@ class UsbDevice(object):
                 value,                                # value
                 0x0000000,                            # index
                 _WMR200_USB_RESET_TIMEOUT)            # timeout
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = ('write_device() Unable to'
                    ' send USB control message %s' % exception)
             logerr(msg)
@@ -485,7 +485,7 @@ class Packet(object):
                    % len(self._pkt_data))
             raise WMR200ProtocolError(msg)
 
-        except (OverflowError, ValueError), exception:
+        except (OverflowError, ValueError) as exception:
             msg = ('Packet timestamp with bogus fields min:%d hr:%d day:%d'
                    ' m:%d y:%d %s' % (pkt_data[0], pkt_data[1],
                    pkt_data[2], pkt_data[3], pkt_data[4], exception))
@@ -1341,7 +1341,7 @@ class PollUsbDevice(threading.Thread):
             self._ok_to_read = True
             time.sleep(1)
 
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = ('reset_console() Unable to send USB control'
                    'message %s' % exception)
             logerr(msg)
@@ -1634,7 +1634,7 @@ class WMR200(weewx.drivers.AbstractDevice):
         buf = [0x01, cmd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         try:
             self.usb_device.write_device(buf)
-        except usb.USBError, exception:
+        except usb.USBError as exception:
             msg = (('_write_cmd() Unable to send USB cmd:0x%02x control'
                     ' message' % cmd))
             logerr(msg)
@@ -1752,7 +1752,7 @@ class WMR200(weewx.drivers.AbstractDevice):
             else:
                 logdbg(('  Acknowledged control packet'
                         ' rx:%d') % PacketControl.pkt_rx)
-        except WMR200PacketParsingError, e:
+        except WMR200PacketParsingError as e:
             # Drop any bogus packets.
             logerr(self._pkt.to_string_raw('Discarding bogus packet: %s ' 
                    % e.msg))

--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -1034,7 +1034,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                 if DEBUG_COMM:
                     loginf("initialization completed in %s tries" % cnt)
                 return pkt
-            except ProtocolError, e:
+            except ProtocolError as e:
                 if DEBUG_COMM:
                     loginf("init_comm: failed attempt %d of %d: %s" %
                            (cnt, max_tries, e))
@@ -1104,7 +1104,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                     loginf("init history completed after attempt %d of %d" %
                            (cnt, max_tries))
                 return                
-            except ProtocolError, e:
+            except ProtocolError as e:
                 if DEBUG_HISTORY:
                     loginf("init_history: failed attempt %d of %d: %s" %
                            (cnt, max_tries, e))
@@ -1135,7 +1135,7 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                     loginf("init history completed after attempt %d of %d" %
                            (cnt, max_tries))
                 return
-            except ProtocolError, e:
+            except ProtocolError as e:
                 if DEBUG_HISTORY:
                     loginf("fini history failed attempt %d of %d: %s" %
                            (cnt, max_tries, e))
@@ -1228,9 +1228,9 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                     break
                 if buf and DEBUG_HISTORY:
                     loginf("get history in progress: %s" % msg)
-            except usb.USBError, e:
+            except usb.USBError as e:
                 raise weewx.WeeWxIOError(e)
-            except DecodeError, e:
+            except DecodeError as e:
                 loginf("genLoopPackets: %s" % e)
             time.sleep(0.001)        
         self.finish_history()
@@ -1266,9 +1266,9 @@ class WMR300Driver(weewx.drivers.AbstractDevice):
                         # if the logger usage exceeds the limit, clear it
                         self.dump_history()
                         self.latest_index = None
-            except usb.USBError, e:
+            except usb.USBError as e:
                 raise weewx.WeeWxIOError(e)
-            except (DecodeError, ProtocolError), e:
+            except (DecodeError, ProtocolError) as e:
                 loginf("genLoopPackets: %s" % e)
             time.sleep(0.001)
 
@@ -1417,7 +1417,7 @@ class Station(object):
         # attempt to claim the interface
         try:
             self.handle.claimInterface(self.interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             raise WMR300Error("Unable to claim interface %s: %s" %
                               (self.interface, e))
@@ -1426,7 +1426,7 @@ class Station(object):
         if self.handle is not None:
             try:
                 self.handle.releaseInterface()
-            except (ValueError, usb.USBError), e:
+            except (ValueError, usb.USBError) as e:
                 logdbg("Release interface failed: %s" % e)
             self.handle = None
 
@@ -1447,7 +1447,7 @@ class Station(object):
     def read(self, count=True, timeout=None, ignore_non_errors=True, ignore_timeouts=True):
         try:
             return self._read(count, timeout)
-        except usb.USBError, e:
+        except usb.USBError as e:
             if DEBUG_COMM:
                 loginf("read: e.errno=%s e.strerror=%s e.message=%s repr=%s" %
                        (e.errno, e.strerror, e.message, repr(e)))
@@ -1471,7 +1471,7 @@ class Station(object):
     def write(self, buf, ignore_non_errors=True, ignore_timeouts=True):
         try:
             return self._write(buf)
-        except usb.USBError, e:
+        except usb.USBError as e:
             if ignore_timeouts and is_timeout(e):
                 return 0
             if ignore_non_errors and is_noerr(e):
@@ -1541,7 +1541,7 @@ class Station(object):
             if cs1 != cs2:
                 raise BadChecksum("%s: bad checksum: %04x != %04x" %
                                   (label, cs1, cs2))
-        except IndexError, e:
+        except IndexError as e:
             raise BadChecksum("%s: not enough bytes for checksum: %s" %
                               (label, e))
 
@@ -1572,7 +1572,7 @@ class Station(object):
             return time.mktime((year, month, day, hour, minute, 0, -1, -1, -1))
         except IndexError:
             raise BadTimestamp("buffer too short for timestamp")
-        except (OverflowError, ValueError), e:
+        except (OverflowError, ValueError) as e:
             raise BadTimestamp(
                 "cannot create timestamp from y:%s m:%s d:%s H:%s M:%s: %s" %
                 (buf[0], buf[1], buf[2], buf[3], buf[4], e))
@@ -1640,7 +1640,7 @@ class Station(object):
             if DEBUG_DECODE:
                 loginf('decode: %s %s' % (_fmt_bytes(buf), pkt))
             return pkt
-        except IndexError, e:
+        except IndexError as e:
             raise BadBuffer("cannot decode buffer: %s" % e)
         except AttributeError:
             raise UnknownPacketType("unknown packet type %02x: %s" %

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -207,7 +207,7 @@ class StationData(object):
                     v -= (1 << bits)
             if multiplier is not None:
                 v *= multiplier
-        except ValueError, e:
+        except ValueError as e:
             if s != '----':
                 logdbg("decode failed for '%s': %s" % (s, e))
         return v
@@ -261,7 +261,7 @@ class StationSerial(object):
                 buf = self.get_readings()
                 StationData.validate_string(buf)
                 return buf
-            except (serial.serialutil.SerialException, weewx.WeeWxIOError), e:
+            except (serial.serialutil.SerialException, weewx.WeeWxIOError) as e:
                 loginf("Failed attempt %d of %d to get readings: %s" %
                        (ntries + 1, max_tries, e))
                 time.sleep(wait_before_retry)
@@ -304,7 +304,7 @@ class StationSocket(object):
             elif protocol == 'udp':
                 self.net_socket = socket.socket(
                     socket.AF_INET, socket.SOCK_DGRAM)
-        except (socket.error, socket.herror), ex:
+        except (socket.error, socket.herror) as ex:
             logerr("Cannot create socket for some reason: %s" % ex)
             raise weewx.WeeWxIOError(ex)
 
@@ -322,7 +322,7 @@ class StationSocket(object):
                     logdbg("Retrying connection...")
                 self.net_socket.connect(self.conn_info)
                 break
-            except (socket.error, socket.timeout, socket.herror), ex:
+            except (socket.error, socket.timeout, socket.herror) as ex:
                 logerr("Cannot connect to %s:%d for some reason: %s. "
                        "%d tries left." % (
                            self.conn_info[0], self.conn_info[1], ex,
@@ -341,7 +341,7 @@ class StationSocket(object):
                (self.conn_info[0], self.conn_info[1]))
         try:
             self.net_socket.close()
-        except (socket.error, socket.herror, socket.timeout), ex:
+        except (socket.error, socket.herror, socket.timeout) as ex:
             logerr("Cannot close connection to %s:%d. Reason: %s" % (
                 self.conn_info[0], self.conn_info[1], ex))
             raise weewx.WeeWxIOError(ex)
@@ -356,7 +356,7 @@ class StationSocket(object):
             while True:
                 try:
                     buf += self.net_socket.recv(8, socket.MSG_WAITALL)
-                except (socket.error, socket.timeout), ex:
+                except (socket.error, socket.timeout) as ex:
                     raise weewx.WeeWxIOError(ex)
                 if DEBUG_READ >= 1:
                     logdbg("(searching...) buf: %s" % buf)
@@ -373,13 +373,13 @@ class StationSocket(object):
             try:
                 buf += self.net_socket.recv(
                     PACKET_SIZE - len(buf), socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
         else:
             # Keep receiving data until we find an exclamation point or two
             try:
                 buf = self.net_socket.recv(2, socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
             while True:
                 if buf == '\r\n':
@@ -398,7 +398,7 @@ class StationSocket(object):
                 else:
                     try:
                         buf = self.net_socket.recv(2, socket.MSG_WAITALL)
-                    except (socket.error, socket.timeout), ex:
+                    except (socket.error, socket.timeout) as ex:
                         raise weewx.WeeWxIOError(ex)
                     if DEBUG_READ >= 2:
                             logdbg("buf: %s" % ' '.join(
@@ -406,7 +406,7 @@ class StationSocket(object):
             try:
                 buf += self.net_socket.recv(
                     PACKET_SIZE - len(buf), socket.MSG_WAITALL)
-            except (socket.error, socket.timeout), ex:
+            except (socket.error, socket.timeout) as ex:
                 raise weewx.WeeWxIOError(ex)
         if DEBUG_READ >= 2:
             logdbg("buf: %s" % buf)
@@ -421,7 +421,7 @@ class StationSocket(object):
                 buf = self.get_readings()
                 StationData.validate_string(buf)
                 return buf
-            except (weewx.WeeWxIOError), e:
+            except (weewx.WeeWxIOError) as e:
                 logdbg("Failed to get data. Reason: %s" % e)
                 self.rec_start = False
 

--- a/bin/weewx/drivers/ws23xx.py
+++ b/bin/weewx/drivers/ws23xx.py
@@ -491,7 +491,7 @@ class WS23xxDriver(weewx.drivers.AbstractDevice):
                                (conn_info[1], conn_info[0]))
                         self._poll_wait = conn_info[1]
                 time.sleep(self._poll_wait)
-            except Ws2300.Ws2300Exception, e:
+            except Ws2300.Ws2300Exception as e:
                 logerr("Failed attempt %d of %d to get LOOP data: %s" %
                        (ntries, self.max_tries, e))
                 logdbg("Waiting %d seconds before retry" % self.retry_wait)
@@ -901,7 +901,7 @@ class LinuxSerialPort(SerialPort):
         #
         try:
             self.serial_port = os.open(self.device, os.O_RDWR)
-        except EnvironmentError, e:
+        except EnvironmentError as e:
             raise FatalError(self.device, "can't open tty device - %s." % str(e))
         try:
             fcntl.flock(self.serial_port, fcntl.LOCK_EX)

--- a/bin/weewx/drivers/ws28xx.py
+++ b/bin/weewx/drivers/ws28xx.py
@@ -3140,7 +3140,7 @@ class sHID(object):
             logdbg('claiming USB interface %d' % interface)
             self.devh.claimInterface(interface)
             self.devh.setAltInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self._close_device()
             logcrt('Unable to claim USB interface %s: %s' % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -4110,7 +4110,7 @@ class CCommunicationService(object):
             logdbg('starting rf communication')
             while self.running:
                 self.doRFCommunication()
-        except Exception, e:
+        except Exception as e:
             logerr('exception in doRF: %s' % e)
             log_traceback(dst=syslog.LOG_INFO)
             self.running = False
@@ -4155,9 +4155,9 @@ class CCommunicationService(object):
         try:
             self.generateResponse(FrameBuffer, DataLength)
             self.shid.setFrame(FrameBuffer[0], DataLength[0])
-        except BadResponse, e:
+        except BadResponse as e:
             logerr('generateResponse failed: %s' % e)
-        except DataWritten, e:
+        except DataWritten as e:
             logdbg('SetTime/SetConfig data written')
         self.shid.setTX()
 

--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -104,7 +104,7 @@ class StdEngine(object):
             loader_function = getattr(driver_module, 'loader')
             # Call it with the configuration dictionary as the only argument:
             self.console = loader_function(config_dict, self)
-        except Exception, ex:
+        except Exception as ex:
             syslog.syslog(syslog.LOG_ERR,
                           "import of driver failed: %s (%s)" % (ex, type(ex)))
             # Signal that we have an initialization error:
@@ -374,9 +374,9 @@ class StdCalibrate(StdService):
             if obs_type == 'foo': continue
             try:
                 event.packet[obs_type] = eval(self.corrections[obs_type], None, event.packet)
-            except (TypeError, NameError), e:
+            except (TypeError, NameError) as e:
                 pass
-            except ValueError, e:
+            except ValueError as e:
                 syslog.syslog(syslog.LOG_ERR, "engine: StdCalibration loop error %s" % e)
 
     def new_archive_record(self, event):
@@ -388,9 +388,9 @@ class StdCalibrate(StdService):
                 if obs_type == 'foo': continue
                 try:
                     event.record[obs_type] = eval(self.corrections[obs_type], None, event.record)
-                except (TypeError, NameError), e:
+                except (TypeError, NameError) as e:
                     pass
-                except ValueError, e:
+                except ValueError as e:
                     syslog.syslog(syslog.LOG_ERR, "engine: StdCalibration archive error %s" % e)
 
 #==============================================================================
@@ -620,7 +620,7 @@ class StdArchive(StdService):
                 self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
                                                       record=record,
                                                       origin='hardware'))
-        except weewx.HardwareError, e:
+        except weewx.HardwareError as e:
             syslog.syslog(syslog.LOG_ERR, "engine: Internal error detected. Catchup abandoned")
             syslog.syslog(syslog.LOG_ERR, "**** %s" % e)
         
@@ -872,7 +872,7 @@ def main(options, args, engine_class=StdEngine):
             syslog.syslog(syslog.LOG_CRIT, "engine: Unexpected exit from main loop. Program exiting.")
     
         # Catch any console initialization error:
-        except InitializationError, e:
+        except InitializationError as e:
             # Log it:
             syslog.syslog(syslog.LOG_CRIT, "engine: Unable to load driver: %s" % e)
             # See if we should loop, waiting for the console to be ready.
@@ -886,7 +886,7 @@ def main(options, args, engine_class=StdEngine):
                 sys.exit(weewx.IO_ERROR)
 
         # Catch any recoverable weewx I/O errors:
-        except weewx.WeeWxIOError, e:
+        except weewx.WeeWxIOError as e:
             # Caught an I/O error. Log it, wait 60 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught WeeWxIOError: %s" % e)
             if options.exit:
@@ -896,7 +896,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(60)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             # Caught a database error. Log it, wait 120 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Database OperationalError exception: %s" % e)
             if options.exit:
@@ -906,7 +906,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(120)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except weedb.CannotConnect, e:
+        except weedb.CannotConnect as e:
             # Unable to connect to the database server. Log it, wait 120 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Database CannotConnect exception: %s" % e)
             if options.exit:
@@ -916,7 +916,7 @@ def main(options, args, engine_class=StdEngine):
             time.sleep(120)
             syslog.syslog(syslog.LOG_NOTICE, "engine: retrying...")
             
-        except OSError, e:
+        except OSError as e:
             # Caught an OS error. Log it, wait 10 seconds, then try again
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught OSError: %s" % e)
             weeutil.weeutil.log_traceback("    ****  ", syslog.LOG_DEBUG)
@@ -940,7 +940,7 @@ def main(options, args, engine_class=StdEngine):
             raise
     
         # Catch any non-recoverable errors. Log them, exit
-        except Exception, ex:
+        except Exception as ex:
             # Caught unrecoverable error. Log it, exit
             syslog.syslog(syslog.LOG_CRIT, "engine: Caught unrecoverable exception in engine:")
             syslog.syslog(syslog.LOG_CRIT, "    ****  %s" % ex)
@@ -961,7 +961,7 @@ def getConfiguration(config_path):
         syslog.syslog(syslog.LOG_CRIT, "engine: Unable to open configuration file %s" % config_path)
         # Reraise the exception (this should cause the program to exit)
         raise
-    except configobj.ConfigObjError, e:
+    except configobj.ConfigObjError as e:
         syslog.syslog(syslog.LOG_CRIT, "engine: Error while parsing configuration file %s" % config_path)
         syslog.syslog(syslog.LOG_CRIT, "****    Reason: '%s'" % e)
         raise

--- a/bin/weewx/imagegenerator.py
+++ b/bin/weewx/imagegenerator.py
@@ -250,7 +250,7 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
                     # Now save the image
                     image.save(img_file)
                     ngen += 1
-                except IOError, e:
+                except IOError as e:
                     syslog.syslog(syslog.LOG_CRIT, "imagegenerator: Unable to save to file '%s' %s:" % (img_file, e))
         t2 = time.time()
 

--- a/bin/weewx/manager.py
+++ b/bin/weewx/manager.py
@@ -176,7 +176,7 @@ class Manager(object):
         try:
             with weedb.Transaction(self.connection) as _cursor:
                 _cursor.execute("CREATE TABLE %s (%s);" % (self.table_name, _sqltypestr, ))
-        except weedb.DatabaseError, e:
+        except weedb.DatabaseError as e:
             syslog.syslog(syslog.LOG_ERR, "manager: "
                           "Unable to create table '%s' in database '%s': %s" % 
                           (self.table_name, self.database_name, e))
@@ -246,7 +246,7 @@ class Manager(object):
 
                     min_ts = min(min_ts, record['dateTime']) if min_ts is not None else record['dateTime']
                     max_ts = max(max_ts, record['dateTime'])
-                except (weedb.IntegrityError, weedb.OperationalError), e:
+                except (weedb.IntegrityError, weedb.OperationalError) as e:
                     syslog.syslog(syslog.LOG_ERR, "manager: "
                                   "Unable to add record %s to database '%s': %s" %
                                   (weeutil.weeutil.timestamp_to_string(record['dateTime']), 
@@ -919,7 +919,7 @@ def get_database_dict_from_config(config_dict, database):
     """
     try:
         database_dict = dict(config_dict['Databases'][database])
-    except KeyError, e:
+    except KeyError as e:
         raise weewx.UnknownDatabase("Unknown database '%s'" % e)
     
     # See if a 'database_type' is specified. This is something
@@ -957,7 +957,7 @@ def get_manager_dict_from_config(config_dict, data_binding,
     # will be adding to it):
     try:
         manager_dict = dict(config_dict['DataBindings'][data_binding])
-    except KeyError, e:
+    except KeyError as e:
         raise weewx.UnknownBinding("Unknown data binding '%s'" % e)
 
     # If anything is missing, substitute from the default dictionary:
@@ -969,7 +969,7 @@ def get_manager_dict_from_config(config_dict, data_binding,
             database = manager_dict.pop('database')
             manager_dict['database_dict'] = get_database_dict_from_config(config_dict,
                                                                           database)
-        except KeyError, e:
+        except KeyError as e:
             raise weewx.UnknownDatabase("Unknown database '%s'" % e)
         
     # The schema may be specified as a string, in which case we resolve the
@@ -1547,7 +1547,7 @@ class DaySummaryManager(Manager):
             # be prepared to catch an exception:
             try:
                 cursor.execute(_sql_replace_str, _write_tuple)
-            except weedb.OperationalError, e:
+            except weedb.OperationalError as e:
                 syslog.syslog(syslog.LOG_ERR, "manager: "
                               "Replace failed for database %s: %s"
                               % (self.database_name, e))
@@ -1598,7 +1598,7 @@ class DaySummaryManager(Manager):
                         _cursor.execute("DROP TABLE %s" % _table_name)
 
             del self.daykeys
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             syslog.syslog(syslog.LOG_ERR, "manager: "
                           "Drop summaries failed for database '%s': %s"
                           % (self.connection.database_name, e))

--- a/bin/weewx/reportengine.py
+++ b/bin/weewx/reportengine.py
@@ -145,14 +145,14 @@ class StdReportEngine(threading.Thread):
                     syslog.LOG_DEBUG,
                     "reportengine: Found configuration file %s for report %s" %
                     (skin_config_path, report))
-            except IOError, e:
+            except IOError as e:
                 syslog.syslog(
                     syslog.LOG_ERR, "reportengine: "
                     "Cannot read skin configuration file %s for report %s: %s"
                     % (skin_config_path, report, e))
                 syslog.syslog(syslog.LOG_ERR, "        ****  Report ignored")
                 continue
-            except SyntaxError, e:
+            except SyntaxError as e:
                 syslog.syslog(
                     syslog.LOG_ERR, "reportengine: "
                     "Failed to read skin configuration file %s for report %s: %s"
@@ -224,7 +224,7 @@ class StdReportEngine(threading.Thread):
                         self.first_run,
                         self.stn_info,
                         self.record)
-                except Exception, e:
+                except Exception as e:
                     syslog.syslog(
                         syslog.LOG_CRIT, "reportengine: "
                         "Unable to instantiate generator %s" % generator)
@@ -238,7 +238,7 @@ class StdReportEngine(threading.Thread):
                     # Call its start() method
                     obj.start()
 
-                except Exception, e:
+                except Exception as e:
                     # Caught unrecoverable error. Log it, continue on to the
                     # next generator.
                     syslog.syslog(
@@ -323,7 +323,7 @@ class FtpGenerator(ReportGenerator):
 
         try:
             n = ftp_data.run()
-        except (socket.timeout, socket.gaierror, ftplib.all_errors, IOError), e:
+        except (socket.timeout, socket.gaierror, ftplib.all_errors, IOError) as e:
             (cl, unused_ob, unused_tr) = sys.exc_info()
             syslog.syslog(syslog.LOG_ERR, "ftpgenerator: "
                           "Caught exception %s: %s" % (cl, e))
@@ -372,7 +372,7 @@ class RsyncGenerator(ReportGenerator):
 
         try:
             rsync_data.run()
-        except IOError, e:
+        except IOError as e:
             (cl, unused_ob, unused_tr) = sys.exc_info()
             syslog.syslog(syslog.LOG_ERR, "rsyncgenerator: "
                           "Caught exception %s: %s" % (cl, e))
@@ -553,7 +553,7 @@ class ReportTiming(object):
             # if we are this far then our line is valid so return True and no
             # error message
             return (True, None)
-        except ValueError, e:
+        except ValueError as e:
             # we picked up a ValueError in self.parse_field() so return False
             # and the error message
             return (False, e)

--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -297,7 +297,7 @@ class RESTThread(threading.Thread):
                 else:
                     _datadict['dayRain'] = None
 
-        except weedb.OperationalError, e:
+        except weedb.OperationalError as e:
             syslog.syslog(syslog.LOG_DEBUG,
                           "restx: %s: Database OperationalError '%s'" %
                           (self.protocol_name, e))
@@ -352,13 +352,13 @@ class RESTThread(threading.Thread):
                                               "waiting %s minutes then retrying" %
                               (self.protocol_name, self.retry_login / 60.0))
                 time.sleep(self.retry_login)
-            except FailedPost, e:
+            except FailedPost as e:
                 if self.log_failure:
                     _time_str = timestamp_to_string(_record['dateTime'])
                     syslog.syslog(syslog.LOG_ERR,
                                   "restx: %s: Failed to publish record %s: %s"
                                   % (self.protocol_name, _time_str, e))
-            except Exception, e:
+            except Exception as e:
                 # Some unknown exception occurred. This is probably a serious
                 # problem. Exit.
                 syslog.syslog(syslog.LOG_CRIT,
@@ -442,7 +442,7 @@ class RESTThread(threading.Thread):
                 # Provide method for derived classes to behave otherwise if
                 # necessary.
                 self.handle_code(_response.code, _count + 1)
-            except (urllib2.URLError, socket.error, httplib.HTTPException), e:
+            except (urllib2.URLError, socket.error, httplib.HTTPException) as e:
                 # An exception was thrown. By default, log it and try again.
                 # Provide method for derived classes to behave otherwise if
                 # necessary.
@@ -976,7 +976,7 @@ class WOWThread(AmbientThread):
                 _response = urllib2.urlopen(request, timeout=self.timeout)
             except TypeError:
                 _response = urllib2.urlopen(request)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             # WOW signals a bad login with a HTML Error 400 or 403 code:
             if e.code == 400 or e.code == 403:
                 raise BadLogin(e)
@@ -1226,12 +1226,12 @@ class CWOPThread(RESTThread):
                         return
                     finally:
                         _sock.close()
-                except ConnectError, e:
+                except ConnectError as e:
                     syslog.syslog(
                         syslog.LOG_DEBUG,
                         "restx: %s: Attempt %d to %s:%d. Connection error: %s"
                         % (self.protocol_name, _count + 1, _server, _port, e))
-                except SendError, e:
+                except SendError as e:
                     syslog.syslog(
                         syslog.LOG_DEBUG,
                         "restx: %s: Attempt %d to %s:%d. Socket send error: %s"
@@ -1249,11 +1249,12 @@ class CWOPThread(RESTThread):
         try:
             _sock = socket.socket()
             _sock.connect((server, port))
-        except IOError, e:
+        except IOError as e:
             # Unsuccessful. Close it in case it was open:
             try:
                 _sock.close()
-            except AttributeError, socket.error:
+            except AttributeError as xxx_todo_changeme:
+                socket.error = xxx_todo_changeme
                 pass
             raise ConnectError(e)
 
@@ -1264,7 +1265,7 @@ class CWOPThread(RESTThread):
 
         try:
             sock.send(msg)
-        except IOError, e:
+        except IOError as e:
             # Unsuccessful. Log it and go around again for another try
             raise SendError("Packet %s; Error %s" % (dbg_msg, e))
         else:
@@ -1272,7 +1273,7 @@ class CWOPThread(RESTThread):
             try:
                 _resp = sock.recv(1024)
                 return _resp
-            except IOError, e:
+            except IOError as e:
                 syslog.syslog(
                     syslog.LOG_DEBUG,
                     "restx: %s: Exception %s (%s) when looking for response to %s packet" %
@@ -1763,7 +1764,7 @@ def get_site_dict(config_dict, service, *args):
         for option in args:
             if site_dict[option] == 'replace_me':
                 raise KeyError(option)
-    except KeyError, e:
+    except KeyError as e:
         syslog.syslog(syslog.LOG_DEBUG, "restx: %s: "
                                         "Data will not be posted: Missing option %s" %
                       (service, e))

--- a/bin/weewx/station.py
+++ b/bin/weewx/station.py
@@ -33,7 +33,7 @@ class StationInfo(object):
             altitude_t = weeutil.weeutil.option_as_list(stn_dict.get('altitude', (None, None)))
             try:
                 self.altitude_vt = weewx.units.ValueTuple(float(altitude_t[0]), altitude_t[1], "group_altitude")
-            except KeyError, e:
+            except KeyError as e:
                 raise weewx.ViolatedPrecondition("Value 'altitude' needs a unit (%s)" % e)
 
         if console and hasattr(console, 'hardware_name'):

--- a/bin/weewx/test/test_daily.py
+++ b/bin/weewx/test/test_daily.py
@@ -67,7 +67,7 @@ class Common(unittest.TestCase):
         try:
             test_html_dir = os.path.join(self.config_dict['WEEWX_ROOT'], self.config_dict['StdReport']['HTML_ROOT'])
             shutil.rmtree(test_html_dir)
-        except OSError, e:
+        except OSError as e:
             if os.path.exists(test_html_dir):
                 print >>sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
                 print >>sys.stderr, "Reason:", e

--- a/bin/weewx/test/test_templates.py
+++ b/bin/weewx/test/test_templates.py
@@ -89,7 +89,7 @@ class Common(unittest.TestCase):
         try:
             test_html_dir = os.path.join(self.config_dict['WEEWX_ROOT'], self.config_dict['StdReport']['HTML_ROOT'])
             shutil.rmtree(test_html_dir)
-        except OSError, e:
+        except OSError as e:
             if os.path.exists(test_html_dir):
                 print >> sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
                 print >> sys.stderr, "Reason:", e

--- a/bin/weewx/wxservices.py
+++ b/bin/weewx/wxservices.py
@@ -368,7 +368,7 @@ class WXCalculate(object):
             # archive interval, so multiply by the length of the archive
             # interval in hours.
             data['ET'] = ET_rate * interval / 3600.0 if ET_rate is not None else None
-        except ValueError, e:
+        except ValueError as e:
             weeutil.weeutil.log_traceback()
             syslog.syslog(syslog.LOG_ERR, "wxservices: Calculation of evapotranspiration failed: %s" % e)
         except weedb.DatabaseError:

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -261,16 +261,16 @@ def main() :
                 no_published += 1
                 print >>sys.stdout, " ...published."
                 wlog.slog(syslog.LOG_DEBUG, "%s ...published" % timestamp_to_string(record['dateTime']))
-            except weewx.restx.BadLogin, e:
+            except weewx.restx.BadLogin as e:
                 print >>sys.stderr, "Bad login"
                 print >>sys.stderr, e
                 exit("Bad login")                
-            except weewx.restx.FailedPost, e:
+            except weewx.restx.FailedPost as e:
                 print >>sys.stderr, e
                 print >>sys.stderr, "Aborted."
                 wlog.slog(syslog.LOG_ERR, "%s ...error %s. Aborting." % (timestamp_to_string(record['dateTime']), e))
                 exit("Failed post")
-            except IOError, e:
+            except IOError as e:
                 print >>sys.stderr, " ... not published."
                 print "Reason: ", e
                 wlog.slog(syslog.LOG_ERR, "%s ...not published. Reason '%s'" % (timestamp_to_string(record['dateTime']), e))
@@ -314,11 +314,11 @@ class WunderStation(weewx.restx.AmbientThread):
         try :
             # Hit the weather underground site:
             _wudata = urllib2.urlopen(_url)
-        except urllib2.URLError, e :
+        except urllib2.URLError as e :
             print >>sys.stderr, "Unable to open Weather Underground station " + self.station, " or ", e
             wlog.slog(syslog.LOG_ERR, "Unable to open Weather Underground station %s or %s" % (self.station, e))
             raise
-        except socket.timeout, e:
+        except socket.timeout as e:
             print >>sys.stderr, "Socket timeout for Weather Underground station " + self.station
             wlog.slog(syslog.LOG_ERR, "Socket timeout for Weather Underground station %s" % self.station)
             raise

--- a/examples/alarm.py
+++ b/examples/alarm.py
@@ -95,7 +95,7 @@ class MyAlarm(StdService):
             
             # If we got this far, it's ok to start intercepting events:
             self.bind(weewx.NEW_ARCHIVE_RECORD, self.newArchiveRecord)    # NOTE 1
-        except KeyError, e:
+        except KeyError as e:
             syslog.syslog(syslog.LOG_INFO, "alarm: No alarm set.  Missing parameter: %s" % e)
             
     def newArchiveRecord(self, event):
@@ -120,7 +120,7 @@ class MyAlarm(StdService):
                     t.start()
                     # Record when the message went out:
                     self.last_msg_ts = time.time()
-            except NameError, e:
+            except NameError as e:
                 # The record was missing a named variable. Write a debug message, then keep going
                 syslog.syslog(syslog.LOG_DEBUG, "alarm: %s" % e)
 
@@ -166,7 +166,7 @@ class MyAlarm(StdService):
             s.sendmail(msg['From'], self.TO,  msg.as_string())
             # Log out of the server:
             s.quit()
-        except Exception, e:
+        except Exception as e:
             syslog.syslog(syslog.LOG_ERR, "alarm: SMTP mailer refused message with error %s" % (e,))
             raise
         

--- a/examples/fileparse/bin/user/fileparse.py
+++ b/examples/fileparse/bin/user/fileparse.py
@@ -73,7 +73,7 @@ def _get_as_float(d, s):
     if s in d:
         try:
             v = float(d[s])
-        except ValueError, e:
+        except ValueError as e:
             logerr("cannot read value for '%s': %s" % (s, e))
     return v
 
@@ -106,7 +106,7 @@ class FileParseDriver(weewx.drivers.AbstractDevice):
                         name = line[:eq_index].strip()
                         value = line[eq_index + 1:].strip()
                         data[name] = value
-            except Exception, e:
+            except Exception as e:
                 logerr("read failed: %s" % e)
 
             # map the data into a weewx loop packet

--- a/examples/lowBattery.py
+++ b/examples/lowBattery.py
@@ -101,7 +101,7 @@ class BatteryAlarm(StdService):
             # If we got this far, it's ok to start intercepting events:
             self.bind(weewx.NEW_LOOP_PACKET,    self.newLoopPacket)
             self.bind(weewx.NEW_ARCHIVE_RECORD, self.newArchiveRecord)
-        except KeyError, e:
+        except KeyError as e:
             syslog.syslog(syslog.LOG_INFO, "lowBattery: No alarm set.  Missing parameter: %s" % e)
 
     def newLoopPacket(self, event):
@@ -201,7 +201,7 @@ Low battery indicators:
             s.sendmail(msg['From'], self.TO,  msg.as_string())
             # Log out of the server:
             s.quit()
-        except Exception, e:
+        except Exception as e:
             syslog.syslog(syslog.LOG_ERR,
                           "lowBattery: send email failed: %s" % (e,))
             raise

--- a/examples/pmon/bin/user/pmon.py
+++ b/examples/pmon/bin/user/pmon.py
@@ -139,7 +139,7 @@ class ProcessMonitor(StdService):
                     if m:
                         record['mem_vsz'] = int(m.group(1))
                         record['mem_rss'] = int(m.group(2))
-        except (ValueError, IOError, KeyError), e:
+        except (ValueError, IOError, KeyError) as e:
             logerr('apcups_info failed: %s' % e)
         return record
 

--- a/setup.py
+++ b/setup.py
@@ -159,9 +159,9 @@ class weewx_install_data(install_data):
         # Open up and parse the distribution config file:
         try:        
             dist_config_dict = configobj.ConfigObj(f, file_error=True)
-        except IOError, e:
+        except IOError as e:
             sys.exit(str(e))
-        except SyntaxError, e:
+        except SyntaxError as e:
             sys.exit("Syntax error in distribution configuration file '%s': %s"
                      % (f, e))
 


### PR DESCRIPTION
These patches modify the 'except' invocations to be python3 compatible according to the 2to3 utility that comes with recent versions of python2.   This passes 'make test' and 'python setup.py build' on ubuntu xenial64 under Vagrant.

Changes all seem to be simply changing the syntax from:

    except Something, e

to:

    except(Something) as e

Edits were created by:

    2to3 -f except -w my_source_directory_path_here

