### PR TITLE
Fix unmatched lines in logwatch

### DIFF
--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -169,7 +169,7 @@ class StdEngine(object):
                 # See if garbage collection is scheduled:
                 if time.time() - last_gc > self.gc_interval:
                     ngc = gc.collect()
-                    syslog.syslog(syslog.LOG_INFO, "engine: Garbage collected %d objects" % ngc)
+                    syslog.syslog(syslog.LOG_INFO, "engine: garbage collected %d objects" % ngc)
                     last_gc = time.time()
 
                 # First, let any interested services know the packet LOOP is

--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -169,7 +169,7 @@ class StdEngine(object):
                 # See if garbage collection is scheduled:
                 if time.time() - last_gc > self.gc_interval:
                     ngc = gc.collect()
-                    syslog.syslog(syslog.LOG_INFO, "engine: garbage collected %d objects" % ngc)
+                    syslog.syslog(syslog.LOG_INFO, "engine: Garbage collected %d objects" % ngc)
                     last_gc = time.time()
 
                 # First, let any interested services know the packet LOOP is

--- a/util/logwatch/scripts/services/weewx
+++ b/util/logwatch/scripts/services/weewx
@@ -14,7 +14,7 @@ my $STARTUPS = 'engine: startups';
 my $HUP_RESTARTS = 'engine: restart from HUP';
 my $KBD_INTERRUPTS = 'engine: keyboard interrupts';
 my $RESTARTS = 'engine: restarts';
-my $GARBAGE = 'engine: garbage collected';
+my $GARBAGE = 'engine: Garbage collected';
 my $ARCHIVE_RECORDS_ADDED = 'archive: records added';
 my $IMAGES_GENERATED = 'imagegenerator: images generated';
 my $FILES_GENERATED = 'filegenerator: files generated';
@@ -128,7 +128,7 @@ while(defined($_ = <STDIN>)) {
         $counts{$KBD_INTERRUPTS} += 1;
     } elsif (/engine: retrying/) {
         $counts{$RESTARTS} += 1;
-    } elsif (/engine: garbage collected (\d+) objects/) {
+    } elsif (/engine: Garbage collected (\d+) objects/) {
         $counts{$GARBAGE} += $1;
     } elsif (/engine: Clock error is ([0-9,.-]+)/) {
         $clocksum += $1;


### PR DESCRIPTION
Changed "Garbage" back to lowercase in bin/weewx/engine.py
"engine: Garbage collected" will be reported as unmatched line in logwatch.