### PR TITLE
python3 'print' mods from 2to 3 based on development

### DIFF
--- a/bin/weecfg/__init__.py
+++ b/bin/weecfg/__init__.py
@@ -126,7 +126,7 @@ class Logger(object):
         self.verbosity = verbosity
     def log(self, msg, level=0):
         if self.verbosity >= level:
-            print "%s%s" % ('  ' * (level - 1), msg)
+            print(("%s%s" % ('  ' * (level - 1), msg)))
     def set_verbosity(self, verbosity):
         self.verbosity = verbosity
 
@@ -1015,10 +1015,10 @@ def print_drivers():
     """Get information about all the available drivers, then print it out."""
     driver_info_dict = get_all_driver_infos()
     keys = sorted(driver_info_dict)
-    print "%-25s%-15s%-9s%-25s" % (
-        "Module name", "Driver name", "Version", "Status")
+    print(("%-25s%-15s%-9s%-25s" % (
+        "Module name", "Driver name", "Version", "Status")))
     for d in keys:
-        print "  %(module_name)-25s%(driver_name)-15s%(version)-9s%(status)-25s" % driver_info_dict[d]
+        print(("  %(module_name)-25s%(driver_name)-15s%(version)-9s%(status)-25s" % driver_info_dict[d]))
 
 def load_driver_editor(driver_module_name):
     """Load the configuration editor from the driver file
@@ -1050,16 +1050,16 @@ def prompt_for_info(location=None, latitude='90.000', longitude='0.000',
     #
     #  Description
     #
-    print "Enter a brief description of the station, such as its location.  For example:"
-    print "Santa's Workshop, North Pole"
+    print("Enter a brief description of the station, such as its location.  For example:")
+    print("Santa's Workshop, North Pole")
     loc = prompt_with_options("description", location)
 
     #
     #  Altitude
     #
-    print "Specify altitude, with units 'foot' or 'meter'.  For example:"
-    print "35, foot"
-    print "12, meter"
+    print("Specify altitude, with units 'foot' or 'meter'.  For example:")
+    print("35, foot")
+    print("12, meter")
     msg = "altitude [%s]: " % weeutil.weeutil.list_as_string(altitude) if altitude else "altitude: "
     alt = None
     while alt is None:
@@ -1079,20 +1079,20 @@ def prompt_for_info(location=None, latitude='90.000', longitude='0.000',
             alt = altitude
 
         if not alt:
-            print "Unrecognized response. Try again."
+            print("Unrecognized response. Try again.")
 
     #
     # Latitude & Longitude
     #
-    print "Specify latitude in decimal degrees, negative for south."
+    print("Specify latitude in decimal degrees, negative for south.")
     lat = prompt_with_limits("latitude", latitude, -90, 90)
-    print "Specify longitude in decimal degrees, negative for west."
+    print("Specify longitude in decimal degrees, negative for west.")
     lon = prompt_with_limits("longitude", longitude, -180, 180)
 
     #
     # Display units
     #
-    print "Indicate the preferred units for display: 'metric' or 'us'"
+    print("Indicate the preferred units for display: 'metric' or 'us'")
     uni = prompt_with_options("units", units, ['us', 'metric'])
 
     return {'location': loc,
@@ -1107,10 +1107,10 @@ def prompt_for_driver(dflt_driver=None):
     infos = get_all_driver_infos()
     keys = sorted(infos)
     dflt_idx = None
-    print "Installed drivers include:"
+    print("Installed drivers include:")
     for i, d in enumerate(keys):
-        print " %2d) %-15s %-25s %s" % (i, infos[d].get('driver_name', '?'),
-                                        "(%s)" % d, infos[d].get('status', ''))
+        print((" %2d) %-15s %-25s %s" % (i, infos[d].get('driver_name', '?'),
+                                        "(%s)" % d, infos[d].get('status', ''))))
         if dflt_driver == d:
             dflt_idx = i
     msg = "choose a driver [%d]: " % dflt_idx if dflt_idx is not None else "choose a driver: "

--- a/bin/weecfg/config.py
+++ b/bin/weecfg/config.py
@@ -25,7 +25,7 @@ class ConfigEngine(object):
     
     def run(self, args, options):
         if options.version:
-            print weewx.__version__
+            print((weewx.__version__))
             sys.exit(0)
     
         if options.list_drivers:

--- a/bin/weecfg/database.py
+++ b/bin/weecfg/database.py
@@ -7,6 +7,7 @@
 """Classes to support fixes or other bulk corrections of weewx data."""
 
 from __future__ import with_statement
+from __future__ import print_function
 
 # standard python imports
 import datetime
@@ -110,8 +111,8 @@ class DatabaseFix(object):
             To do nothing override with a pass statement.
         """
 
-        print >>sys.stdout, "Fixing database record: %d; Timestamp: %s\r" % \
-            (record, timestamp_to_string(ts)),
+        print("Fixing database record: %d; Timestamp: %s\r" % \
+            (record, timestamp_to_string(ts)), end=' ', file=sys.stdout)
         sys.stdout.flush()
 
 
@@ -249,7 +250,7 @@ class WindSpeedRecalculation(DatabaseFix):
         # we have finished, give the user some final information on progress,
         # mainly so the total tallies with the log
         self._progress(n_days, last_start)
-        print >>sys.stdout
+        print(file=sys.stdout)
         tdiff = time.time() - t1
         # We are done so log and inform the user
         syslog.syslog(syslog.LOG_INFO,
@@ -336,8 +337,8 @@ class WindSpeedRecalculation(DatabaseFix):
     def _progress(ndays, last_time):
         """Utility function to show our progress while processing the fix."""
 
-        print >>sys.stdout, "Updating 'windSpeed' daily summary: %d; Timestamp: %s\r" % \
-            (ndays, timestamp_to_string(last_time, format_str="%Y-%m-%d")),
+        print("Updating 'windSpeed' daily summary: %d; Timestamp: %s\r" % \
+            (ndays, timestamp_to_string(last_time, format_str="%Y-%m-%d")), end=' ', file=sys.stdout)
         sys.stdout.flush()
 
 
@@ -560,7 +561,7 @@ class IntervalWeighting(DatabaseFix):
             # Give the user some final information on progress,
             # mainly so the total tallies with the log
             self._progress(_days, last_start)
-            print >>sys.stdout
+            print(file=sys.stdout)
             tdiff = time.time() - t1
             # We are done so log and inform the user
             syslog.syslog(syslog.LOG_INFO,
@@ -677,6 +678,6 @@ class IntervalWeighting(DatabaseFix):
     def _progress(ndays, last_time):
         """Utility function to show our progress while processing the fix."""
 
-        print >>sys.stdout, "Weighting daily summary: %d; Timestamp: %s\r" % \
-            (ndays, timestamp_to_string(last_time, format_str="%Y-%m-%d")),
+        print("Weighting daily summary: %d; Timestamp: %s\r" % \
+            (ndays, timestamp_to_string(last_time, format_str="%Y-%m-%d")), end=' ', file=sys.stdout)
         sys.stdout.flush()

--- a/bin/weecfg/test/test_config.py
+++ b/bin/weecfg/test/test_config.py
@@ -24,7 +24,7 @@ try:
     import __builtin__  # @UnusedImport
     have_mock = True
 except ImportError:
-    print "Module 'mock' not installed. Testing will be restricted."
+    print("Module 'mock' not installed. Testing will be restricted.")
     have_mock = False
 
 # Redirect the import of setup:

--- a/bin/weedb/test/check_sqlite.py
+++ b/bin/weedb/test/check_sqlite.py
@@ -7,6 +7,7 @@
 # script "setup_mysql" will set them up with the necessary permissions.
 #
 from __future__ import with_statement
+from __future__ import print_function
 import unittest
 import sys
 import os
@@ -24,16 +25,16 @@ try:
     fd = open(sqdb1, 'w')
     fd.close()
 except:
-    print >>sys.stderr, "For tests to work properly, you must have permission to write to '%s'." % sqdb1
-    print >>sys.stderr, "Change the permissions and try again."
+    print("For tests to work properly, you must have permission to write to '%s'." % sqdb1, file=sys.stderr)
+    print("Change the permissions and try again.", file=sys.stderr)
 try:
     fd = open(sqdb2, 'w')
     fd.close()
 except IOError:
     pass
 else:
-    print >>sys.stderr, "For tests to work properly, you must NOT have permission to write to '%s'." % sqdb2
-    print >>sys.stderr, "Change the permissions and try again."
+    print("For tests to work properly, you must NOT have permission to write to '%s'." % sqdb2, file=sys.stderr)
+    print("Change the permissions and try again.", file=sys.stderr)
 
 class Cursor(object):
     """Class to be used to wrap a cursor in a 'with' clause."""

--- a/bin/weedb/test/test_errors.py
+++ b/bin/weedb/test/test_errors.py
@@ -1,5 +1,6 @@
 """Test the weedb exception hierarchy"""
 from __future__ import with_statement
+from __future__ import print_function
 import os
 import stat
 import unittest
@@ -22,16 +23,16 @@ try:
     fd = open(sqdb1_dict['database_name'], 'w')
     fd.close()
 except:
-    print >>sys.stderr, "For tests to work properly, you must have permission to write to '%s'." % sqdb1_dict['database_name']
-    print >>sys.stderr, "Change the permissions and try again."
+    print("For tests to work properly, you must have permission to write to '%s'." % sqdb1_dict['database_name'], file=sys.stderr)
+    print("Change the permissions and try again.", file=sys.stderr)
 try:
     fd = open(sqdb2_dict['database_name'], 'w')
     fd.close()
 except IOError:
     pass
 else:
-    print >>sys.stderr, "For tests to work properly, you must NOT have permission to write to '%s'." % sqdb2_dict['database_name']
-    print >>sys.stderr, "Change the permissions and try again."
+    print("For tests to work properly, you must NOT have permission to write to '%s'." % sqdb2_dict['database_name'], file=sys.stderr)
+    print("Change the permissions and try again.", file=sys.stderr)
 
 class Cursor(object):
     """Class to be used to wrap a cursor in a 'with' clause."""

--- a/bin/weeimport/csvimport.py
+++ b/bin/weeimport/csvimport.py
@@ -117,16 +117,16 @@ class CSVSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print("Missing derived observations will be calculated.")
         if not self.UV_sensor:
-            print "All weeWX UV fields will be set to None."
+            print("All weeWX UV fields will be set to None.")
         if not self.solar_sensor:
-            print "All weeWX radiation fields will be set to None."
+            print("All weeWX radiation fields will be set to None.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print(("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )))
+            print(("including %s will be imported." % (timestamp_to_string(self.last_ts), )))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Obtain an iterable containing the raw data to be imported.

--- a/bin/weeimport/cumulusimport.py
+++ b/bin/weeimport/cumulusimport.py
@@ -246,16 +246,16 @@ class CumulusSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print("Missing derived observations will be calculated.")
         if not self.UV_sensor:
-            print "All weeWX UV fields will be set to None."
+            print("All weeWX UV fields will be set to None.")
         if not self.solar_sensor:
-            print "All weeWX radiation fields will be set to None."
+            print("All weeWX radiation fields will be set to None.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print(("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )))
+            print(("including %s will be imported." % (timestamp_to_string(self.last_ts), )))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Get raw observation data and construct a map from Cumulus monthly

--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -6,6 +6,7 @@
 #
 
 from __future__ import with_statement
+from __future__ import print_function
 
 """Module providing the base classes and API for importing observational data
 into weeWX.
@@ -375,8 +376,8 @@ class Source(object):
                                                                                                                                self.total_unique_rec,
                                                                                                                                self.tdiff)
                     self.wlog.printlog(syslog.LOG_INFO, _msg)
-                    print "Those records with a timestamp already in the archive will not have been"
-                    print "imported. Confirm successful import in the weeWX log file."
+                    print("Those records with a timestamp already in the archive will not have been")
+                    print("imported. Confirm successful import in the weeWX log file.")
 
     def parseMap(self, source_type, source, import_config_dict):
         """Produce a source field-to-weeWX archive field map.
@@ -764,25 +765,25 @@ class Source(object):
             if _diff_interval and self.interval_ans != 'y':
                 # we had more than one unique value for interval, warn the user
                 self.wlog.printlog(syslog.LOG_INFO, "Warning: Records to be imported contain multiple different 'interval' values.")
-                print "         This may mean the imported data is missing some records and it may lead"
-                print "         to data integrity issues. If the raw data has a known, fixed interval"
-                print "         value setting the relevant 'interval' setting in wee_import config to"
-                print "         this value may give a better result."
+                print("         This may mean the imported data is missing some records and it may lead")
+                print("         to data integrity issues. If the raw data has a known, fixed interval")
+                print("         value setting the relevant 'interval' setting in wee_import config to")
+                print("         this value may give a better result.")
                 while self.interval_ans not in ['y', 'n']:
                     self.interval_ans = raw_input('Are you sure you want to proceed (y/n)? ')
                 if self.interval_ans == 'n':
                     # the user chose to abort, but we may have already
                     # processed some records. So log it then raise a SystemExit()
                     if self.dry_run:
-                        print "Dry run import aborted by user. %d records were processed." % self.total_rec_proc
+                        print("Dry run import aborted by user. %d records were processed." % self.total_rec_proc)
                     else:
                         if self.total_rec_proc > 0:
-                            print "Those records with a timestamp already in the archive will not have been"
-                            print "imported. As the import was aborted before completion refer to the weeWX log"
-                            print "file to confirm which records were imported."
+                            print("Those records with a timestamp already in the archive will not have been")
+                            print("imported. As the import was aborted before completion refer to the weeWX log")
+                            print("file to confirm which records were imported.")
                             raise SystemExit('Exiting.')
                         else:
-                            print "Import aborted by user. No records saved to archive."
+                            print("Import aborted by user. No records saved to archive.")
                         _msg = "User chose to abort import. %d records were processed. Exiting." % self.total_rec_proc
                         self.wlog.logonly(syslog.LOG_INFO, _msg)
                         raise SystemExit('Exiting. Nothing done.')
@@ -957,9 +958,9 @@ class Source(object):
             self.t1 = time.time()
             # it's convenient to give this message now
             if self.dry_run:
-                print 'Starting dry run import ...'
+                print('Starting dry run import ...')
             else:
-                print 'Starting import ...'
+                print('Starting import ...')
         # do we have any records?
         if records and len(records) > 0:
             # if this is the first period then give a little summary about what
@@ -967,13 +968,13 @@ class Source(object):
             if self.first_period:
                 if self.last_period:
                     # there is only 1 period, so we can count them
-                    print "%s records identified for import." % len(records)
+                    print("%s records identified for import." % len(records))
                 else:
                     # there are more periods so say so
-                    print "Records covering multiple periods have been identified for import."
+                    print("Records covering multiple periods have been identified for import.")
             # we do, confirm the user actually wants to save them
             while self.ans not in ['y', 'n'] and not self.dry_run:
-                print "Proceeding will save all imported records in the weeWX archive."
+                print("Proceeding will save all imported records in the weeWX archive.")
                 self.ans = raw_input("Are you sure you want to proceed (y/n)? ")
             if self.ans == 'y' or self.dry_run:
                 # we are going to save them
@@ -987,7 +988,7 @@ class Source(object):
                 # if we are importing multiple periods of data then tell the
                 # user what period we are up to
                 if not (self.first_period and self.last_period):
-                    print "Period %d ..." % self.period_no
+                    print("Period %d ..." % self.period_no)
                 # step through each record in this period
                 for _rec in records:
                     # convert our record
@@ -1014,7 +1015,7 @@ class Source(object):
                         _msg = "Records processed: %d; Unique records: %d; Last timestamp: %s\r" % (nrecs,
                                                                                                     len(unique_set),
                                                                                                     timestamp_to_string(_final_rec['dateTime']))
-                        print >> sys.stdout, _msg,
+                        print(_msg, end=' ', file=sys.stdout)
                         sys.stdout.flush()
                         _tranche = []
                 # we have processed all records but do we have any records left
@@ -1032,8 +1033,8 @@ class Source(object):
                     _msg = "Records processed: %d; Unique records: %d; Last timestamp: %s\r" % (nrecs,
                                                                                                 len(unique_set),
                                                                                                 timestamp_to_string(_final_rec['dateTime']))
-                    print >> sys.stdout, _msg,
-                print
+                    print(_msg, end=' ', file=sys.stdout)
+                print()
                 sys.stdout.flush()
                 # update our counts
                 self.total_rec_proc += nrecs
@@ -1053,7 +1054,7 @@ class Source(object):
             else:
                 # multiple periods
                 _msg = 'Period %d - no records identified for import.' % self.period_no
-            print _msg
+            print(_msg)
         # if we have finished record the time taken for our summary
         if self.last_period:
             self.tdiff = time.time() - self.t1
@@ -1113,14 +1114,14 @@ class WeeImportLog(object):
     def printlog(self, level, message):
         """Print to screen and log to file."""
 
-        print message
+        print(message)
         self.logonly(level, message)
 
     def verboselog(self, level, message):
         """Print to screen if --verbose and log to file always."""
 
         if self.verbose:
-            print message
+            print(message)
             self.logonly(level, message)
 
 

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -154,12 +154,12 @@ class WUSource(weeimport.Source):
                                                                         unit_nicknames[self.archive_unit_sys])
         self.wlog.printlog(syslog.LOG_INFO, _msg)
         if self.calc_missing:
-            print "Missing derived observations will be calculated."
+            print("Missing derived observations will be calculated.")
         if options.date or options.date_from:
-            print "Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )
-            print "including %s will be imported." % (timestamp_to_string(self.last_ts), )
+            print(("Observations timestamped after %s and up to and" % (timestamp_to_string(self.first_ts), )))
+            print(("including %s will be imported." % (timestamp_to_string(self.last_ts), )))
         if self.dry_run:
