### PR TITLE
Added weeknumber substitution for filenames

### DIFF
--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -15,7 +15,7 @@ Configuration Options
   search_list = a, b, c
   search_list_extensions = d, e, f
 
-The strings YYYY and MM will be replaced if they appear in the filename.
+The strings YYYY, MM, DD and WW will be replaced if they appear in the filename.
 
 search_list will override the default search_list
 
@@ -59,6 +59,7 @@ from __future__ import with_statement
 import os.path
 import syslog
 import time
+import datetime
 
 import configobj
 
@@ -380,16 +381,19 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
 
         _filename = os.path.basename(template).replace('.tmpl', '')
 
-        # If the filename contains YYYY, MM, or DD, then do the replacement
-        if 'YYYY' in _filename or 'MM' in _filename or 'DD' in _filename:
+        # If the filename contains YYYY, MM, DD or WW, then do the replacement
+        if 'YYYY' in _filename or 'MM' in _filename or 'DD' in _filename or 'WW' in _filename:
             # Get strings representing year, month, and day
             _yr_str  = "%4d"  % ref_tt[0]
             _mo_str  = "%02d" % ref_tt[1]
             _day_str = "%02d"  % ref_tt[2]
+            _week_str = "%02d"  % datetime.date( ref_tt[0], ref_tt[1], ref_tt[2] ).isocalendar()[1];
             # Replace any instances of 'YYYY' with the year string
             _filename = _filename.replace('YYYY', _yr_str)
             # Do the same thing with the month...
             _filename = _filename.replace('MM', _mo_str)
+            # ... the week ...
+            _filename = _filename.replace('WW', _week_str)
             # ... and the day
             _filename = _filename.replace('DD', _day_str)
 

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -4438,12 +4438,14 @@ UV      = UV Index</pre>
       <p>
         The name of a template file. A template filename must end with <span
           class="code">.tmpl</span>. Filenames are case-sensitive. If
-        the template filename has the letters <span class="code">YYYY</span>
-        or <span class="code">MM</span> in its name, these will be
-        substituted for the year and month, respectively. So, a template
-        with the name <span class="code">summary-YYYY-MM.html.tmpl</span>
-        would have name <span class="code">summary-2010-03.html</span>
-        for the month of March, 2010.
+        the template filename has the letters <span class="code">YYYY</span>,
+        <span class="code">MM</span>, <span class="code">WW</span> or 
+	<span class="code">DD</span> in its name, these will be
+        substituted for the year, month, week and day of month, respectively. 
+	So, a template with the name 
+	<span class="code">summary-YYYY-MM.html.tmpl</span> would have name 
+	<span class="code">summary-2010-03.html</span> for the month of 
+	March, 2010.
       </p>
 
       <p class="config_option">stale_age</p>


### PR DESCRIPTION
According to my feature request at
https://github.com/weewx/weewx/issues/318

this patch adds the ability to substitute the string "WW" with the week number in filenames of "ToDate archive files", just like it's already doing with "DD", "MM" and "YYYY".