-            print "This is a dry run, imported data will not be saved to archive."
+            print("This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Get raw observation data and construct a map from WU to weeWX

--- a/bin/weeplot/utilities.py
+++ b/bin/weeplot/utilities.py
@@ -571,5 +571,5 @@ if __name__ == "__main__":
     import doctest
 
     if not doctest.testmod().failed:
-        print "PASSED"
+        print("PASSED")
     

--- a/bin/weeutil/Sun.py
+++ b/bin/weeutil/Sun.py
@@ -535,7 +535,7 @@ def rev180(x):
 
 if __name__ == "__main__":
     (sunrise_utc, sunset_utc) = sunRiseSet(2009, 3, 27, -122.65, 45.517)
-    print sunrise_utc, sunset_utc
+    print((sunrise_utc, sunset_utc))
     
     #Assert that the results are within 1 minute of NOAA's 
     # calculator (see http://www.srrb.noaa.gov/highlights/sunrise/sunrise.html)

--- a/bin/weeutil/ftpupload.py
+++ b/bin/weeutil/ftpupload.py
@@ -270,13 +270,13 @@ if __name__ == '__main__':
     syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
 
     if len(sys.argv) < 2 :
-        print """Usage: ftpupload.py path-to-configuration-file [path-to-be-ftp'd]"""
+        print("""Usage: ftpupload.py path-to-configuration-file [path-to-be-ftp'd]""")
         sys.exit(weewx.CMD_ERROR)
         
     try :
         config_dict = configobj.ConfigObj(sys.argv[1], file_error=True)
     except IOError:
-        print "Unable to open configuration file ", sys.argv[1]
+        print(("Unable to open configuration file ", sys.argv[1]))
         raise
 
     if len(sys.argv) == 2:
@@ -284,7 +284,7 @@ if __name__ == '__main__':
             ftp_dir = os.path.join(config_dict['WEEWX_ROOT'],
                                    config_dict['StdReport']['HTML_ROOT'])
         except KeyError:
-            print "No HTML_ROOT in configuration dictionary."
+            print("No HTML_ROOT in configuration dictionary.")
             sys.exit(1)
     else:
         ftp_dir = sys.argv[2]

--- a/bin/weeutil/rsyncupload.py
+++ b/bin/weeutil/rsyncupload.py
@@ -145,13 +145,13 @@ if __name__ == '__main__':
     syslog.setlogmask(syslog.LOG_UPTO(syslog.LOG_DEBUG))
 
     if len(sys.argv) < 2 :
-        print """Usage: rsyncupload.py path-to-configuration-file [path-to-be-rsync'd]"""
+        print("""Usage: rsyncupload.py path-to-configuration-file [path-to-be-rsync'd]""")
         sys.exit(weewx.CMD_ERROR)
         
     try :
         config_dict = configobj.ConfigObj(sys.argv[1], file_error=True)
     except IOError:
-        print "Unable to open configuration file ", sys.argv[1]
+        print(("Unable to open configuration file ", sys.argv[1]))
         raise
 
     if len(sys.argv) == 2:
@@ -159,7 +159,7 @@ if __name__ == '__main__':
             rsync_dir = os.path.join(config_dict['WEEWX_ROOT'],
                                    config_dict['StdReport']['HTML_ROOT'])
         except KeyError:
-            print "No HTML_ROOT in configuration dictionary."
+            print("No HTML_ROOT in configuration dictionary.")
             sys.exit(1)
     else:
         rsync_dir = sys.argv[2]

--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -1318,10 +1318,10 @@ def print_dict(d, margin=0, increment=4):
     """
     for k in d:
         if type(d[k]) is dict:
-            print margin * ' ', k
+            print((margin * ' ', k))
             print_dict(d[k], margin + increment, increment)
         else:
-            print margin * ' ', k, '=', d[k]
+            print((margin * ' ', k, '=', d[k]))
 
 def move_with_timestamp(filepath):
     """Save a file to a path with a timestamp."""

--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -56,6 +56,7 @@ Example:
 """
 
 from __future__ import with_statement
+from __future__ import print_function
 import os.path
 import syslog
 import time

--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -327,7 +327,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                     filter=encoding,
                     filtersLib=weewx.cheetahgenerator)
                 with open(tmpname, mode='w') as _file:
-                    print >> _file, compiled_template
+                    print(compiled_template, file=_file)
                 os.rename(tmpname, _fullname)
             except Exception, e:
                 # We would like to get better feedback when there are cheetah

--- a/bin/weewx/drivers/acurite.py
+++ b/bin/weewx/drivers/acurite.py
@@ -978,7 +978,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "acurite driver version %s" % DRIVER_VERSION
+        print(("acurite driver version %s" % DRIVER_VERSION))
         exit(0)
 
     test_r1 = True
@@ -992,20 +992,20 @@ if __name__ == '__main__':
                                               time.localtime(ts)), ts)
             if test_r1:
                 r1 = s.read_R1()
-                print tstr, _fmt_bytes(r1), Station.decode_R1(r1)
+                print((tstr, _fmt_bytes(r1), Station.decode_R1(r1)))
                 delay = min(delay, 18)
             if test_r2:
                 r2 = s.read_R2()
-                print tstr, _fmt_bytes(r2), Station.decode_R2(r2)
+                print((tstr, _fmt_bytes(r2), Station.decode_R2(r2)))
                 delay = min(delay, 60)
             if test_r3:
                 try:
                     x = s.read_x()
-                    print tstr, _fmt_bytes(x)
+                    print((tstr, _fmt_bytes(x)))
                     for i in range(0, 17):
                         r3 = s.read_R3()
-                        print tstr, _fmt_bytes(r3)
+                        print((tstr, _fmt_bytes(r3)))
                 except usb.USBError, e:
-                    print tstr, e
+                    print((tstr, e))
                 delay = min(delay, 12*60)
             time.sleep(delay)

--- a/bin/weewx/drivers/acurite.py
+++ b/bin/weewx/drivers/acurite.py
@@ -505,7 +505,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                             self.polling_interval)
                 logdbg("next read in %s seconds" % delay)
                 time.sleep(delay)
-            except (usb.USBError, weewx.WeeWxIOError), e:
+            except (usb.USBError, weewx.WeeWxIOError) as e:
                 logerr("Failed attempt %d of %d to get LOOP data: %s" %
                        (ntries, self.max_tries, e))
                 time.sleep(self.retry_wait)
@@ -561,7 +561,7 @@ class AcuRiteDriver(weewx.drivers.AbstractDevice):
                 for i in range(17):
                     r3.append(station.read_R3())
                 self.last_r3 = time.time()
-            except usb.USBError, e:
+            except usb.USBError as e:
                 self.r3_fail_count += 1
                 logdbg("R3: read failed %d of %d: %s" %
                        (self.r3_fail_count, self.r3_max_fail, e))
@@ -627,13 +627,13 @@ class Station(object):
         # FIXME: is it necessary to set the configuration?
         try:
             self.handle.setConfiguration(dev.configurations[0])
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
         # attempt to claim the interface
         try:
             self.handle.claimInterface(interface)
-        except usb.USBError, e:
+        except usb.USBError as e:
             self.close()
             logcrt("Unable to claim USB interface %s: %s" % (interface, e))
             raise weewx.WeeWxIOError(e)
@@ -641,14 +641,14 @@ class Station(object):
         # FIXME: is it necessary to set the alt interface?
         try:
             self.handle.setAltInterface(interface)
-        except (AttributeError, usb.USBError), e:
+        except (AttributeError, usb.USBError) as e:
             pass
 
     def close(self):
         if self.handle is not None:
             try:
                 self.handle.releaseInterface()
-            except (ValueError, usb.USBError), e:
+            except (ValueError, usb.USBError) as e:
                 logerr("release interface failed: %s" % e)
             self.handle = None
 
@@ -754,7 +754,7 @@ class Station(object):
                 try:
                     for b in r:
                         buf.append(int(b, 16))
-                except ValueError, e:
+                except ValueError as e:
                     logerr("R3: bad value in row %d: %s" % (i, _fmt_bytes(r)))
                     fail = True
             elif len(r) != 33:
@@ -1005,7 +1005,7 @@ if __name__ == '__main__':
                     for i in range(0, 17):
                         r3 = s.read_R3()
                         print((tstr, _fmt_bytes(r3)))
-                except usb.USBError, e:
+                except usb.USBError as e:
                     print((tstr, e))
                 delay = min(delay, 12*60)
             time.sleep(delay)

--- a/bin/weewx/drivers/cc3000.py
+++ b/bin/weewx/drivers/cc3000.py
@@ -187,126 +187,126 @@ class CC3000Configurator(weewx.drivers.AbstractConfigurator):
     def do_options(self, options, parser, config_dict, prompt):
         self.driver = CC3000Driver(**config_dict[DRIVER_NAME])
         if options.current:
-            print self.driver.get_current()
+            print((self.driver.get_current()))
         elif options.nrecords is not None:
             for r in self.driver.station.gen_records(nrecords):
-                print r
+                print(r)
         elif options.clear:
             self.clear_memory(prompt)
         elif options.reset:
             self.reset_rain(prompt)
         elif options.getclock:
-            print self.driver.station.get_time()
+            print((self.driver.station.get_time()))
         elif options.setclock:
             self.set_clock(prompt)
         elif options.getdst:
-            print self.driver.station.get_dst()
+            print((self.driver.station.get_dst()))
         elif options.dst is not None:
             self.set_dst(options.setdst, prompt)
         elif options.getint:
-            print self.driver.station.get_interval() * 60
+            print((self.driver.station.get_interval() * 60))
         elif options.interval is not None:
             self.set_interval(options.interval / 60, prompt)
         elif options.getunits:
-            print self.driver.station.get_units()
+            print((self.driver.station.get_units()))
         elif options.units is not None:
             self.set_units(options.units, prompt)
         elif options.getch:
-            print self.driver.station.get_channel()
+            print((self.driver.station.get_channel()))
         elif options.ch is not None:
             self.set_channel(options.ch, prompt)
         else:
-            print "firmware:", self.driver.station.get_version()
-            print "time:", self.driver.station.get_time()
-            print "dst:", self.driver.station.get_dst()
-            print "units:", self.driver.station.get_units()
-            print "memory:", self.driver.station.get_memory_status()
-            print "interval:", self.driver.station.get_interval() * 60
-            print "channel:", self.driver.station.get_channel()
-            print "charger:", self.driver.station.get_charger()
-            print "baro:", self.driver.station.get_baro()
-            print "rain:", self.driver.station.get_rain()
+            print(("firmware:", self.driver.station.get_version()))
+            print(("time:", self.driver.station.get_time()))
+            print(("dst:", self.driver.station.get_dst()))
+            print(("units:", self.driver.station.get_units()))
+            print(("memory:", self.driver.station.get_memory_status()))
+            print(("interval:", self.driver.station.get_interval() * 60))
+            print(("channel:", self.driver.station.get_channel()))
+            print(("charger:", self.driver.station.get_charger()))
+            print(("baro:", self.driver.station.get_baro()))
+            print(("rain:", self.driver.station.get_rain()))
         self.driver.closePort()
 
     def clear_memory(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
-            print self.driver.station.get_memory_status()
+            print((self.driver.station.get_memory_status()))
             if prompt:
                 ans = raw_input("Clear console memory (y/n)? ")
             else:
-                print 'Clearing console memory'
+                print('Clearing console memory')
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.clear_memory()
-                print self.driver.station.get_memory_status()
+                print((self.driver.station.get_memory_status()))
             elif ans == 'n':
-                print "Clear memory cancelled."
+                print("Clear memory cancelled.")
 
     def reset_rain(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
-            print self.driver.station.get_rain()
+            print((self.driver.station.get_rain()))
             if prompt:
                 ans = raw_input("Reset rain counter (y/n)? ")
             else:
-                print 'Resetting rain counter'
+                print('Resetting rain counter')
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.reset_rain()
-                print self.driver.station.get_rain()
+                print((self.driver.station.get_rain()))
             elif ans == 'n':
-                print "Reset rain cancelled."
+                print("Reset rain cancelled.")
 
     def set_interval(self, interval, prompt):
         if interval < 0 or 60 < interval:
             raise ValueError("Logger interval must be 0-60 minutes")
         ans = None
         while ans not in ['y', 'n']:
-            print "Interval is", self.driver.station.get_interval()
+            print(("Interval is", self.driver.station.get_interval()))
             if prompt:
                 ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
             else:
-                print "Setting interval to %d minutes" % interval
+                print(("Setting interval to %d minutes" % interval))
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.set_interval(interval)
-                print "Interval is now", self.driver.station.get_interval()
+                print(("Interval is now", self.driver.station.get_interval()))
             elif ans == 'n':
-                print "Set interval cancelled."
+                print("Set interval cancelled.")
 
     def set_clock(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
-            print "Station clock is", self.driver.station.get_time()
+            print(("Station clock is", self.driver.station.get_time()))
             now = datetime.datetime.now()
             if prompt:
                 ans = raw_input("Set station clock to %s (y/n)? " % now)
             else:
-                print "Setting station clock to %s" % now
+                print(("Setting station clock to %s" % now))
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.set_time()
-                print "Station clock is now", self.driver.station.get_time()
+                print(("Station clock is now", self.driver.station.get_time()))
             elif ans == 'n':
-                print "Set clock cancelled."
+                print("Set clock cancelled.")
 
     def set_units(self, units, prompt):
         if units.lower() not in ['metric', 'english']:
             raise ValueError("Units must be METRIC or ENGLISH")
         ans = None
         while ans not in ['y', 'n']:
-            print "Station units is", self.driver.station.get_units()
+            print(("Station units is", self.driver.station.get_units()))
             if prompt:
                 ans = raw_input("Set station units to %s (y/n)? " % units)
             else:
-                print "Setting station units to %s" % units
+                print(("Setting station units to %s" % units))
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.set_units(units)
-                print "Station units is now", self.driver.station.get_units()
+                print(("Station units is now", self.driver.station.get_units()))
             elif ans == 'n':
-                print "Set units cancelled."
+                print("Set units cancelled.")
 
     def set_dst(self, dst, prompt):
         if dst != '0' and len(dst.split(',')) != 3:
@@ -314,34 +314,34 @@ class CC3000Configurator(weewx.drivers.AbstractConfigurator):
                              "with the format mm/dd HH:MM, mm/dd HH:MM, [MM]M")
         ans = None
         while ans not in ['y', 'n']:
-            print "Station DST is", self.driver.station.get_dst()
+            print(("Station DST is", self.driver.station.get_dst()))
             if prompt:
                 ans = raw_input("Set DST to %s (y/n)? " % dst)
             else:
-                print "Setting station DST to %s" % dst
+                print(("Setting station DST to %s" % dst))
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.set_dst(dst)
-                print "Station DST is now", self.driver.station.get_dst()
+                print(("Station DST is now", self.driver.station.get_dst()))
             elif ans == 'n':
-                print "Set DST cancelled."
+                print("Set DST cancelled.")
 
     def set_channel(self, ch, prompt):
         if ch not in [0, 1, 2, 3]:
             raise ValueError("Channel must be one of 0, 1, 2, or 3")
         ans = None
         while ans not in ['y', 'n']:
-            print "Station channel is", self.driver.station.get_channel()
+            print(("Station channel is", self.driver.station.get_channel()))
             if prompt:
                 ans = raw_input("Set channel to %s (y/n)? " % ch)
             else:
-                print "Setting station channel to %s" % ch
+                print(("Setting station channel to %s" % ch))
                 ans = 'y'
             if ans == 'y':
                 self.driver.station.set_channel(ch)
-                print "Station channel is now", self.driver.station.get_ch()
+                print(("Station channel is now", self.driver.station.get_ch()))
             elif ans == 'n':
-                print "Set channel cancelled."
+                print("Set channel cancelled.")
 
 
 class CC3000Driver(weewx.drivers.AbstractDevice):
@@ -1034,8 +1034,8 @@ class CC3000ConfEditor(weewx.drivers.AbstractConfEditor):
 """ % (CC3000.DEFAULT_PORT,)
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print("Specify the serial port on which the station is connected, for")
+        print("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', CC3000.DEFAULT_PORT)
         return {'port': port}
 
@@ -1105,7 +1105,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "%s driver version %s" % (DRIVER_NAME, DRIVER_VERSION)
+        print(("%s driver version %s" % (DRIVER_NAME, DRIVER_VERSION)))
         exit(0)
 
     if options.debug:
@@ -1125,49 +1125,49 @@ if __name__ == '__main__':
         s.wakeup()
         s.set_echo()
         if options.getver:
-            print s.get_version()
+            print((s.get_version()))
         if options.status:
-            print "firmware:", s.get_version()
-            print "time:", s.get_time()
-            print "dst:", s.get_dst()
-            print "units:", s.get_units()
-            print "memory:", s.get_memory_status()
-            print "interval:", s.get_interval() * 60
-            print "channel:", s.get_channel()
-            print "charger:", s.get_charger()
-            print "baro:", s.get_baro()
-            print "rain:", s.get_rain()
+            print(("firmware:", s.get_version()))
+            print(("time:", s.get_time()))
+            print(("dst:", s.get_dst()))
+            print(("units:", s.get_units()))
+            print(("memory:", s.get_memory_status()))
+            print(("interval:", s.get_interval() * 60))
+            print(("channel:", s.get_channel()))
+            print(("charger:", s.get_charger()))
+            print(("baro:", s.get_baro()))
+            print(("rain:", s.get_rain()))
         if options.getch:
-            print s.get_channel()
+            print((s.get_channel()))
         if options.setch is not None:
             s.set_channel(int(options.setch))
         if options.getbat:
-            print s.get_charger()
+            print((s.get_charger()))
         if options.getcur:
-            print s.get_current_data()
+            print((s.get_current_data()))
         if options.getmem:
-            print s.get_memory_status()
+            print((s.get_memory_status()))
         if options.getrec is not None:
             i = 0
             for r in s.gen_records(int(options.getrec)):
-                print i, r
+                print((i, r))
                 i += 1
         if options.gethead:
-            print s.get_header()
+            print((s.get_header()))
         if options.getunits:
-            print s.get_units()
+            print((s.get_units()))
         if options.setunits:
             s.set_units(options.setunits)
         if options.gettime:
-            print s.get_time()
+            print((s.get_time()))
         if options.settime:
             s.set_time()
         if options.getdst:
-            print s.get_dst()
+            print((s.get_dst()))
         if options.setdst:
             s.set_dst(options.setdst)
         if options.getint:
-            print s.get_interval() * 60
+            print((s.get_interval() * 60))
         if options.setint:
             s.set_interval(int(options.setint) / 60)
         if options.clear:
@@ -1180,5 +1180,5 @@ if __name__ == '__main__':
                 cmd_mode = False
                 s.set_auto()
             while True:
-                print s.get_current_data(cmd_mode)
+                print((s.get_current_data(cmd_mode)))
                 time.sleep(options.poll)

--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -210,6 +210,8 @@ It is used as: A200 1A20 A2AA 0020 to indicate a data refresh.
 The WH1080 acknowledges the write with an 8 byte chunk: A5A5 A5A5.
 """
 
+from __future__ import print_function
+
 import datetime
 import sys
 import syslog

--- a/bin/weewx/drivers/fousb.py
+++ b/bin/weewx/drivers/fousb.py
@@ -270,22 +270,22 @@ def getvalues(station, name, value):
     return values
 
 def raw_dump(date, pos, data):
-    print date,
-    print "%04x" % pos,
+    print(date, end=' ')
+    print("%04x" % pos, end=' ')
     for item in data:
-        print "%02x" % item,
-    print
+        print("%02x" % item, end=' ')
+    print()
 
 def table_dump(date, data, showlabels=False):
     if showlabels:
-        print '# date time',
+        print('# date time', end=' ')
         for key in data.keys():
-            print key,
-        print
-    print date,
+            print(key, end=' ')
+        print()
+    print(date, end=' ')
     for key in data.keys():
-        print data[key],
-    print
+        print(data[key], end=' ')
+    print()
 
 
 class FOUSBConfEditor(weewx.drivers.AbstractConfEditor):
@@ -311,22 +311,22 @@ class FOUSBConfEditor(weewx.drivers.AbstractConfEditor):
         import configobj
         stanza = configobj.ConfigObj(orig_stanza.splitlines())
         if 'pressure_offset' in stanza[DRIVER_NAME]:
-            print """
+            print("""
 The pressure_offset is no longer supported by the FineOffsetUSB driver.  Move
-the pressure calibration constant to [StdCalibrate] instead."""
+the pressure calibration constant to [StdCalibrate] instead.""")
         if ('polling_mode' in stanza[DRIVER_NAME] and
             stanza[DRIVER_NAME]['polling_mode'] == 'ADAPTIVE'):
-            print """
-Using ADAPTIVE as the polling_mode can lead to USB lockups."""
+            print("""
+Using ADAPTIVE as the polling_mode can lead to USB lockups.""")
         if ('polling_interval' in stanza[DRIVER_NAME] and
             int(stanza[DRIVER_NAME]['polling_interval']) < 48):
-            print """
-A polling_interval of anything less than 48 seconds is not recommened."""
+            print("""
+A polling_interval of anything less than 48 seconds is not recommened.""")
         return orig_stanza
 
     def modify_config(self, config_dict):
-        print """
-Setting record_generation to software."""
+        print("""
+Setting record_generation to software.""")
         config_dict['StdArchive']['record_generation'] = 'software'
 
 
@@ -403,14 +403,14 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
     def show_info(self):
         """Query the station then display the settings."""
 
-        print "Querying the station..."
+        print("Querying the station...")
         val = getvalues(self.station, '', fixed_format)
 
-        print 'Fine Offset station settings:'
-        print '%s: %s' % ('local time'.rjust(30),
+        print('Fine Offset station settings:')
+        print('%s: %s' % ('local time'.rjust(30),
                           time.strftime('%Y.%m.%d %H:%M:%S %Z',
-                                        time.localtime()))
-        print '%s: %s' % ('polling mode'.rjust(30), self.station.polling_mode)
+                                        time.localtime())))
+        print('%s: %s' % ('polling mode'.rjust(30), self.station.polling_mode))
 
         slist = {'values':[], 'minmax_values':[], 'settings':[],
                  'display_settings':[], 'alarm_settings':[]}
@@ -425,17 +425,17 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
                 slist = stash(slist, s)
         for k in ('values', 'minmax_values', 'settings',
                   'display_settings', 'alarm_settings'):
-            print ''
+            print('')
             for s in slist[k]:
-                print s
+                print(s)
 
     def check_usb(self):
         """Run diagnostics on the USB connection."""
-        print "This will read from the station console repeatedly to see if"
-        print "there are errors in the USB communications.  Leave this running"
-        print "for an hour or two to see if any bad reads are encountered."
-        print "Bad reads will be reported in the system log.  A few bad reads"
-        print "per hour is usually acceptable."
+        print("This will read from the station console repeatedly to see if")
+        print("there are errors in the USB communications.  Leave this running")
+        print("for an hour or two to see if any bad reads are encountered.")
+        print("Bad reads will be reported in the system log.  A few bad reads")
+        print("per hour is usually acceptable.")
         ptr = data_start
         total_count = 0
         bad_count = 0
@@ -456,25 +456,25 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
                 syslog.syslog(syslog.LOG_INFO, '  %s' % str(result_2))
                 bad_count += 1
             total_count += 1
-            print "\rbad/total: %d/%d " % (bad_count, total_count),
+            print("\rbad/total: %d/%d " % (bad_count, total_count), end=' ')
             sys.stdout.flush()
 
     def check_fixedblock(self):
         """Display changes to fixed block as they occur."""
-        print 'This will read the fixed block then display changes as they'
-        print 'occur.  Typically the most common change is the incrementing'
-        print 'of the data pointer, which happens whenever readings are saved'
-        print 'to the station memory.  For example, if the logging interval'
-        print 'is set to 5 minutes, the fixed block should change at least'
-        print 'every 5 minutes.'
+        print('This will read the fixed block then display changes as they')
+        print('occur.  Typically the most common change is the incrementing')
+        print('of the data pointer, which happens whenever readings are saved')
+        print('to the station memory.  For example, if the logging interval')
+        print('is set to 5 minutes, the fixed block should change at least')
+        print('every 5 minutes.')
         raw_fixed = self.station.get_raw_fixed_block()
         while True:
             new_fixed = self.station.get_raw_fixed_block(unbuffered=True)
             for ptr in range(len(new_fixed)):
                 if new_fixed[ptr] != raw_fixed[ptr]:
-                    print datetime.datetime.now().strftime('%H:%M:%S'),
-                    print ' %04x (%d) %02x -> %02x' % (
-                        ptr, ptr, raw_fixed[ptr], new_fixed[ptr])
+                    print(datetime.datetime.now().strftime('%H:%M:%S'), end=' ')
+                    print(' %04x (%d) %02x -> %02x' % (
+                        ptr, ptr, raw_fixed[ptr], new_fixed[ptr]))
                     raw_fixed = new_fixed
                     time.sleep(0.5)
 
@@ -482,22 +482,22 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
         """Display the raw fixed block contents."""
         fb = self.station.get_raw_fixed_block(unbuffered=True)
         for i, ptr in enumerate(range(len(fb))):
-            print '%02x' % fb[ptr],
+            print('%02x' % fb[ptr], end=' ')
             if (i+1) % 16 == 0:
-                print
+                print()
 
     def show_readings(self, logged_only):
         """Display live readings from the station."""
         for data,ptr,_ in self.station.live_data(logged_only):
-            print '%04x' % ptr,
-            print data['idx'].strftime('%H:%M:%S'),
+            print('%04x' % ptr, end=' ')
+            print(data['idx'].strftime('%H:%M:%S'), end=' ')
             del data['idx']
-            print data
+            print(data)
 
     def show_current(self):
         """Display latest readings from the station."""
         for packet in self.station.genLoopPackets():
-            print packet
+            print(packet)
             break
 
     def show_history(self, ts=0, count=0, fmt='raw'):
@@ -510,59 +510,59 @@ class FOUSBConfigurator(weewx.drivers.AbstractConfigurator):
             elif fmt.lower() == 'table':
                 table_dump(r['datetime'], r['data'], i==0)
             else:
-                print r['datetime'], r['data']
+                print(r['datetime'], r['data'])
 
     def clear_history(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.get_fixed_block(['data_count'], True)
-            print "Records in memory:", v
+            print("Records in memory:", v)
             if prompt:
                 ans = raw_input("Clear console memory (y/n)? ")
             else:
-                print 'Clearing console memory'
+                print('Clearing console memory')
                 ans = 'y'
             if ans == 'y' :
                 self.station.clear_history()
                 v = self.station.get_fixed_block(['data_count'], True)
-                print "Records in memory:", v
+                print("Records in memory:", v)
             elif ans == 'n':
-                print "Clear memory cancelled."
+                print("Clear memory cancelled.")
 
     def set_interval(self, interval, prompt):
         v = self.station.get_fixed_block(['read_period'], True)
         ans = None
         while ans not in ['y', 'n']:
-            print "Interval is", v
+            print("Interval is", v)
             if prompt:
                 ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
             else:
-                print "Setting interval to %d minutes" % interval
+                print("Setting interval to %d minutes" % interval)
                 ans = 'y'
             if ans == 'y' :
                 self.station.set_read_period(interval)
                 v = self.station.get_fixed_block(['read_period'], True)
-                print "Interval is now", v
+                print("Interval is now", v)
             elif ans == 'n':
-                print "Set interval cancelled."
+                print("Set interval cancelled.")
 
     def set_clock(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.get_fixed_block(['date_time'], True)
-            print "Station clock is", v
+            print("Station clock is", v)
             now = datetime.datetime.now()
             if prompt:
                 ans = raw_input("Set station clock to %s (y/n)? " % now)
             else:
-                print "Setting station clock to %s" % now
+                print("Setting station clock to %s" % now)
                 ans = 'y'
             if ans == 'y' :
                 self.station.set_clock()
                 v = self.station.get_fixed_block(['date_time'], True)
-                print "Station clock is now", v
+                print("Station clock is now", v)
             elif ans == 'n':
-                print "Set clock cancelled."
+                print("Set clock cancelled.")
 
 
 # these are the raw data we get from the station:

--- a/bin/weewx/drivers/simulator.py
+++ b/bin/weewx/drivers/simulator.py
@@ -276,4 +276,4 @@ class SimulatorConfEditor(weewx.drivers.AbstractConfEditor):
 if __name__ == "__main__":
     station = Simulator(mode='simulator',loop_interval=2.0)
     for packet in station.genLoopPackets():
-        print weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet
+        print((weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet))

--- a/bin/weewx/drivers/te923.py
+++ b/bin/weewx/drivers/te923.py
@@ -807,50 +807,50 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
 
     @staticmethod
     def show_info(station, fmt='dict'):
-        print 'Querying the station for the configuration...'
+        print('Querying the station for the configuration...')
         data = station.get_config()
         TE923Configurator.print_data(data, fmt)
 
     @staticmethod
     def show_current(station, fmt='dict'):
-        print 'Querying the station for current weather data...'
+        print('Querying the station for current weather data...')
         data = station.get_readings()
         TE923Configurator.print_data(data, fmt)
 
     @staticmethod
     def show_history(station, ts=0, count=None, fmt='dict'):
-        print "Querying the station for historical records..."
+        print("Querying the station for historical records...")
         for r in station.gen_records(ts, count):
             TE923Configurator.print_data(r, fmt)
 
     @staticmethod
     def show_minmax(station):
-        print "Querying the station for historical min/max data"
+        print("Querying the station for historical min/max data")
         data = station.get_minmax()
-        print "Console Temperature Min : %s" % data['t_in_min']
-        print "Console Temperature Max : %s" % data['t_in_max']
-        print "Console Humidity Min    : %s" % data['h_in_min']
-        print "Console Humidity Max    : %s" % data['h_in_max']
+        print(("Console Temperature Min : %s" % data['t_in_min']))
+        print(("Console Temperature Max : %s" % data['t_in_max']))
+        print(("Console Humidity Min    : %s" % data['h_in_min']))
+        print(("Console Humidity Max    : %s" % data['h_in_max']))
         for i in range(1, 6):
-            print "Channel %d Temperature Min : %s" % (i, data['t_%d_min' % i])
-            print "Channel %d Temperature Max : %s" % (i, data['t_%d_max' % i])
-            print "Channel %d Humidity Min    : %s" % (i, data['h_%d_min' % i])
-            print "Channel %d Humidity Max    : %s" % (i, data['h_%d_max' % i])
-        print "Wind speed max since midnight : %s" % data['windspeed_max']
-        print "Wind gust max since midnight  : %s" % data['windgust_max']
-        print "Rain yesterday  : %s" % data['rain_yesterday']
-        print "Rain this week  : %s" % data['rain_week']
-        print "Rain this month : %s" % data['rain_month']
-        print "Last Barometer reading : %s" % time.strftime(
-            "%Y %b %d %H:%M", time.localtime(data['barometer_ts']))
+            print(("Channel %d Temperature Min : %s" % (i, data['t_%d_min' % i])))
+            print(("Channel %d Temperature Max : %s" % (i, data['t_%d_max' % i])))
+            print(("Channel %d Humidity Min    : %s" % (i, data['h_%d_min' % i])))
+            print(("Channel %d Humidity Max    : %s" % (i, data['h_%d_max' % i])))
+        print(("Wind speed max since midnight : %s" % data['windspeed_max']))
+        print(("Wind gust max since midnight  : %s" % data['windgust_max']))
+        print(("Rain yesterday  : %s" % data['rain_yesterday']))
+        print(("Rain this week  : %s" % data['rain_week']))
+        print(("Rain this month : %s" % data['rain_month']))
+        print(("Last Barometer reading : %s" % time.strftime(
+            "%Y %b %d %H:%M", time.localtime(data['barometer_ts']))))
         for i in range(25):
-            print "   T-%02d Hours : %.1f" % (i, data['barometer_%d' % i])
+            print(("   T-%02d Hours : %.1f" % (i, data['barometer_%d' % i])))
 
     @staticmethod
     def show_date(station):
         ts = station.get_date()
         tt = time.localtime(ts)
-        print "Date: %02d/%02d/%d" % (tt[2], tt[1], tt[0])
+        print(("Date: %02d/%02d/%d" % (tt[2], tt[1], tt[0])))
         TE923Configurator.print_alignment()
 
     @staticmethod
@@ -858,16 +858,16 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
         if datestr is not None:
             date_list = datestr.split(',')
             if len(date_list) != 3:
-                print "Bad date '%s', format is YEAR,MONTH,DAY" % datestr
+                print(("Bad date '%s', format is YEAR,MONTH,DAY" % datestr))
                 return
             if int(date_list[0]) < 2000 or int(date_list[0]) > 2099:
-                print "Year must be between 2000 and 2099 inclusive"
+                print("Year must be between 2000 and 2099 inclusive")
                 return
             if int(date_list[1]) < 1 or int(date_list[1]) > 12:
-                print "Month must be between 1 and 12 inclusive"
+                print("Month must be between 1 and 12 inclusive")
                 return
             if int(date_list[2]) < 1 or int(date_list[2]) > 31:
-                print "Day must be between 1 and 31 inclusive"
+                print("Day must be between 1 and 31 inclusive")
                 return
             tt = time.localtime()
             offset = 1 if tt[3] < 12 else 0
@@ -879,17 +879,17 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
 
     def show_location(self, station, loc_type):
         data = station.get_loc(loc_type)
-        print "City     : %s (%s)" % (self.city_dict[data['city_time']][9],
-                                      self.city_dict[data['city_time']][0])
+        print(("City     : %s (%s)" % (self.city_dict[data['city_time']][9],
+                                      self.city_dict[data['city_time']][0])))
         degree_sign= u'\N{DEGREE SIGN}'.encode('iso-8859-1')
-        print "Location : %03d%s%02d'%s %02d%s%02d'%s" % (
+        print(("Location : %03d%s%02d'%s %02d%s%02d'%s" % (
             data['long_deg'], degree_sign, data['long_min'], data['long_dir'],
-            data['lat_deg'], degree_sign, data['lat_min'], data['lat_dir'])
+            data['lat_deg'], degree_sign, data['lat_min'], data['lat_dir'])))
         if data['dst_always_on']:
-            print "DST      : Always on"
+            print("DST      : Always on")
         else:
-            print "DST      : %s (%s)" % (self.dst_dict[data['dst']][1],
-                                          self.dst_dict[data['dst']][0])
+            print(("DST      : %s (%s)" % (self.dst_dict[data['dst']][1],
+                                          self.dst_dict[data['dst']][0])))
 
     def set_location(self, station, loc_type, location):
         dst_on = 1
@@ -902,7 +902,7 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
                     city_index = idx
                     break
             if city_index is None:
-                print "City code '%s' not recognized - consult station manual for valid city codes" % location_list[0]
+                print(("City code '%s' not recognized - consult station manual for valid city codes" % location_list[0]))
                 return
             long_deg = self.city_dict[city_index][6]
             long_min = self.city_dict[city_index][7]
@@ -916,32 +916,32 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             dst_index = self.city_dict[city_index][2]
         elif len(location_list) == 9 and location_list[0] == "USR":
             if int(location_list[1]) < 0 or int(location_list[1]) > 180:
-                print "Longitude degrees must be between 0 and 180 inclusive"
+                print("Longitude degrees must be between 0 and 180 inclusive")
                 return
             if int(location_list[2]) < 0 or int(location_list[2]) > 180:
-                print "Longitude minutes must be between 0 and 59 inclusive"
+                print("Longitude minutes must be between 0 and 59 inclusive")
                 return
             if location_list[3] != "E" and location_list[3] != "W":
-                print "Longitude direction must be E or W"
+                print("Longitude direction must be E or W")
                 return
             if int(location_list[4]) < 0 or int(location_list[4]) > 180:
-                print "Latitude degrees must be between 0 and 90 inclusive"
+                print("Latitude degrees must be between 0 and 90 inclusive")
                 return
             if int(location_list[5]) < 0 or int(location_list[5]) > 180:
-                print "Latitude minutes must be between 0 and 59 inclusive"
+                print("Latitude minutes must be between 0 and 59 inclusive")
                 return
             if location_list[6] != "N" and location_list[6] != "S":
-                print "Longitude direction must be N or S"
+                print("Longitude direction must be N or S")
                 return
             tz_list = location_list[7].split(':')
             if len(tz_list) != 2:
-                print "Bad timezone '%s', format is HOUR:MINUTE" % location_list[7]
+                print(("Bad timezone '%s', format is HOUR:MINUTE" % location_list[7]))
                 return
             if int(tz_list[0]) < -12 or int(tz_list[0]) > 12:
-                print "Timezone hour must be between -12 and 12 inclusive"
+                print("Timezone hour must be between -12 and 12 inclusive")
                 return
             if int(tz_list[1]) != 0 and int(tz_list[1]) != 30:
-                print "Timezone minute must be 0 or 30"
+                print("Timezone minute must be 0 or 30")
                 return
             if location_list[8].lower() != 'on':
                 dst_on = 0
@@ -951,7 +951,7 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
                         dst_index = idx
                         break
                 if dst_index is None:
-                    print "DST code '%s' not recognized - consult station manual for valid DST codes" % location_list[8]
+                    print(("DST code '%s' not recognized - consult station manual for valid DST codes" % location_list[8]))
                     return
             else:
                 dst_on = 1
@@ -966,8 +966,8 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             tz_hr = int(tz_list[0])
             tz_min = int(tz_list[1])
         else:
-            print "Bad location '%s'" % location
-            print "Location format is: %s" % self.LOCSTR
+            print(("Bad location '%s'" % location))
+            print(("Location format is: %s" % self.LOCSTR))
             return
         station.set_loc(loc_type, city_index, dst_on, dst_index, tz_hr, tz_min,
                         lat_deg, lat_min, lat_dir,
@@ -976,98 +976,98 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
     @staticmethod
     def show_altitude(station):
         altitude = station.get_alt()
-        print "Altitude: %d meters" % altitude
+        print(("Altitude: %d meters" % altitude))
 
     @staticmethod
     def set_altitude(station, altitude):
         if altitude < -200 or altitude > 5000:
-            print "Altitude must be between -200 and 5000 inclusive"
+            print("Altitude must be between -200 and 5000 inclusive")
             return
         station.set_alt(altitude)
 
     @staticmethod
     def show_alarms(station):
         data = station.get_alarms()
-        print "Weekday alarm : %02d:%02d (%s)" % (
-            data['weekday_hour'], data['weekday_min'], data['weekday_active'])
-        print "Single  alarm : %02d:%02d (%s)" % (
-            data['single_hour'], data['single_min'], data['single_active'])
-        print "Pre-alarm     : %s (%s)" % (
-            data['prealarm_period'], data['prealarm_active'])
+        print(("Weekday alarm : %02d:%02d (%s)" % (
+            data['weekday_hour'], data['weekday_min'], data['weekday_active'])))
+        print(("Single  alarm : %02d:%02d (%s)" % (
+            data['single_hour'], data['single_min'], data['single_active'])))
+        print(("Pre-alarm     : %s (%s)" % (
+            data['prealarm_period'], data['prealarm_active'])))
         if data['snooze'] > 0:
-            print "Snooze        : %d mins" % data['snooze']
+            print(("Snooze        : %d mins" % data['snooze']))
         else:
-            print "Snooze        : Invalid"
-        print "Max Temperature Alarm : %s" % data['max_temp']
-        print "Min Temperature Alarm : %s" % data['min_temp']
-        print "Rain Alarm            : %d mm (%s)" % (
-            data['rain'], data['rain_active'])
-        print "Wind Speed Alarm      : %s (%s)" % (
-            data['windspeed'], data['windspeed_active'])
-        print "Wind Gust  Alarm      : %s (%s)" % (
-            data['windgust'], data['windgust_active'])
+            print("Snooze        : Invalid")
+        print(("Max Temperature Alarm : %s" % data['max_temp']))
+        print(("Min Temperature Alarm : %s" % data['min_temp']))
+        print(("Rain Alarm            : %d mm (%s)" % (
+            data['rain'], data['rain_active'])))
+        print(("Wind Speed Alarm      : %s (%s)" % (
+            data['windspeed'], data['windspeed_active'])))
+        print(("Wind Gust  Alarm      : %s (%s)" % (
+            data['windgust'], data['windgust_active'])))
 
     @staticmethod
     def set_alarms(station, alarm):
         alarm_list = alarm.split(',')
         if len(alarm_list) != 9:
-            print "Bad alarm '%s'" % alarm
-            print "Alarm format is: %s" % TE923Configurator.ALMSTR
+            print(("Bad alarm '%s'" % alarm))
+            print(("Alarm format is: %s" % TE923Configurator.ALMSTR))
             return
         weekday = alarm_list[0]
         if weekday.lower() != 'off':
             weekday_list = weekday.split(':')
             if len(weekday_list) != 2:
-                print "Bad alarm '%s', expected HOUR:MINUTE or OFF" % weekday
+                print(("Bad alarm '%s', expected HOUR:MINUTE or OFF" % weekday))
                 return
             if int(weekday_list[0]) < 0 or int(weekday_list[0]) > 23:
-                print "Alarm hours must be between 0 and 23 inclusive"
+                print("Alarm hours must be between 0 and 23 inclusive")
                 return
             if int(weekday_list[1]) < 0 or int(weekday_list[1]) > 59:
-                print "Alarm minutes must be between 0 and 59 inclusive"
+                print("Alarm minutes must be between 0 and 59 inclusive")
                 return
         single = alarm_list[1]
         if single.lower() != 'off':
             single_list = single.split(':')
             if len(single_list) != 2:
-                print "Bad alarm '%s', expected HOUR:MINUTE or OFF" % single
+                print(("Bad alarm '%s', expected HOUR:MINUTE or OFF" % single))
                 return
             if int(single_list[0]) < 0 or int(single_list[0]) > 23:
-                print "Alarm hours must be between 0 and 23 inclusive"
+                print("Alarm hours must be between 0 and 23 inclusive")
                 return
             if int(single_list[1]) < 0 or int(single_list[1]) > 59:
-                print "Alarm minutes must be between 0 and 59 inclusive"
+                print("Alarm minutes must be between 0 and 59 inclusive")
                 return
         if alarm_list[2].lower() != 'off' and alarm_list[2] not in ['15', '30', '45', '60', '90']:
-            print "Prealarm must be 15, 30, 45, 60, 90 or OFF"
+            print("Prealarm must be 15, 30, 45, 60, 90 or OFF")
             return
         if int(alarm_list[3]) < 1 or int(alarm_list[3]) > 15:
-            print "Snooze must be between 1 and 15 inclusive"
+            print("Snooze must be between 1 and 15 inclusive")
             return
         if float(alarm_list[4]) < -50 or float(alarm_list[4]) > 70:
-            print "Temperature alarm must be between -50 and 70 inclusive"
+            print("Temperature alarm must be between -50 and 70 inclusive")
             return
         if float(alarm_list[5]) < -50 or float(alarm_list[5]) > 70:
-            print "Temperature alarm must be between -50 and 70 inclusive"
+            print("Temperature alarm must be between -50 and 70 inclusive")
             return
         if alarm_list[6].lower() != 'off' and (int(alarm_list[6]) < 1 or int(alarm_list[6]) > 9999):
-            print "Rain alarm must be between 1 and 999 inclusive or OFF"
+            print("Rain alarm must be between 1 and 999 inclusive or OFF")
             return
         if alarm_list[7].lower() != 'off' and (float(alarm_list[7]) < 1 or float(alarm_list[7]) > 199):
-            print "Wind alarm must be between 1 and 199 inclusive or OFF"
+            print("Wind alarm must be between 1 and 199 inclusive or OFF")
             return
         if alarm_list[8].lower() != 'off' and (float(alarm_list[8]) < 1 or float(alarm_list[8]) > 199):
-            print "Wind alarm must be between 1 and 199 inclusive or OFF"
+            print("Wind alarm must be between 1 and 199 inclusive or OFF")
             return
         station.set_alarms(alarm_list[0], alarm_list[1], alarm_list[2],
                            alarm_list[3], alarm_list[4], alarm_list[5],
                            alarm_list[6], alarm_list[7], alarm_list[8])
-        print "Temperature alarms can only be modified via station controls"
+        print("Temperature alarms can only be modified via station controls")
 
     @staticmethod
     def show_interval(station):
         idx = station.get_interval()
-        print "Interval: %s" % TE923Configurator.idx_to_interval.get(idx, 'unknown')
+        print(("Interval: %s" % TE923Configurator.idx_to_interval.get(idx, 'unknown')))
 
     @staticmethod
     def set_interval(station, interval):
@@ -1082,8 +1082,8 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
             except ValueError:
                 pass
         if idx is None:
-            print "Bad interval '%s'" % interval
-            print "Valid intervals are %s" % ','.join(TE923Configurator.interval_to_idx.keys())
+            print(("Bad interval '%s'" % interval))
+            print(("Valid intervals are %s" % ','.join(TE923Configurator.interval_to_idx.keys())))
             return
         station.set_interval(idx)
 
@@ -1092,17 +1092,17 @@ class TE923Configurator(weewx.drivers.AbstractConfigurator):
         if fmt.lower() == 'table':
             TE923Configurator.print_table(data)
         else:
-            print data
+            print(data)
 
     @staticmethod
     def print_table(data):
         for key in sorted(data):
-            print "%s: %s" % (key.rjust(16), data[key])
+            print(("%s: %s" % (key.rjust(16), data[key])))
 
     @staticmethod
     def print_alignment():
-        print "  If computer time is not aligned to station time then date"
-        print "  may be incorrect by 1 day"
+        print("  If computer time is not aligned to station time then date")
+        print("  may be incorrect by 1 day")
 
 
 class TE923Driver(weewx.drivers.AbstractDevice):
@@ -2339,7 +2339,7 @@ if __name__ == '__main__':
         (options, _) = parser.parse_args()
 
         if options.version:
-            print "te923 driver version %s" % DRIVER_VERSION
+            print(("te923 driver version %s" % DRIVER_VERSION))
             exit(1)
 
         if options.debug is not None:
@@ -2350,8 +2350,8 @@ if __name__ == '__main__':
         if (options.format.lower() != FMT_TE923TOOL and
             options.format.lower() != FMT_TABLE and
             options.format.lower() != FMT_DICT):
-            print "Unknown format '%s'.  Known formats include: %s" % (
-                options.format, ','.join([FMT_TE923TOOL, FMT_TABLE, FMT_DICT]))
+            print(("Unknown format '%s'.  Known formats include: %s" % (
+                options.format, ','.join([FMT_TE923TOOL, FMT_TABLE, FMT_DICT]))))
             exit(1)
 
         with TE923Station() as station:
@@ -2382,23 +2382,23 @@ if __name__ == '__main__':
         if fmt.lower() == FMT_TABLE:
             print_table(data)
         else:
-            print data
+            print(data)
 
     def print_hex(ptr, data):
-        print "0x%06x %s" % (ptr, _fmt(data))
+        print(("0x%06x %s" % (ptr, _fmt(data))))
 
     def print_table(data):
         """output entire dictionary contents in two columns"""
         for key in sorted(data):
-            print "%s: %s" % (key.rjust(16), data[key])
+            print(("%s: %s" % (key.rjust(16), data[key])))
 
     def print_status(data):
         """output status fields in te923tool format"""
-        print "0x%x:0x%x:0x%x:0x%x:0x%x:%d:%d:%d:%d:%d:%d:%d:%d" % (
+        print(("0x%x:0x%x:0x%x:0x%x:0x%x:%d:%d:%d:%d:%d:%d:%d:%d" % (
             data['version_sys'], data['version_bar'], data['version_uv'],
             data['version_rcc'], data['version_wind'],
             data['bat_rain'], data['bat_uv'], data['bat_wind'], data['bat_5'],
-            data['bat_4'], data['bat_3'], data['bat_2'], data['bat_1'])
+            data['bat_4'], data['bat_3'], data['bat_2'], data['bat_1'])))
 
     def print_readings(data):
         """output sensor readings in te923tool format"""
@@ -2417,7 +2417,7 @@ if __name__ == '__main__':
         output.append(getvalue(data, 'windgust', '%0.1f'))
         output.append(getvalue(data, 'windchill', '%0.1f'))
         output.append(getvalue(data, 'rain', '%d'))
-        print ':'.join(output)
+        print((':'.join(output)))
 
     def getvalue(data, label, fmt):
         if label + '_state' in data:

--- a/bin/weewx/drivers/ultimeter.py
+++ b/bin/weewx/drivers/ultimeter.py
@@ -347,8 +347,8 @@ class UltimeterConfEditor(weewx.drivers.AbstractConfEditor):
 """ % Station.DEFAULT_PORT
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example: /dev/ttyUSB0 or /dev/ttyS0 or /dev/cua0."
+        print("Specify the serial port on which the station is connected, for")
+        print("example: /dev/ttyUSB0 or /dev/ttyS0 or /dev/cua0.")
         port = self._prompt('port', Station.DEFAULT_PORT)
         return {'port': port}
 
@@ -376,10 +376,10 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ultimeter driver version %s" % DRIVER_VERSION
+        print(("ultimeter driver version %s" % DRIVER_VERSION))
         exit(0)
 
     with Station(options.port, debug_serial=options.debug) as station:
         station.set_logger_mode()
         while True:
-            print time.time(), _fmt(station.get_readings())
+            print((time.time(), _fmt(station.get_readings())))

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -221,7 +221,7 @@ def guard_termios(fn):
         def guarded_fn(*args, **kwargs):
             try:
                 return fn(*args, **kwargs)
-            except termios.error, e:
+            except termios.error as e:
                 raise weewx.WeeWxIOError(e)
     except ImportError:
         def guarded_fn(*args, **kwargs):
@@ -254,7 +254,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             _buffer = self.serial_port.read(chars)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on read.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             syslog.syslog(syslog.LOG_ERR, "   ****  Is there a competing process running??")
@@ -269,7 +269,7 @@ class SerialWrapper(BaseWrapper):
         import serial
         try:
             N = self.serial_port.write(data)
-        except serial.serialutil.SerialException, e:
+        except serial.serialutil.SerialException as e:
             syslog.syslog(syslog.LOG_ERR, "vantage: SerialException on write.")
             syslog.syslog(syslog.LOG_ERR, "   ****  %s" % e)
             # Reraise as a Weewx error I/O error:
@@ -316,7 +316,7 @@ class EthernetWrapper(BaseWrapper):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(self.timeout)
             self.socket.connect((self.host, self.port))
-        except (socket.error, socket.timeout, socket.herror), ex:
+        except (socket.error, socket.timeout, socket.herror) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: Socket error while opening port %d to ethernet host %s." % (self.port, self.host))
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -379,7 +379,7 @@ class EthernetWrapper(BaseWrapper):
             _N = min(4096, _remaining)
             try:
                 _recv = self.socket.recv(_N)
-            except (socket.timeout, socket.error), ex:
+            except (socket.timeout, socket.error) as ex:
                 syslog.syslog(syslog.LOG_ERR, "vantage: ip-read error: %s" % ex)
                 # Reraise as a weewx I/O error:
                 raise weewx.WeeWxIOError(ex)
@@ -398,7 +398,7 @@ class EthernetWrapper(BaseWrapper):
             # A delay of 0.0 gives socket write error; 0.01 gives no ack error; 0.05 is OK for weewx program
             # Note: a delay of 0.5 s is required for wee_device --logger=logger_info
             time.sleep(self.tcp_send_delay)
-        except (socket.timeout, socket.error), ex:
+        except (socket.timeout, socket.error) as ex:
             syslog.syslog(syslog.LOG_ERR, "vantage: ip-write error: %s" % ex)
             # Reraise as a weewx I/O error:
             raise weewx.WeeWxIOError(ex)
@@ -507,7 +507,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     # on the VP (somewhere around 220).
                     for _loop_packet in self.genDavisLoopPackets(200):
                         yield _loop_packet
-                except weewx.WeeWxIOError, e:
+                except weewx.WeeWxIOError as e:
                     syslog.syslog(syslog.LOG_ERR, "vantage: LOOP try #%d; error: %s" % (count + 1, e))
                     break
 
@@ -560,7 +560,7 @@ class Vantage(weewx.drivers.AbstractDevice):
                     yield _record
                 # The generator loop exited. We're done.
                 return
-            except weewx.WeeWxIOError, e:
+            except weewx.WeeWxIOError as e:
                 # Problem. Increment retry count
                 count += 1
                 syslog.syslog(syslog.LOG_ERR, "vantage: DMPAFT try #%d; error: %s" % (count, e))
@@ -2196,7 +2196,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setArchiveInterval(new_interval_minutes * 60)
-                    except StandardError, e:
+                    except StandardError as e:
                         print("Unable to set new archive interval. Reason:\n\t****", e, file=sys.stderr)
                     else:
                         print("Archive interval now set to %d seconds." % (station.archive_interval,))
@@ -2219,7 +2219,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setLatitude(latitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print("Unable to set new latitude. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     print("Station latitude set to %.1f degree." % latitude_dg)
@@ -2237,7 +2237,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setLongitude(longitude_dg)
-                except StandardError, e:
+                except StandardError as e:
                     print("Unable to set new longitude. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     print("Station longitude set to %.1f degree." % longitude_dg)
@@ -2323,7 +2323,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setWindCupType(new_wind_cup_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print("Unable to set new wind cup type. Reason:\n\t****", e, file=sys.stderr)
                     else:
                         print("Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size))
@@ -2349,7 +2349,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setBucketType(new_bucket_type)
-                    except StandardError, e:
+                    except StandardError as e:
                         print("Unable to set new bucket type. Reason:\n\t****", e, file=sys.stderr)
                     else:
                         print("Bucket type now set to %d." % (station.rain_bucket_type,))
@@ -2371,7 +2371,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 if ans == 'y':
                     try:
                         station.setRainYearStart(rain_year_start)
-                    except StandardError, e:
+                    except StandardError as e:
                         print("Unable to set new rain year start. Reason:\n\t****", e, file=sys.stderr)
                     else:
                         print("Rain year start now set to %d." % (station.rain_year_start,))
@@ -2404,7 +2404,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationWindDir(offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print("Unable to set new wind offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
                             print("Wind direction offset now set to %+d." % (offset))
@@ -2420,7 +2420,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationTemp(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print("Unable to set new temperature offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
                             print("Temperature offset %s now set to %+.1f." % (variable, offset))
@@ -2436,7 +2436,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     if ans == 'y':
                         try:
                             station.setCalibrationHumid(variable, offset)
-                        except StandardError, e:
+                        except StandardError as e:
                             print("Unable to set new humidity offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
                             print("Humidity offset %s now set to %+d." % (variable, offset))
@@ -2506,7 +2506,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setTransmitterType(channel, transmitter_type, extra_temp, extra_hum, repeater)
-                except StandardError, e:
+                except StandardError as e:
                     print("Unable to set transmitter type. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     print("Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
@@ -2558,7 +2558,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setRetransmit(channel)
-                except StandardError, e:
+                except StandardError as e:
                     print("Unable to set retransmit. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     if channel != 0:
@@ -2579,7 +2579,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if ans == 'y':
                 try:
                     station.setTempLogging(tempLogging)
-                except StandardError, e:
+                except StandardError as e:
                     print("Unable to set new console temperature logging. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     print("Console temperature logging set to '%s'." % (tempLogging.upper()))
@@ -2665,7 +2665,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
     def logger_summary(station, dest_path):
         try:
             dest = open(dest_path, mode="w")
-        except IOError, e:
+        except IOError as e:
             print("Unable to open destination '%s' for write" % dest_path, file=sys.stderr)
             print("Reason: %s" % e, file=sys.stderr)
             return

--- a/bin/weewx/drivers/vantage.py
+++ b/bin/weewx/drivers/vantage.py
@@ -7,6 +7,7 @@
 or VantageVue weather station"""
 
 from __future__ import with_statement
+from __future__ import print_function
 import datetime
 import struct
 import sys
@@ -83,9 +84,9 @@ class BaseWrapper(object):
                 if _resp == '\n\r':
                     syslog.syslog(syslog.LOG_DEBUG, "vantage: Rude wake up of console successful")
                     return
-                print "Unable to wake up console... sleeping"
+                print("Unable to wake up console... sleeping")
                 time.sleep(self.wait_before_retry)
-                print "Unable to wake up console... retrying"
+                print("Unable to wake up console... retrying")
             except weewx.WeeWxIOError:
                 pass
             syslog.syslog(syslog.LOG_DEBUG, "vantage: Retry  #%d failed" % count)
@@ -2018,7 +2019,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         """Query the configuration of the Vantage, printing out status
         information"""
 
-        print "Querying..."
+        print("Querying...")
         try:
             _firmware_date = station.getFirmwareDate()
         except Exception:
@@ -2031,7 +2032,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         console_time = station.getConsoleTime()
         altitude_converted = weewx.units.convert(station.altitude_vt, station.altitude_unit)[0]
     
-        print >> dest, """Davis Vantage EEPROM settings:
+        print("""Davis Vantage EEPROM settings:
     
     CONSOLE TYPE:                   %s
     
@@ -2058,7 +2059,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
              station.wind_cup_size, station.rain_bucket_size,
              station.rain_year_start, console_time,
              station.barometer_unit, station.temperature_unit,
-             station.rain_unit, station.wind_unit)
+             station.rain_unit, station.wind_unit), file=dest)
 
         try:
             (stnlat, stnlon, man_or_auto, dst, gmt_or_zone, zone_code, gmt_offset,
@@ -2071,7 +2072,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                 gmt_offset_str = "%+.1f hours" % gmt_offset
                 zone_code = 'N/A'
             on_off = "ON" if retransmit_channel else "OFF"
-            print >> dest, """    CONSOLE STATION INFO:
+            print("""    CONSOLE STATION INFO:
       Latitude (onboard):           %+0.1f\xc2\xb0
       Longitude (onboard):          %+0.1f\xc2\xb0
       Use manual or auto DST?       %s
@@ -2082,7 +2083,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
       Temperature logging:          %s
       Retransmit channel:           %s (%d)
         """ % (stnlat, stnlon, man_or_auto, dst, gmt_or_zone, zone_code, gmt_offset_str,
-               tempLogging, on_off, retransmit_channel)
+               tempLogging, on_off, retransmit_channel), file=dest)
         except:
             pass
     
@@ -2090,8 +2091,8 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         transmitter_list = None
         try:
             transmitter_list = station.getStnTransmitters()
-            print >> dest, "    TRANSMITTERS: "
-            print >> dest, "      Channel   Receive   Repeater  Type"
+            print("    TRANSMITTERS: ", file=dest)
+            print("      Channel   Receive   Repeater  Type", file=dest)
             for transmitter_id in range(0, 8):
                 comment = ""
                 transmitter_type = transmitter_list[transmitter_id]["transmitter_type"]
@@ -2106,28 +2107,28 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     comment = "(as extra humidity %d)" % transmitter_list[transmitter_id]["hum"]
                 elif transmitter_type == 'none':
                     transmitter_type = "(N/A)"
-                print >> dest, "         %d      %-8s    %-4s    %s %s" % (transmitter_id + 1, listen, repeater, transmitter_type, comment)
-            print >> dest, ""
+                print("         %d      %-8s    %-4s    %s %s" % (transmitter_id + 1, listen, repeater, transmitter_type, comment), file=dest)
+            print("", file=dest)
         except:
             pass
     
         # Add reception statistics if we can:
         try:
             _rx_list = station.getRX()
-            print >> dest, """    RECEPTION STATS:
+            print("""    RECEPTION STATS:
       Total packets received:       %d
       Total packets missed:         %d
       Number of resynchronizations: %d
       Longest good stretch:         %d
       Number of CRC errors:         %d
-      """ % _rx_list
+      """ % _rx_list, file=dest)
         except:
             pass
 
         # Add barometer calibration data if we can.
         try:
             _bar_list = station.getBarData()
-            print >> dest, """    BAROMETER CALIBRATION DATA:
+            print("""    BAROMETER CALIBRATION DATA:
       Current barometer reading:    %.3f inHg
       Altitude:                     %.0f feet
       Dew point:                    %.0f F
@@ -2137,19 +2138,19 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
       Correction constant:          %+.3f inHg
       Gain:                         %.3f
       Offset:                       %.3f
-      """ % _bar_list
+      """ % _bar_list, file=dest)
         except:
             pass
 
         # Add temperature/humidity/wind calibration if we can.
         try:
             calibration_dict = station.getStnCalibration()
-            print >> dest, """    OFFSETS:
+            print("""    OFFSETS:
       Wind direction:               %(wind)+.0f deg
       Inside Temperature:           %(inTemp)+.1f F
       Inside Humidity:              %(inHumid)+.0f %%
       Outside Temperature:          %(outTemp)+.1f F
-      Outside Humidity:             %(outHumid)+.0f %%""" % calibration_dict
+      Outside Humidity:             %(outHumid)+.0f %%""" % calibration_dict, file=dest)
             if transmitter_list is not None:
                 # Only print the calibrations for channels that we are
                 # listening to.
@@ -2158,24 +2159,24 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                         t_type = transmitter_list[t_id]["transmitter_type"]
                         if t_type in ['temp', 'temp_hum'] and \
                                 extraTemp == transmitter_list[t_id]["temp"]:
-                            print >> dest, "      Extra Temperature %d:          %+.1f F" % (extraTemp, calibration_dict["extraTemp%d" % extraTemp])
+                            print("      Extra Temperature %d:          %+.1f F" % (extraTemp, calibration_dict["extraTemp%d" % extraTemp]), file=dest)
                 for extraHumid in range(1, 8):
                     for t_id in range(0, 8):
                         t_type = transmitter_list[t_id]["transmitter_type"]
                         if t_type in ['hum', 'temp_hum'] and \
                                 extraHumid == transmitter_list[t_id]["hum"]:
-                            print >> dest, "      Extra Humidity %d:             %+.1f F" % (extraHumid, calibration_dict["extraHumid%d" % extraHumid])
+                            print("      Extra Humidity %d:             %+.1f F" % (extraHumid, calibration_dict["extraHumid%d" % extraHumid]), file=dest)
                 for t_id in range(0, 8):
                     t_type = transmitter_list[t_id]["transmitter_type"]
                     if t_type in ['soil', 'leaf_soil']:
                         for soil in range(1, 5):
-                            print >> dest, "      Soil Temperature %d:           %+.1f F" % (soil, calibration_dict["soilTemp%d" % soil])
+                            print("      Soil Temperature %d:           %+.1f F" % (soil, calibration_dict["soilTemp%d" % soil]), file=dest)
                 for t_id in range(0, 8):
                     t_type = transmitter_list[t_id]["transmitter_type"]
                     if t_type in ['leaf', 'leaf_soil']:
                         for leaf in range(1, 5):
-                            print >> dest, "      Leaf Temperature %d:           %+.1f F" % (leaf, calibration_dict["leafTemp%d" % leaf])
-            print >> dest, ""
+                            print("      Leaf Temperature %d:           %+.1f F" % (leaf, calibration_dict["leafTemp%d" % leaf]), file=dest)
+            print("", file=dest)
         except:
             raise
 
@@ -2184,28 +2185,28 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         """Set the console archive interval."""
     
         old_interval_minutes = station.archive_interval/60
-        print "Old archive interval is %d minutes, new one will be %d minutes." % (station.archive_interval/60, new_interval_minutes)
+        print("Old archive interval is %d minutes, new one will be %d minutes." % (station.archive_interval/60, new_interval_minutes))
         if old_interval_minutes == new_interval_minutes:
-            print "Old and new archive intervals are the same. Nothing done."
+            print("Old and new archive intervals are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the archive interval as well as erase all old archive records."
+                print("Proceeding will change the archive interval as well as erase all old archive records.")
                 ans = raw_input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setArchiveInterval(new_interval_minutes * 60)
                     except StandardError, e:
-                        print >> sys.stderr, "Unable to set new archive interval. Reason:\n\t****", e
+                        print("Unable to set new archive interval. Reason:\n\t****", e, file=sys.stderr)
                     else:
-                        print "Archive interval now set to %d seconds." % (station.archive_interval,)
+                        print("Archive interval now set to %d seconds." % (station.archive_interval,))
                         # The Davis documentation implies that the log is
                         # cleared after changing the archive interval, but that
                         # doesn't seem to be the case. Clear it explicitly:
                         station.clearLog()
-                        print "Archive records cleared."
+                        print("Archive records cleared.")
                 elif ans == 'n':
-                    print "Nothing done."
+                    print("Nothing done.")
 
     @staticmethod
     def set_latitude(station, latitude_dg):
@@ -2213,17 +2214,17 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set the latitude value to %.1f degree." % latitude_dg
+            print("Proceeding will set the latitude value to %.1f degree." % latitude_dg)
             ans = raw_input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setLatitude(latitude_dg)
                 except StandardError, e:
-                    print >> sys.stderr, "Unable to set new latitude. Reason:\n\t****", e
+                    print("Unable to set new latitude. Reason:\n\t****", e, file=sys.stderr)
                 else:
-                    print "Station latitude set to %.1f degree." % latitude_dg
+                    print("Station latitude set to %.1f degree." % latitude_dg)
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_longitude(station, longitude_dg):
@@ -2231,24 +2232,24 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set the longitude value to %.1f degree." % longitude_dg
+            print("Proceeding will set the longitude value to %.1f degree." % longitude_dg)
             ans = raw_input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setLongitude(longitude_dg)
                 except StandardError, e:
-                    print >> sys.stderr, "Unable to set new longitude. Reason:\n\t****", e
+                    print("Unable to set new longitude. Reason:\n\t****", e, file=sys.stderr)
                 else:
-                    print "Station longitude set to %.1f degree." % longitude_dg
+                    print("Station longitude set to %.1f degree." % longitude_dg)
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod    
     def set_altitude(station, altitude_ft):
         """Set the console station altitude"""
         ans = None
         while ans not in ['y', 'n']:    
-            print "Proceeding will set the station altitude to %.0f feet." % altitude_ft
+            print("Proceeding will set the station altitude to %.0f feet." % altitude_ft)
             ans = raw_input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 # Hit the console to get the current barometer calibration data and preserve it:
@@ -2262,7 +2263,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     # Set previous _barcal value
                     station.setBarData(_bardata[0] + _barcal, altitude_ft)
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_barometer(station, barometer_inHg):
@@ -2273,14 +2274,14 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         ans = None
         while ans not in ['y', 'n']:
             if barometer_inHg:
-                print "Proceeding will set the barometer value to %.3f and the station altitude to %.0f feet." % (barometer_inHg, _bardata[1])
+                print("Proceeding will set the barometer value to %.3f and the station altitude to %.0f feet." % (barometer_inHg, _bardata[1]))
             else:
-                print "Proceeding will have the console pick a sensible barometer calibration and set the station altitude to %.0f feet," % (_bardata[1],)
+                print("Proceeding will have the console pick a sensible barometer calibration and set the station altitude to %.0f feet," % (_bardata[1],))
             ans = raw_input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
                 station.setBarData(barometer_inHg, _bardata[1])
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def clear_memory(station):
@@ -2288,94 +2289,94 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
     
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will erase old archive records."
+            print("Proceeding will erase old archive records.")
             ans = raw_input("Are you sure you wish to proceed (y/n)? ")
             if ans == 'y':
-                print "Clearing the archive memory ..."
+                print("Clearing the archive memory ...")
                 station.clearLog()
-                print "Archive records cleared."
+                print("Archive records cleared.")
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_wind_cup(station, new_wind_cup_type):
         """Set the wind cup type on the console."""
 
         if station.hardware_type != 16:
-            print >> sys.stderr, """Unable to set new wind cup type. Reason:
+            print("""Unable to set new wind cup type. Reason:
     **** Command only valid with Vantage Pro or Vantage Pro2 station.
-    """
+    """, file=sys.stderr)
             return
 
-        print "Old rain wind cup type is %d (%s), new one is %d (%s)." % (
+        print("Old rain wind cup type is %d (%s), new one is %d (%s)." % (
             station.wind_cup_type,
             station.wind_cup_size,
             new_wind_cup_type,
-            Vantage.wind_cup_dict[new_wind_cup_type])
+            Vantage.wind_cup_dict[new_wind_cup_type]))
         if station.wind_cup_type == new_wind_cup_type:
-            print "Old and new wind cup types are the same. Nothing done."
+            print("Old and new wind cup types are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the wind cup type."
+                print("Proceeding will change the wind cup type.")
                 ans = raw_input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setWindCupType(new_wind_cup_type)
                     except StandardError, e:
-                        print >> sys.stderr, "Unable to set new wind cup type. Reason:\n\t****", e
+                        print("Unable to set new wind cup type. Reason:\n\t****", e, file=sys.stderr)
                     else:
-                        print "Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size)
+                        print("Wind cup type set to %d (%s)." % (station.wind_cup_type, station.wind_cup_size))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print("Nothing done.")
 
     @staticmethod
     def set_bucket(station, new_bucket_type):
         """Set the bucket type on the console."""
 
-        print "Old rain bucket type is %d (%s), new one is %d (%s)." % (
+        print("Old rain bucket type is %d (%s), new one is %d (%s)." % (
             station.rain_bucket_type,
             station.rain_bucket_size,
             new_bucket_type,
-            Vantage.rain_bucket_dict[new_bucket_type])
+            Vantage.rain_bucket_dict[new_bucket_type]))
         if station.rain_bucket_type == new_bucket_type:
-            print "Old and new bucket types are the same. Nothing done."
+            print("Old and new bucket types are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the rain bucket type."
+                print("Proceeding will change the rain bucket type.")
                 ans = raw_input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setBucketType(new_bucket_type)
                     except StandardError, e:
-                        print >> sys.stderr, "Unable to set new bucket type. Reason:\n\t****", e
+                        print("Unable to set new bucket type. Reason:\n\t****", e, file=sys.stderr)
                     else:
-                        print "Bucket type now set to %d." % (station.rain_bucket_type,)
+                        print("Bucket type now set to %d." % (station.rain_bucket_type,))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print("Nothing done.")
 
     @staticmethod
     def set_rain_year_start(station, rain_year_start):
 
-        print "Old rain season start is %d, new one is %d." % (station.rain_year_start, rain_year_start)
+        print("Old rain season start is %d, new one is %d." % (station.rain_year_start, rain_year_start))
 
         if station.rain_year_start == rain_year_start:
-            print "Old and new rain season starts are the same. Nothing done."
+            print("Old and new rain season starts are the same. Nothing done.")
         else:
             ans = None
             while ans not in ['y', 'n']:
-                print "Proceeding will change the rain season start."
+                print("Proceeding will change the rain season start.")
                 ans = raw_input("Are you sure you want to proceed (y/n)? ")
                 if ans == 'y':
                     try:
                         station.setRainYearStart(rain_year_start)
                     except StandardError, e:
-                        print >> sys.stderr, "Unable to set new rain year start. Reason:\n\t****", e
+                        print("Unable to set new rain year start. Reason:\n\t****", e, file=sys.stderr)
                     else:
-                        print "Rain year start now set to %d." % (station.rain_year_start,)
+                        print("Rain year start now set to %d." % (station.rain_year_start,))
                 elif ans == 'n':
-                    print "Nothing done."
+                    print("Nothing done.")
 
     @staticmethod
     def set_offset(station, offset_list):
@@ -2394,53 +2395,53 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         if variable == "windDir":
             offset = int(offset_str)
             if not -359 <= offset <= 359:
-                print >> sys.stderr, "Wind direction offset %d is out of range." % (offset)
+                print("Wind direction offset %d is out of range." % (offset), file=sys.stderr)
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for wind direction to %+d." % (offset)
+                    print("Proceeding will set offset for wind direction to %+d." % (offset))
                     ans = raw_input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationWindDir(offset)
                         except StandardError, e:
-                            print >> sys.stderr, "Unable to set new wind offset. Reason:\n\t****", e
+                            print("Unable to set new wind offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
-                            print "Wind direction offset now set to %+d." % (offset)
+                            print("Wind direction offset now set to %+d." % (offset))
         elif variable in temp_variables:
             offset = float(offset_str)
             if not -12.8 <= offset <= 12.7:
-                print >> sys.stderr, "Temperature offset %+.1f is out of range." % (offset)
+                print("Temperature offset %+.1f is out of range." % (offset), file=sys.stderr)
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for temperature %s to %.1f." % (variable, offset)
+                    print("Proceeding will set offset for temperature %s to %.1f." % (variable, offset))
                     ans = raw_input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationTemp(variable, offset)
                         except StandardError, e:
-                            print >> sys.stderr, "Unable to set new temperature offset. Reason:\n\t****", e
+                            print("Unable to set new temperature offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
-                            print "Temperature offset %s now set to %+.1f." % (variable, offset)
+                            print("Temperature offset %s now set to %+.1f." % (variable, offset))
         elif variable in humid_variables:
             offset = int(offset_str)
             if not 0 <= offset <= 100:
-                print >> sys.stderr, "Humidity offset %+d is out of range." % (offset)
+                print("Humidity offset %+d is out of range." % (offset), file=sys.stderr)
             else:
                 ans = None
                 while ans not in ['y', 'n']:
-                    print "Proceeding will set offset for humidity %s to %+d." % (variable, offset)
+                    print("Proceeding will set offset for humidity %s to %+d." % (variable, offset))
                     ans = raw_input("Are you sure you want to proceed (y/n)? ")
                     if ans == 'y':
                         try:
                             station.setCalibrationHumid(variable, offset)
                         except StandardError, e:
-                            print >> sys.stderr, "Unable to set new humidity offset. Reason:\n\t****", e
+                            print("Unable to set new humidity offset. Reason:\n\t****", e, file=sys.stderr)
                         else:
-                            print "Humidity offset %s now set to %+d." % (variable, offset)
+                            print("Humidity offset %s now set to %+d." % (variable, offset))
         else:
-            print >> sys.stderr, "Unknown variable %s" % (variable)
+            print("Unknown variable %s" % (variable), file=sys.stderr)
 
     @staticmethod
     def set_transmitter_type(station, transmitter_list):
@@ -2449,14 +2450,14 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         transmitter_list = map((lambda x: int(x) if x.isdigit() else x if x != "" else None), transmitter_list.split(','))
         channel = transmitter_list[0]
         if not 1 <= channel <= 8:
-            print "Channel number must be between 1 and 8."
+            print("Channel number must be between 1 and 8.")
             return
         
         # Check new channel against retransmit channel.
         # Warn and stop if new channel is used as retransmit channel.
         retransmit_channel = station._getEEPROM_value(0x18)[0]
         if retransmit_channel == channel:
-            print "This channel is used as retransmit channel. Please turn off retransmit function or choose another channel."
+            print("This channel is used as retransmit channel. Please turn off retransmit function or choose another channel.")
             return
         
         # Init repeater to 'no repeater'
@@ -2472,7 +2473,7 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                         repeater = key
                         break
                 if repeater == 0:
-                    print "Repeater ID must be between 'A' and 'H'."
+                    print("Repeater ID must be between 'A' and 'H'.")
                     return
         except:
             # No repeater letter
@@ -2486,32 +2487,32 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
         try:
             transmitter_type_name = station.transmitter_type_dict[transmitter_type]
         except KeyError:
-            print "Unknown transmitter type (%s)" % transmitter_type
+            print("Unknown transmitter type (%s)" % transmitter_type)
             return
         
         if transmitter_type_name in ['temp', 'temp_hum'] and extra_temp not in range(1, 8):
-            print "Transmitter type %s requires extra_temp in range 1-7'" % transmitter_type_name
+            print("Transmitter type %s requires extra_temp in range 1-7'" % transmitter_type_name)
             return
         
         if transmitter_type_name in ['hum', 'temp_hum'] and extra_hum not in range(1, 8):
-            print "Transmitter type %s requires extra_hum in range 1-7'" % transmitter_type_name
+            print("Transmitter type %s requires extra_hum in range 1-7'" % transmitter_type_name)
             return
         
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will set channel %d to type %d (%s), repeater: %s, %s." % (
-                channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx])
+            print("Proceeding will set channel %d to type %d (%s), repeater: %s, %s." % (
+                channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx]))
             ans = raw_input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setTransmitterType(channel, transmitter_type, extra_temp, extra_hum, repeater)
                 except StandardError, e:
-                    print >> sys.stderr, "Unable to set transmitter type. Reason:\n\t****", e
+                    print("Unable to set transmitter type. Reason:\n\t****", e, file=sys.stderr)
                 else:
-                    print "Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
-                        channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx])
+                    print("Transmitter type for channel %d set to %d (%s), repeater: %s, %s." % (
+                        channel, transmitter_type, transmitter_type_name, station.repeater_dict[repeater], station.listen_dict[usetx]))
             else:
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_retransmit(station, channel_on_off):
@@ -2525,13 +2526,13 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             if len(channel_on_off_list) > 1:
                 channel = map((lambda x: int(x) if x != "" else None), channel_on_off_list[1])[0]
                 if not 0 < channel < 9:
-                    print "Channel out of range 1..8. Nothing done."
+                    print("Channel out of range 1..8. Nothing done.")
                     return
         
             transmitter_list = station.getStnTransmitters()
             if channel != 0:
                 if transmitter_list[channel-1]["listen"] == "active":
-                    print "Channel %d in use. Please select another channel. Nothing done." % channel
+                    print("Channel %d in use. Please select another channel. Nothing done." % channel)
                     return
             else:
                 for i in range(0, 7):
@@ -2539,33 +2540,33 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                         channel = i+1
                         break
             if channel == 0:
-                print "All Channels in use. Retransmit can't be enabled. Nothing done."
+                print("All Channels in use. Retransmit can't be enabled. Nothing done.")
                 return
     
         old_channel = station._getEEPROM_value(0x18)[0]
         if old_channel == channel:
-            print "Old and new retransmit settings are the same. Nothing done."
+            print("Old and new retransmit settings are the same. Nothing done.")
             return
         
         ans = None
         while ans not in ['y', 'n']:
             if channel != 0:
-                print "Proceeding will set retransmit to 'ON' at channel: %d." % channel
+                print("Proceeding will set retransmit to 'ON' at channel: %d." % channel)
             else:
-                print "Proceeding will set retransmit to 'OFF'."
+                print("Proceeding will set retransmit to 'OFF'.")
             ans = raw_input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setRetransmit(channel)
                 except StandardError, e:
-                    print >> sys.stderr, "Unable to set retransmit. Reason:\n\t****", e
+                    print("Unable to set retransmit. Reason:\n\t****", e, file=sys.stderr)
                 else:
                     if channel != 0:
-                        print "Retransmit set to 'ON' at channel: %d." % channel
+                        print("Retransmit set to 'ON' at channel: %d." % channel)
                     else:
-                        print "Retransmit set to 'OFF'."
+                        print("Retransmit set to 'OFF'.")
             else:
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_temp_logging(station, tempLogging):
@@ -2573,36 +2574,36 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
 
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will change the console temperature logging to '%s'." % (tempLogging.upper())
+            print("Proceeding will change the console temperature logging to '%s'." % (tempLogging.upper()))
             ans = raw_input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 try:
                     station.setTempLogging(tempLogging)
                 except StandardError, e:
-                    print >> sys.stderr, "Unable to set new console temperature logging. Reason:\n\t****", e
+                    print("Unable to set new console temperature logging. Reason:\n\t****", e, file=sys.stderr)
                 else:
-                    print "Console temperature logging set to '%s'." % (tempLogging.upper())
+                    print("Console temperature logging set to '%s'." % (tempLogging.upper()))
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def set_time(station):
-        print "Setting time on console..."
+        print("Setting time on console...")
         station.setTime()
         newtime_ts = station.getTime()
-        print "Current console time is %s" % weeutil.weeutil.timestamp_to_string(newtime_ts)
+        print("Current console time is %s" % weeutil.weeutil.timestamp_to_string(newtime_ts))
 
     @staticmethod
     def set_dst(station, dst):
         station.setDST(dst) 
-        print "Set DST on console to '%s'" % dst
+        print("Set DST on console to '%s'" % dst)
 
     @staticmethod
     def set_tz_code(station, tz_code):
-        print "Setting time zone code to %d..." % tz_code
+        print("Setting time zone code to %d..." % tz_code)
         station.setTZcode(tz_code)
         new_tz_code = station.getStnInfo()[5]
-        print "Set time zone code to %s" % new_tz_code
+        print("Set time zone code to %s" % new_tz_code)
 
     @staticmethod
     def set_tz_offset(station, tz_offset):
@@ -2616,31 +2617,31 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
             offset = -offset
         station.setTZoffset(offset)
         new_offset = station.getStnInfo()[6]
-        print "Set time zone offset to %+.1f hours" % new_offset
+        print("Set time zone offset to %+.1f hours" % new_offset)
 
     @staticmethod
     def set_lamp(station, onoff):
-        print "Setting lamp on console..."
+        print("Setting lamp on console...")
         station.setLamp(onoff)
 
     @staticmethod
     def start_logger(station):
-        print "Starting logger ..."
+        print("Starting logger ...")
         station.startLogger()
-        print "Logger started"
+        print("Logger started")
 
     @staticmethod
     def stop_logger(station):
-        print "Stopping logger ..."
+        print("Stopping logger ...")
         station.stopLogger()
-        print "Logger stopped"
+        print("Logger stopped")
 
     @staticmethod
     def dump_logger(station, config_dict):
         import weewx.manager
         ans = None
         while ans not in ['y', 'n']:
-            print "Proceeding will dump all data in the logger."
+            print("Proceeding will dump all data in the logger.")
             ans = raw_input("Are you sure you want to proceed (y/n)? ")
             if ans == 'y':
                 with weewx.manager.open_manager_with_config(config_dict, 'wx_binding',
@@ -2649,41 +2650,41 @@ class VantageConfigurator(weewx.drivers.AbstractConfigurator):
                     # Wrap the Vantage generator function in a converter, which will convert the units to the
                     # same units used by the database:
                     converted_generator = weewx.units.GenWithConvert(station.genArchiveDump(), archive.std_unit_system)
-                    print "Starting dump ..."
+                    print("Starting dump ...")
                     for record in converted_generator:
                         archive.addRecord(record)
                         nrecs += 1
                         if nrecs % 10 == 0:
-                            print >> sys.stdout, "Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(record['dateTime'])),
+                            print("Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(record['dateTime'])), end=' ', file=sys.stdout)
                             sys.stdout.flush()
-                    print "\nFinished dump. %d records added" % (nrecs,)
+                    print("\nFinished dump. %d records added" % (nrecs,))
             elif ans == 'n':
-                print "Nothing done."
+                print("Nothing done.")
 
     @staticmethod
     def logger_summary(station, dest_path):
         try:
             dest = open(dest_path, mode="w")
         except IOError, e:
-            print >> sys.stderr, "Unable to open destination '%s' for write" % dest_path
-            print >> sys.stderr, "Reason: %s" % e
+            print("Unable to open destination '%s' for write" % dest_path, file=sys.stderr)
+            print("Reason: %s" % e, file=sys.stderr)
             return
 
         VantageConfigurator.show_info(station, dest)
     
-        print "Starting download of logger summary..."
+        print("Starting download of logger summary...")
     
         nrecs = 0
         for (page, index, y, mo, d, h, mn, time_ts) in station.genLoggerSummary():
             if time_ts:
-                print >> dest, "%4d %4d %4d | %4d-%02d-%02d %02d:%02d | %s" % (nrecs, page, index, y + 2000, mo, d, h, mn, weeutil.weeutil.timestamp_to_string(time_ts))
+                print("%4d %4d %4d | %4d-%02d-%02d %02d:%02d | %s" % (nrecs, page, index, y + 2000, mo, d, h, mn, weeutil.weeutil.timestamp_to_string(time_ts)), file=dest)
             else:
-                print >> dest, "%4d %4d %4d [*** Unused index ***]" % (nrecs, page, index)
+                print("%4d %4d %4d [*** Unused index ***]" % (nrecs, page, index), file=dest)
             nrecs += 1
             if nrecs % 10 == 0:
-                print >> sys.stdout, "Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(time_ts)),
+                print("Records processed: %d; Timestamp: %s\r" % (nrecs, weeutil.weeutil.timestamp_to_string(time_ts)), end=' ', file=sys.stdout)
                 sys.stdout.flush()
-        print "\nFinished download of logger summary to file '%s'. %d records processed." % (dest_path, nrecs)
+        print("\nFinished download of logger summary to file '%s'. %d records processed." % (dest_path, nrecs))
 
 
 # =============================================================================
@@ -2750,18 +2751,18 @@ class VantageConfEditor(weewx.drivers.AbstractConfEditor):
 
     def prompt_for_settings(self):
         settings = dict()
-        print "Specify the hardware interface, either 'serial' or 'ethernet'."
-        print "If the station is connected by serial, USB, or serial-to-USB"
-        print "adapter, specify serial.  Specify ethernet for stations with"
-        print "WeatherLinkIP interface."
+        print("Specify the hardware interface, either 'serial' or 'ethernet'.")
+        print("If the station is connected by serial, USB, or serial-to-USB")
+        print("adapter, specify serial.  Specify ethernet for stations with")
+        print("WeatherLinkIP interface.")
         settings['type'] = self._prompt('type', 'serial', ['serial', 'ethernet'])
         if settings['type'] == 'serial':
-            print "Specify a port for stations with a serial interface, for"
-            print "example /dev/ttyUSB0 or /dev/ttyS0."
+            print("Specify a port for stations with a serial interface, for")
+            print("example /dev/ttyUSB0 or /dev/ttyS0.")
             settings['port'] = self._prompt('port', '/dev/ttyUSB0')
         else:
-            print "Specify the IP address (e.g., 192.168.0.10) or hostname"
-            print "(e.g., console or console.example.com) for stations with"
-            print "an ethernet interface."
+            print("Specify the IP address (e.g., 192.168.0.10) or hostname")
+            print("(e.g., console or console.example.com) for stations with")
+            print("an ethernet interface.")
             settings['host'] = self._prompt('host')
         return settings

--- a/bin/weewx/drivers/wmr100.py
+++ b/bin/weewx/drivers/wmr100.py
@@ -439,8 +439,8 @@ class WMR100ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate calculation to hardware."""
+        print("""
+Setting rainRate calculation to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'

--- a/bin/weewx/drivers/wmr200.py
+++ b/bin/weewx/drivers/wmr200.py
@@ -2067,8 +2067,8 @@ class WMR200ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate and windchill calculations to hardware."""
+        print("""
+Setting rainRate and windchill calculations to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'

--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -1803,9 +1803,9 @@ class WMR300ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def modify_config(self, config_dict):
-        print """
+        print("""
 Setting rainRate, windchill, heatindex calculations to hardware. 
-Dewpoint from hardware is truncated to integer so use software"""
+Dewpoint from hardware is truncated to integer so use software""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'
@@ -1837,7 +1837,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "%s driver version %s" % (DRIVER_NAME, DRIVER_VERSION)
+        print(("%s driver version %s" % (DRIVER_NAME, DRIVER_VERSION)))
         exit(0)
 
     driver_dict = {
@@ -1852,8 +1852,8 @@ if __name__ == '__main__':
     if options.get_history:
         ts = time.time() - 3600 # get last hour of data
         for pkt in stn.genStartupRecords(ts):
-            print to_sorted_string(pkt)
+            print((to_sorted_string(pkt)))
 
     if options.get_current:
         for packet in stn.genLoopPackets():
-            print to_sorted_string(packet)
+            print((to_sorted_string(packet)))

--- a/bin/weewx/drivers/wmr9x8.py
+++ b/bin/weewx/drivers/wmr9x8.py
@@ -339,7 +339,7 @@ class WMR9x8(weewx.drivers.AbstractDevice):
 
     def log_packet(self, packet):
         packet_str = ','.join(["x%x" % v for v in packet])
-        print "%d, %s, %s" % (int(time.time() + 0.5), time.asctime(), packet_str)
+        print(("%d, %s, %s" % (int(time.time() + 0.5), time.asctime(), packet_str)))
 
     @wmr9x8_registerpackettype(typecode=0x00, size=11)
     def _wmr9x8_wind_packet(self, packet):
@@ -708,14 +708,14 @@ class WMR9x8ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print("Specify the serial port on which the station is connected, for")
+        print("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', '/dev/ttyUSB0')
         return {'port': port}
 
     def modify_config(self, config_dict):
-        print """
-Setting rainRate, windchill, and dewpoint calculations to hardware."""
+        print("""
+Setting rainRate, windchill, and dewpoint calculations to hardware.""")
         config_dict.setdefault('StdWXCalculate', {})
         config_dict['StdWXCalculate'].setdefault('Calculations', {})
         config_dict['StdWXCalculate']['Calculations']['rainRate'] = 'hardware'
@@ -750,7 +750,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "WMR9x8 driver version %s" % DRIVER_VERSION
+        print(("WMR9x8 driver version %s" % DRIVER_VERSION))
         exit(0)
 
     if options.gen_packets:
@@ -759,4 +759,4 @@ if __name__ == '__main__':
         stn = WMR9x8(**stn_dict)
         
         for packet in stn.genLoopPackets():
-            print packet
+            print(packet)

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -464,20 +464,20 @@ class WS1ConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "How is the station connected? tcp, udp, or serial."
+        print("How is the station connected? tcp, udp, or serial.")
         con_mode = self._prompt('mode', 'serial')
         con_mode = con_mode.lower()
 
         if con_mode == 'serial':
-            print "Specify the serial port on which the station is connected, "
+            print("Specify the serial port on which the station is connected, ")
             "for example: /dev/ttyUSB0 or /dev/ttyS0."
             port = self._prompt('port', '/dev/ttyUSB0')
         elif con_mode == 'tcp' or con_mode == 'udp':
-            print "Specify the IP address and port of the station. For "
+            print("Specify the IP address and port of the station. For ")
             "example: 192.168.36.40:3000."
             port = self._prompt('port', '192.168.36.40:3000')
 
-        print "Specify how long to wait for a response, in seconds."
+        print("Specify how long to wait for a response, in seconds.")
         timeout = self._prompt('timeout', 3)
 
         return {'mode': con_mode, 'port': port, 'timeout': timeout}
@@ -504,9 +504,9 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ADS WS1 driver version %s" % DRIVER_VERSION
+        print(("ADS WS1 driver version %s" % DRIVER_VERSION))
         exit(0)
 
     with StationSerial(options.port) as s:
         while True:
-            print time.time(), s.get_readings()
+            print((time.time(), s.get_readings()))

--- a/bin/weewx/drivers/ws23xx.py
+++ b/bin/weewx/drivers/ws23xx.py
@@ -328,24 +328,24 @@ class WS23xxConfigurator(weewx.drivers.AbstractConfigurator):
 
     def show_info(self):
         """Query the station then display the settings."""
-        print 'Querying the station for the configuration...'
+        print('Querying the station for the configuration...')
         config = self.station.getConfig()
         for key in sorted(config):
-            print '%s: %s' % (key, config[key])
+            print(('%s: %s' % (key, config[key])))
 
     def show_current(self):
         """Get current weather observation."""
-        print 'Querying the station for current weather data...'
+        print('Querying the station for current weather data...')
         for packet in self.station.genLoopPackets():
-            print packet
+            print(packet)
             break
 
     def show_history(self, ts=None, count=0):
         """Show the indicated number of records or records since timestamp"""
-        print "Querying the station for historical records..."
+        print("Querying the station for historical records...")
         for i, r in enumerate(self.station.genArchiveRecords(since_ts=ts,
                                                              count=count)):
-            print r
+            print(r)
             if count and i > count:
                 break
 
@@ -355,54 +355,54 @@ class WS23xxConfigurator(weewx.drivers.AbstractConfigurator):
         while ans not in ['y', 'n']:
             v = self.station.getTime()
             vstr = weeutil.weeutil.timestamp_to_string(v)
-            print "Station clock is", vstr
+            print(("Station clock is", vstr))
             if prompt:
                 ans = raw_input("Set station clock (y/n)? ")
             else:
-                print "Setting station clock"
+                print("Setting station clock")
                 ans = 'y'
             if ans == 'y':
                 self.station.setTime()
                 v = self.station.getTime()
                 vstr = weeutil.weeutil.timestamp_to_string(v)
-                print "Station clock is now", vstr
+                print(("Station clock is now", vstr))
             elif ans == 'n':
-                print "Set clock cancelled."
+                print("Set clock cancelled.")
 
     def set_interval(self, interval, prompt):
-        print "Changing the interval will clear the station memory."
+        print("Changing the interval will clear the station memory.")
         v = self.station.getArchiveInterval()
         ans = None
         while ans not in ['y', 'n']:
-            print "Interval is", v
+            print(("Interval is", v))
             if prompt:
                 ans = raw_input("Set interval to %d minutes (y/n)? " % interval)
             else:
-                print "Setting interval to %d minutes" % interval
+                print(("Setting interval to %d minutes" % interval))
                 ans = 'y'
             if ans == 'y':
                 self.station.setArchiveInterval(interval)
                 v = self.station.getArchiveInterval()
-                print "Interval is now", v
+                print(("Interval is now", v))
             elif ans == 'n':
-                print "Set interval cancelled."
+                print("Set interval cancelled.")
 
     def clear_history(self, prompt):
         ans = None
         while ans not in ['y', 'n']:
             v = self.station.getRecordCount()
-            print "Records in memory:", v
+            print(("Records in memory:", v))
             if prompt:
                 ans = raw_input("Clear console memory (y/n)? ")
             else:
-                print 'Clearing console memory'
+                print('Clearing console memory')
                 ans = 'y'
             if ans == 'y':
                 self.station.clearHistory()
                 v = self.station.getRecordCount()
-                print "Records in memory:", v
+                print(("Records in memory:", v))
             elif ans == 'n':
-                print "Clear memory cancelled."
+                print("Clear memory cancelled.")
 
 
 class WS23xxDriver(weewx.drivers.AbstractDevice):
@@ -2064,14 +2064,14 @@ class WS23xxConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the serial port on which the station is connected, for"
-        print "example /dev/ttyUSB0 or /dev/ttyS0."
+        print("Specify the serial port on which the station is connected, for")
+        print("example /dev/ttyUSB0 or /dev/ttyS0.")
         port = self._prompt('port', '/dev/ttyUSB0')
         return {'port': port}
 
     def modify_config(self, config_dict):
-        print """
-Setting record_generation to software."""
+        print("""
+Setting record_generation to software.""")
         config_dict['StdArchive']['record_generation'] = 'software'
 
 
@@ -2107,7 +2107,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "ws23xx driver version %s" % DRIVER_VERSION
+        print(("ws23xx driver version %s" % DRIVER_VERSION))
         exit(1)
 
     if options.debug is not None:
@@ -2118,13 +2118,13 @@ if __name__ == '__main__':
     with WS23xx(port) as s:
         if options.readings:
             data = s.get_raw_data(SENSOR_IDS)
-            print data
+            print(data)
         if options.records is not None:
             for ts,record in s.gen_records(count=options.records):
-                print ts,record
+                print((ts,record))
         if options.measure:
             data = s.get_raw_data([options.measure])
-            print data
+            print(data)
         if options.hm:
             for m in Measure.IDS:
-                print "%s\t%s" % (m, Measure.IDS[m].name)
+                print(("%s\t%s" % (m, Measure.IDS[m].name)))

--- a/bin/weewx/drivers/ws28xx.py
+++ b/bin/weewx/drivers/ws28xx.py
@@ -1040,9 +1040,9 @@ def index_to_addr(idx):
 def print_dict(data):
     for x in sorted(data.keys()):
         if x == 'dateTime':
-            print '%s: %s' % (x, weeutil.weeutil.timestamp_to_string(data[x]))
+            print(('%s: %s' % (x, weeutil.weeutil.timestamp_to_string(data[x]))))
         else:
-            print '%s: %s' % (x, data[x])
+            print(('%s: %s' % (x, data[x])))
 
 
 class WS28xxConfEditor(weewx.drivers.AbstractConfEditor):
@@ -1064,8 +1064,8 @@ class WS28xxConfEditor(weewx.drivers.AbstractConfEditor):
 """
 
     def prompt_for_settings(self):
-        print "Specify the frequency used between the station and the"
-        print "transceiver, either 'US' (915 MHz) or 'EU' (868.3 MHz)."
+        print("Specify the frequency used between the station and the")
+        print("transceiver, either 'US' (915 MHz) or 'EU' (868.3 MHz).")
         freq = self._prompt('frequency', 'US', ['US', 'EU'])
         return {'transceiver_frequency': freq}
 
@@ -1115,30 +1115,30 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
 
     def check_transceiver(self, maxtries):
         """See if the transceiver is installed and operational."""
-        print 'Checking for transceiver...'
+        print('Checking for transceiver...')
         ntries = 0
         while ntries < maxtries:
             ntries += 1
             if self.station.transceiver_is_present():
-                print 'Transceiver is present'
+                print('Transceiver is present')
                 sn = self.station.get_transceiver_serial()
-                print 'serial: %s' % sn
+                print(('serial: %s' % sn))
                 tid = self.station.get_transceiver_id()
-                print 'id: %d (0x%04x)' % (tid, tid)
+                print(('id: %d (0x%04x)' % (tid, tid)))
                 break
-            print 'Not found (attempt %d of %d) ...' % (ntries, maxtries)
+            print(('Not found (attempt %d of %d) ...' % (ntries, maxtries)))
             time.sleep(5)
         else:
-            print 'Transceiver not responding.'
+            print('Transceiver not responding.')
 
     def pair(self, maxtries):
         """Pair the transceiver with the station console."""
-        print 'Pairing transceiver with console...'
+        print('Pairing transceiver with console...')
         maxwait = 90 # how long to wait between button presses, in seconds
         ntries = 0
         while ntries < maxtries or maxtries == 0:
             if self.station.transceiver_is_paired():
-                print 'Transceiver is paired to console'
+                print('Transceiver is paired to console')
                 break
             ntries += 1
             msg = 'Press and hold the [v] key until "PC" appears'
@@ -1146,14 +1146,14 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 msg += ' (attempt %d of %d)' % (ntries, maxtries)
             else:
                 msg += ' (attempt %d)' % ntries
-            print msg
+            print(msg)
             now = start_ts = int(time.time())
             while (now - start_ts < maxwait and
                    not self.station.transceiver_is_paired()):
                 time.sleep(5)
                 now = int(time.time())
         else:
-            print 'Transceiver not paired to console.'
+            print('Transceiver not paired to console.')
 
     def get_interval(self, maxtries):
         cfg = self.get_config(maxtries)
@@ -1173,24 +1173,24 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 start_ts = int(time.time())
             else:
                 dur = int(time.time()) - start_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print(('No data after %d seconds (press SET to sync)' % dur))
             time.sleep(30)
         return None
 
     def set_interval(self, maxtries, interval, prompt):
         """Set the station archive interval"""
-        print "This feature is not yet implemented"
+        print("This feature is not yet implemented")
 
     def show_info(self, maxtries):
         """Query the station then display the settings."""
-        print 'Querying the station for the configuration...'
+        print('Querying the station for the configuration...')
         cfg = self.get_config(maxtries)
         if cfg is not None:
             print_dict(cfg)
 
     def show_current(self, maxtries):
         """Get current weather observation."""
-        print 'Querying the station for current weather data...'
+        print('Querying the station for current weather data...')
         start_ts = None
         ntries = 0
         while ntries < maxtries or maxtries == 0:
@@ -1203,20 +1203,20 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
                 start_ts = int(time.time())
             else:
                 dur = int(time.time()) - start_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print(('No data after %d seconds (press SET to sync)' % dur))
             time.sleep(30)
 
     def show_history(self, maxtries, ts=0, count=0):
         """Display the indicated number of records or the records since the 
         specified timestamp (local time, in seconds)"""
-        print "Querying the station for historical records..."
+        print("Querying the station for historical records...")
         ntries = 0
         last_n = nrem = None
         last_ts = int(time.time())
         self.station.start_caching_history(since_ts=ts, num_rec=count)
         while nrem is None or nrem > 0:
             if ntries >= maxtries:
-                print 'Giving up after %d tries' % ntries
+                print(('Giving up after %d tries' % ntries))
                 break
             time.sleep(30)
             ntries += 1
@@ -1224,7 +1224,7 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
             n = self.station.get_num_history_scanned()
             if n == last_n:
                 dur = now - last_ts
-                print 'No data after %d seconds (press SET to sync)' % dur
+                print(('No data after %d seconds (press SET to sync)' % dur))
             else:
                 ntries = 0
                 last_ts = now
@@ -1238,10 +1238,10 @@ class WS28xxConfigurator(weewx.drivers.AbstractConfigurator):
         self.station.stop_caching_history()
         records = self.station.get_history_cache_records()
         self.station.clear_history_cache()
-        print
-        print 'Found %d records' % len(records)
+        print()
+        print(('Found %d records' % len(records)))
         for r in records:
-            print r
+            print(r)
 
 
 class WS28xxDriver(weewx.drivers.AbstractDevice):

--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -707,11 +707,11 @@ class StdPrint(StdService):
         
     def new_loop_packet(self, event):
         """Print out the new LOOP packet"""
-        print "LOOP:  ", weeutil.weeutil.timestamp_to_string(event.packet['dateTime']), to_sorted_string(event.packet)
+        print(("LOOP:  ", weeutil.weeutil.timestamp_to_string(event.packet['dateTime']), to_sorted_string(event.packet)))
     
     def new_archive_record(self, event):
         """Print out the new archive record."""
-        print "REC:   ", weeutil.weeutil.timestamp_to_string(event.record['dateTime']), to_sorted_string(event.record)
+        print(("REC:   ", weeutil.weeutil.timestamp_to_string(event.record['dateTime']), to_sorted_string(event.record)))
 
 
 #==============================================================================

--- a/bin/weewx/manager.py
+++ b/bin/weewx/manager.py
@@ -5,6 +5,7 @@
 #
 """Classes and functions for interfacing with a weewx archive."""
 from __future__ import with_statement
+from __future__ import print_function
 import math
 import syslog
 import sys
@@ -1057,8 +1058,8 @@ def drop_database_with_config(config_dict, data_binding,
 
 def show_progress(nrec, last_time):
     """Utility function to show our progress while backfilling"""
-    print >>sys.stdout, "Records processed: %d; Last date: %s\r" % \
-        (nrec, weeutil.weeutil.timestamp_to_string(last_time)),
+    print("Records processed: %d; Last date: %s\r" % \
+        (nrec, weeutil.weeutil.timestamp_to_string(last_time)), end=' ', file=sys.stdout)
     sys.stdout.flush()
         
 class DaySummaryManager(Manager):
@@ -1617,7 +1618,7 @@ if __name__ == '__main__':
 #     nrecs, ndays = mgr.backfill_day_summary(start_d, stop_d)
     nrecs, ndays = mgr.backfill_day_summary(None, None)
     t2 = time.time()
-    print nrecs, ndays, t2-t1
+    print(nrecs, ndays, t2-t1)
     
     import doctest
 

--- a/bin/weewx/test/gen_fake_data.py
+++ b/bin/weewx/test/gen_fake_data.py
@@ -91,7 +91,7 @@ def configDatabase(config_dict, binding, start_ts=start_ts, stop_ts=stop_ts, int
                                          annual_phase_offset=annual_phase_offset,
                                          weather_phase_offset=weather_phase_offset))
         t2 = time.time()
-        print "\nTime to create synthetic archive database = %6.2fs" % (t2-t1,)
+        print(("\nTime to create synthetic archive database = %6.2fs" % (t2-t1,)))
         
     with weewx.manager.open_manager_with_config(config_dict, binding, initialize=True) as archive:
 
@@ -103,9 +103,9 @@ def configDatabase(config_dict, binding, start_ts=start_ts, stop_ts=stop_ts, int
         nrecs, ndays = archive.backfill_day_summary()
         tdiff = time.time() - t1
         if nrecs:
-            print "\nProcessed %d records to backfill %d day summaries in %.2f seconds" % (nrecs, ndays, tdiff)
+            print(("\nProcessed %d records to backfill %d day summaries in %.2f seconds" % (nrecs, ndays, tdiff)))
         else:
-            print "Daily summaries up to date."
+            print("Daily summaries up to date.")
 
     
 def genFakeRecords(start_ts=start_ts, stop_ts=stop_ts, interval=interval, 

--- a/bin/weewx/test/test_daily.py
+++ b/bin/weewx/test/test_daily.py
@@ -7,6 +7,7 @@
 """Unit test module weewx.wxstats"""
 
 from __future__ import with_statement
+from __future__ import print_function
 import datetime
 import math
 import os.path
@@ -69,9 +70,9 @@ class Common(unittest.TestCase):
             shutil.rmtree(test_html_dir)
         except OSError, e:
             if os.path.exists(test_html_dir):
-                print >>sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
-                print >>sys.stderr, "Reason:", e
-                print >>sys.stderr, "Aborting"
+                print("\nUnable to remove old test directory %s", test_html_dir, file=sys.stderr)
+                print("Reason:", e, file=sys.stderr)
+                print("Aborting", file=sys.stderr)
                 exit(1)
 
         # This will generate the test databases if necessary:

--- a/bin/weewx/test/test_sim.py
+++ b/bin/weewx/test/test_sim.py
@@ -6,6 +6,7 @@
 """Test the accumulators by using the simulator wx station"""
 
 from __future__ import with_statement
+from __future__ import print_function
 import sys
 import syslog
 import time
@@ -66,7 +67,7 @@ class Common(unittest.TestCase):
         try:
             with weewx.manager.open_manager_with_config(self.config_dict, 'wx_binding') as dbmanager:
                 if dbmanager.firstGoodStamp() == first_ts and dbmanager.lastGoodStamp() == last_ts:
-                    print "\nSimulator need not be run"
+                    print("\nSimulator need not be run")
                     return 
         except weedb.OperationalError:
             pass
@@ -107,7 +108,7 @@ class Stopper(weewx.engine.StdService):
         self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)
         
     def new_archive_record(self, event):
-        print >>sys.stdout, "Archive record %s" % (weeutil.weeutil.timestamp_to_string(event.record['dateTime']))
+        print("Archive record %s" % (weeutil.weeutil.timestamp_to_string(event.record['dateTime'])), file=sys.stdout)
         sys.stdout.flush()
         if event.record['dateTime'] >= self.last_ts:
             raise weewx.StopNow("Time to stop!")

--- a/bin/weewx/test/test_templates.py
+++ b/bin/weewx/test/test_templates.py
@@ -6,6 +6,7 @@
 #
 """Test tag notation for template generation."""
 from __future__ import with_statement
+from __future__ import print_function
 import locale
 import os.path
 import shutil
@@ -91,9 +92,9 @@ class Common(unittest.TestCase):
             shutil.rmtree(test_html_dir)
         except OSError, e:
             if os.path.exists(test_html_dir):
-                print >> sys.stderr, "\nUnable to remove old test directory %s", test_html_dir
-                print >> sys.stderr, "Reason:", e
-                print >> sys.stderr, "Aborting"
+                print("\nUnable to remove old test directory %s", test_html_dir, file=sys.stderr)
+                print("Reason:", e, file=sys.stderr)
+                print("Aborting", file=sys.stderr)
                 exit(1)
 
         # This will generate the test databases if necessary:
@@ -106,7 +107,7 @@ class Common(unittest.TestCase):
         
         # The generation time should be the same as the last record in the test database:
         testtime_ts = gen_fake_data.stop_ts
-        print "\ntest time is ", weeutil.weeutil.timestamp_to_string(testtime_ts)
+        print("\ntest time is ", weeutil.weeutil.timestamp_to_string(testtime_ts))
 
         stn_info = weewx.station.StationInfo(**self.config_dict['Station'])
         
@@ -125,9 +126,9 @@ class Common(unittest.TestCase):
         t.config_dict['StdReport']['SKIN_ROOT'] = os.path.join(test_dir, 'test_skins')
         
         # Although the report engine inherits from Thread, we can just run it in the main thread:
-        print "Starting report engine test"
+        print("Starting report engine test")
         t.run()
-        print "Done."
+        print("Done.")
         
         test_html_dir = os.path.join(t.config_dict['WEEWX_ROOT'], t.config_dict['StdReport']['HTML_ROOT'])
         expected_dir  = os.path.join(test_dir, 'expected')
@@ -156,7 +157,7 @@ class Common(unittest.TestCase):
                     self.assertEqual(actual_line, expected_line, msg="%s[%d]:\n%r vs\n%r" % 
                                      (actual_filename_abs, n, actual_line, expected_line))
                 
-                print "Checked %d lines" % (n,)
+                print("Checked %d lines" % (n,))
 
 class TestSqlite(Common):
 

--- a/bin/weewx/uwxutils.py
+++ b/bin/weewx/uwxutils.py
@@ -525,4 +525,4 @@ if __name__ == "__main__":
     import doctest
 
     if not doctest.testmod().failed:
-        print "PASSED"
+        print("PASSED")

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -48,6 +48,8 @@ considered the same. Epsilon can be specified on the command line.
 Now tries up to max_tries times to publish to the WU before giving up.
 """
 
+from __future__ import print_function
+
 import csv
 import datetime
 import optparse
@@ -131,7 +133,7 @@ def main() :
     
     # get our config file
     config_fn, config_dict = weecfg.read_config(options.config, args)
-    print "Using configuration file %s." % config_fn
+    print("Using configuration file %s." % config_fn)
     wlog.slog(syslog.LOG_INFO, "Using weewx configuration file %s." % config_fn)
 
     # Retrieve the station ID and password from the config file
@@ -146,15 +148,15 @@ def main() :
     
     # exit if any essential arguments are not present
     if not options.station or (not options.password and not options.simulate):
-        print "Missing argument(s).\n"
-        print parser.parse_args(["--help"])
+        print("Missing argument(s).\n")
+        print(parser.parse_args(["--help"]))
         wlog.slog(syslog.LOG_ERR, "Missing argument(s). Wunderfixer exiting.")
         exit()
 
     # get our binding and database and say what we are using
     db_binding = options.binding
     database = config_dict['DataBindings'][db_binding]['database']
-    print "Using database binding '%s', which is bound to database '%s'" % (db_binding, database)
+    print("Using database binding '%s', which is bound to database '%s'" % (db_binding, database))
     wlog.slog(syslog.LOG_INFO, "Using database binding '%s', which is bound to database '%s'" % (db_binding, database))
 
     # get the manager object for our db_binding
@@ -178,8 +180,8 @@ def main() :
     epsilon = options.epsilon
     
     if options.verbose:
-        print "Weather Underground Station:  ", options.station
-        print "Date to check:                ", date_date
+        print("Weather Underground Station:  ", options.station)
+        print("Date to check:                ", date_date)
         wlog.slog(syslog.LOG_INFO, "Checking Weather Underground station '%s' data for date %s" % (options.station, date_date))
 
 
@@ -187,7 +189,7 @@ def main() :
     archive_results = getArchiveDayTimeStamps(dbmanager_t, date_date)
 
     if options.verbose :
-        print "Number of archive records:    ", len(archive_results)
+        print("Number of archive records:    ", len(archive_results))
 
     # Get a WunderStation object so we can interact with Weather Underground
     wunder = WunderStation(queue=None,  # Bogus queue. We will not be using it.
@@ -206,7 +208,7 @@ def main() :
         exit("Could not get Weather Underground data. Exiting.")
         
     if options.verbose :
-        print "Number of WU records:         ", len(wunder_results)
+        print("Number of WU records:         ", len(wunder_results))
     wlog.slog(syslog.LOG_DEBUG, "Found %d archive records and %d WU records" % (len(archive_results), len(wunder_results)))
 
     #===========================================================================
@@ -218,8 +220,8 @@ def main() :
     #===========================================================================
     if len(wunder_results) == 0 :
         sys.stdout.flush()
-        print >>sys.stderr, "\nNo results returned from Weather Underground (perhaps a bad station name??)."
-        print >>sys.stderr, "Publishing anyway."
+        print("\nNo results returned from Weather Underground (perhaps a bad station name??).", file=sys.stderr)
+        print("Publishing anyway.", file=sys.stderr)
         wlog.slog(syslog.LOG_ERR, "No results returned from Weather Underground for station '%s'"
                   "(perhaps a bad station name??). Publishing anyway." % options.station)
 
@@ -227,9 +229,9 @@ def main() :
     missing_records = sorted([x for x in archive_results if not x in wunder_results])
     
     if options.verbose :
-        print "Number of missing records:    ", len(missing_records)
+        print("Number of missing records:    ", len(missing_records))
         if missing_records:
-            print "\nMissing records:"
+            print("\nMissing records:")
     wlog.slog(syslog.LOG_INFO, "%d Weather Underground records missing." % len(missing_records))
     
     no_published = 0
@@ -239,7 +241,7 @@ def main() :
         # Get the archive record for this timestamp:
         record = dbmanager_t.getRecord(ts)
         # Print it out:
-        print >>sys.stdout, print_record(record),
+        print(print_record(record), end=' ', file=sys.stdout)
         sys.stdout.flush()
 
         # If this is an interactive session (option "-q") see if the
@@ -247,7 +249,7 @@ def main() :
         if options.query :
             _ans=raw_input("...fix? (y/n/a/q):")
             if _ans == "q" :
-                print "Quitting."
+                print("Quitting.")
                 wlog.slog(syslog.LOG_DEBUG, "... exiting")
                 exit()
             if _ans == "a" :
@@ -259,32 +261,32 @@ def main() :
                 # Post the data to the WU:
                 wunder.process_record(record, dbmanager_t)
                 no_published += 1
-                print >>sys.stdout, " ...published."
+                print(" ...published.", file=sys.stdout)
                 wlog.slog(syslog.LOG_DEBUG, "%s ...published" % timestamp_to_string(record['dateTime']))
             except weewx.restx.BadLogin, e:
-                print >>sys.stderr, "Bad login"
-                print >>sys.stderr, e
+                print("Bad login", file=sys.stderr)
+                print(e, file=sys.stderr)
                 exit("Bad login")                
             except weewx.restx.FailedPost, e:
-                print >>sys.stderr, e
-                print >>sys.stderr, "Aborted."
+                print(e, file=sys.stderr)
+                print("Aborted.", file=sys.stderr)
                 wlog.slog(syslog.LOG_ERR, "%s ...error %s. Aborting." % (timestamp_to_string(record['dateTime']), e))
                 exit("Failed post")
             except IOError, e:
-                print >>sys.stderr, " ... not published."
-                print "Reason: ", e
+                print(" ... not published.", file=sys.stderr)
+                print("Reason: ", e)
                 wlog.slog(syslog.LOG_ERR, "%s ...not published. Reason '%s'" % (timestamp_to_string(record['dateTime']), e))
                 if hasattr(e, 'reason'):
-                    print >>sys.stderr, "Failed to reach server. Reason: %s" % e.reason
+                    print("Failed to reach server. Reason: %s" % e.reason, file=sys.stderr)
                     wlog.slog(syslog.LOG_ERR, "%s ...not published. Failed to reach server. Reason '%s'" % 
                               (timestamp_to_string(record['dateTime']), e.reason))
                 if hasattr(e, 'code'):
-                    print >>sys.stderr, "Failed to reach server. Error code: %s" % e.code
+                    print("Failed to reach server. Error code: %s" % e.code, file=sys.stderr)
                     wlog.slog(syslog.LOG_ERR, "%s ...not published. Failed to reach server. Error code '%s'" % 
                               (timestamp_to_string(record['dateTime']), e.code))
 
         else :
-            print " ... skipped."
+            print(" ... skipped.")
             wlog.slog(syslog.LOG_DEBUG, "%s ...skipped" % timestamp_to_string(record['dateTime']))
     wlog.slog(syslog.LOG_INFO, "%s out of %s missing records published to '%s' for date %s."
               " Wunderfixer exiting." % (no_published, len(missing_records), options.station, date_date))
@@ -315,11 +317,11 @@ class WunderStation(weewx.restx.AmbientThread):
             # Hit the weather underground site:
             _wudata = urllib2.urlopen(_url)
         except urllib2.URLError, e :
-            print >>sys.stderr, "Unable to open Weather Underground station " + self.station, " or ", e
+            print("Unable to open Weather Underground station " + self.station, " or ", e, file=sys.stderr)
             wlog.slog(syslog.LOG_ERR, "Unable to open Weather Underground station %s or %s" % (self.station, e))
             raise
         except socket.timeout, e:
-            print >>sys.stderr, "Socket timeout for Weather Underground station " + self.station
+            print("Socket timeout for Weather Underground station " + self.station, file=sys.stderr)
             wlog.slog(syslog.LOG_ERR, "Socket timeout for Weather Underground station %s" % self.station)
             raise
 

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -263,16 +263,16 @@ def main() :
                 no_published += 1
                 print(" ...published.", file=sys.stdout)
                 wlog.slog(syslog.LOG_DEBUG, "%s ...published" % timestamp_to_string(record['dateTime']))
-            except weewx.restx.BadLogin, e:
+            except weewx.restx.BadLogin as e:
                 print("Bad login", file=sys.stderr)
                 print(e, file=sys.stderr)
                 exit("Bad login")                
-            except weewx.restx.FailedPost, e:
+            except weewx.restx.FailedPost as e:
                 print(e, file=sys.stderr)
                 print("Aborted.", file=sys.stderr)
                 wlog.slog(syslog.LOG_ERR, "%s ...error %s. Aborting." % (timestamp_to_string(record['dateTime']), e))
                 exit("Failed post")
-            except IOError, e:
+            except IOError as e:
                 print(" ... not published.", file=sys.stderr)
                 print("Reason: ", e)
                 wlog.slog(syslog.LOG_ERR, "%s ...not published. Reason '%s'" % (timestamp_to_string(record['dateTime']), e))
@@ -316,11 +316,11 @@ class WunderStation(weewx.restx.AmbientThread):
         try :
             # Hit the weather underground site:
             _wudata = urllib2.urlopen(_url)
-        except urllib2.URLError, e :
+        except urllib2.URLError as e :
             print("Unable to open Weather Underground station " + self.station, " or ", e, file=sys.stderr)
             wlog.slog(syslog.LOG_ERR, "Unable to open Weather Underground station %s or %s" % (self.station, e))
             raise
-        except socket.timeout, e:
+        except socket.timeout as e:
             print("Socket timeout for Weather Underground station " + self.station, file=sys.stderr)
             wlog.slog(syslog.LOG_ERR, "Socket timeout for Weather Underground station %s" % self.station)
             raise

--- a/examples/alarm.py
+++ b/examples/alarm.py
@@ -202,11 +202,11 @@ if __name__ == '__main__':
     try :
         config_dict = configobj.ConfigObj(config_path, file_error=True)
     except IOError:
-        print "Unable to open configuration file ", config_path
+        print("Unable to open configuration file ", config_path)
         exit()
         
     if 'Alarm' not in config_dict:
-        print >>sys.stderr, "No [Alarm] section in the configuration file %s" % config_path
+        print("No [Alarm] section in the configuration file %s" % config_path, file=sys.stderr)
         exit(1)
     
     engine = None

--- a/examples/fileparse/bin/user/fileparse.py
+++ b/examples/fileparse/bin/user/fileparse.py
@@ -128,4 +128,4 @@ if __name__ == "__main__":
     import weeutil.weeutil
     driver = FileParseDriver()
     for packet in driver.genLoopPackets():
-        print weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet
+        print(weeutil.weeutil.timestamp_to_string(packet['dateTime']), packet)

--- a/examples/pmon/bin/user/pmon.py
+++ b/examples/pmon/bin/user/pmon.py
@@ -185,17 +185,17 @@ if __name__ == "__main__":
 
     nowts = lastts = int(time.time())
     rec = svc.get_data(nowts, lastts)
-    print rec
+    print(rec)
 
     time.sleep(5)
     nowts = int(time.time())
     rec = svc.get_data(nowts, lastts)
-    print rec
+    print(rec)
 
     time.sleep(5)
     lastts = nowts
     nowts = int(time.time())
     rec = svc.get_data(nowts, lastts)
-    print rec
+    print(rec)
 
     os.remove('/var/tmp/pmon.sdb')

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class weewx_install_lib(install_lib):
         # Save any existing 'bin' subdirectory:
         if os.path.exists(self.install_dir):
             bin_savedir = weeutil.weeutil.move_with_timestamp(self.install_dir)
-            print "Saved bin subdirectory as %s" % bin_savedir
+            print("Saved bin subdirectory as %s" % bin_savedir)
         else:
             bin_savedir = None
 
@@ -173,7 +173,7 @@ class weewx_install_data(install_data):
             # Yes. Read it
             config_path, config_dict = weecfg.read_config(install_path, None)
             if DEBUG:
-                print "Old configuration file found at", config_path
+                print("Old configuration file found at", config_path)
 
             # Update the old configuration file to the current version,
             # then merge it into the distribution file
@@ -189,7 +189,7 @@ class weewx_install_data(install_data):
                 stn_info['driver'] = driver
                 stn_info.update(weecfg.prompt_for_driver_settings(driver))
                 if DEBUG:
-                    print "Station info =", stn_info
+                    print("Station info =", stn_info)
             weecfg.modify_config(config_dict, stn_info, DEBUG)
 
         # Set the WEEWX_ROOT
@@ -214,7 +214,7 @@ class weewx_install_data(install_data):
         # Save the old config file if it exists:
         if not self.dry_run and os.path.exists(install_path):
             backup_path = weeutil.weeutil.move_with_timestamp(install_path)
-            print "Saved old configuration file as %s" % backup_path
+            print("Saved old configuration file as %s" % backup_path)
 
         # Now install the temporary file (holding the merged config data)
         # into the proper place:


### PR DESCRIPTION
These patches modify the 'print' invocations to be python3 compatible according to the 2to3 utility that comes with recent versions of python2. This passes 'make test' and 'python setup.py build' on ubuntu xenial64 under Vagrant.

Changes all seem to be essentially wrapping the items printed in parens, although in some cases it is also necessary to add the following at the top of the file:

    import from __future__ with print_function

Note:  2to3 wasn't 100% accurate in adding this import, there were a few that I had to add manually.

The only complicated modifications were things using ">>>" as in bin/weecfg/database.py which 2to3 handled (and StackOverflow agreed, FWIW).  Those cases needed the import statement above, it seems.   database.py also shows the syntax difference when a previous print statement ended in a bare comma.   Might be worth checking out that the results are as you intend with that one particular syntax.

Edits were created by:

    2to3 -f print-w my_source_directory_path_here