### PR TITLE
Address issue #346

### DIFF
--- a/bin/weecfg/__init__.py
+++ b/bin/weecfg/__init__.py
@@ -77,30 +77,30 @@ DEFAULT_LOCATIONS = ['../..', '/etc/weewx', '/home/weewx']
 def find_file(file_path=None, args=None, locations=DEFAULT_LOCATIONS,
               file_name='weewx.conf'):
     """Find and return a path to a file, looking in "the usual places."
-    
+
     General strategy:
 
     First, file_path is tried. If not found there, then the first element of
     args is tried.
 
     If those fail, try a path based on where the application is running.
-    
+
     If that fails, then the list of directory locations is searched,
-    looking for a file with file name file_name. 
-    
+    looking for a file with file name file_name.
+
     If after all that, the file still cannot be found, then an IOError
     exception will be raised.
-    
+
     Parameters:
 
     file_path: A candidate path to the file.
 
     args: command-line arguments. If the file cannot be found in file_path,
     then the first element in args will be tried.
-    
+
     locations: A list of directories to be searched. If they do not
     start with a slash ('/'), then they will be treated as relative to
-    this file (bin/weecfg/__init__.py). 
+    this file (bin/weecfg/__init__.py).
     Default is ['../..', '/etc/weewx', '/home/weewx'].
 
     file_name: The name of the file to be found. This is used
@@ -148,11 +148,11 @@ def read_config(config_path, args=None, locations=DEFAULT_LOCATIONS,
     args: command-line arguments
 
     return: path-to-file, instance-of-ConfigObj
-    
+
     Raises:
-    
+
     SyntaxError: If there is a syntax error in the file
-    
+
     IOError: If the file cannot be found
     """
     # Find and open the config file:
@@ -331,9 +331,9 @@ def update_config(config_dict):
 
 def merge_config(config_dict, template_dict):
     """Merge the template (distribution) dictionary into the user's dictionary.
-    
+
     config_dict: An existing, older configuration dictionary.
-    
+
     template_dict: A newer dictionary supplied by the installer.
     """
 
@@ -443,17 +443,17 @@ def update_to_v25(config_dict):
         [[StationRegistry]]
             # Uncomment the following line to register this weather station.
             #register_this_station = True
-    
+
             # Specify a station URL, otherwise the station_url from [Station]
             # will be used.
             #station_url = http://example.com/weather/
-    
+
             # Specify a description of the station, otherwise the location from
             # [Station] will be used.
             #description = The greatest station on earth
-    
+
             driver = weewx.restful.StationRegistry
-    
+
     """))
             config_dict.merge(stnreg_dict)
     except KeyError:
@@ -730,7 +730,7 @@ def update_to_v30(config_dict):
             # This section binds a data store to a database
 
             [[wx_binding]]
-                # The database must match one of the sections in [Databases] 
+                # The database must match one of the sections in [Databases]
                 database = archive_sqlite
                 # The name of the table within the database
                 table_name = archive
@@ -953,7 +953,7 @@ def update_to_v36(config_dict):
     #                      otherwise use value calculated by weewx"""
             # Create a new 'Calculations' section:
             config_dict['StdWXCalculate']['Calculations'] = {}
-            # Now transfer over the options. Make a copy of them first: we will be 
+            # Now transfer over the options. Make a copy of them first: we will be
             # deleting some of them.
             scalars = list(config_dict['StdWXCalculate'].scalars)
             for scalar in scalars:
@@ -1113,7 +1113,7 @@ def get_all_driver_infos():
 def get_driver_infos(driver_pkg_name='weewx.drivers', excludes=['__init__.py']):
     """Scan the drivers folder, extracting information about each available
     driver. Return as a dictionary, keyed by the driver module name.
-    
+
     Valid drivers must be importable, and must have attribute "DRIVER_NAME"
     defined.
     """
@@ -1176,7 +1176,7 @@ def print_drivers():
 
 def load_driver_editor(driver_module_name):
     """Load the configuration editor from the driver file
-    
+
     driver_module_name: A string holding the driver name.
                         E.g., 'weewx.drivers.fousb'
     """
@@ -1283,7 +1283,7 @@ def prompt_for_driver(dflt_driver=None):
     return keys[idx]
 
 
-def prompt_for_driver_settings(driver):
+def prompt_for_driver_settings(driver, config_dict):
     """Let the driver prompt for any required settings.  If the driver does
     not define a method for prompting, return an empty dictionary."""
     settings = dict()
@@ -1292,6 +1292,7 @@ def prompt_for_driver_settings(driver):
         driver_module = sys.modules[driver]
         loader_function = getattr(driver_module, 'confeditor_loader')
         editor = loader_function()
+        editor.existing_options = config_dict.get(driver_module.DRIVER_NAME, {})
         settings[driver_module.DRIVER_NAME] = editor.prompt_for_settings()
     except AttributeError:
         pass
@@ -1300,12 +1301,12 @@ def prompt_for_driver_settings(driver):
 
 def prompt_with_options(prompt, default=None, options=None):
     """Ask the user for an input with an optional default value.
-    
+
     prompt: A string to be used for a prompt.
-    
+
     default: A default value. If the user simply hits <enter>, this
     is the value returned. Optional.
-    
+
     options: A list of possible choices. The returned value must be in
     this list. Optional."""
 
@@ -1325,15 +1326,15 @@ def prompt_with_options(prompt, default=None, options=None):
 def prompt_with_limits(prompt, default=None, low_limit=None, high_limit=None):
     """Ask the user for an input with an optional default value. The
     returned value must lie between optional upper and lower bounds.
-    
+
     prompt: A string to be used for a prompt.
-    
+
     default: A default value. If the user simply hits <enter>, this
     is the value returned. Optional.
-    
+
     low_limit: The value must be equal to or greater than this value.
     Optional.
-    
+
     high_limit: The value must be less than or equal to this value.
     Optional.
     """
@@ -1388,7 +1389,7 @@ def extract_roots(config_path, config_dict, bin_root):
 
 def extract_tar(filename, target_dir, logger=None):
     """Extract files from a tar archive into a given directory
-    
+
     Returns: A list of the extracted files
     """
     logger = logger or Logger()

--- a/bin/weecfg/config.py
+++ b/bin/weecfg/config.py
@@ -19,15 +19,15 @@ stn_info_defaults = {'station_type': 'Simulator',
                      'driver': 'weewx.drivers.simulator'}
 
 class ConfigEngine(object):
-    
+
     def __init__(self, logger=None):
         self.logger = logger or Logger()
-    
+
     def run(self, args, options):
         if options.version:
             print weewx.__version__
             sys.exit(0)
-    
+
         if options.list_drivers:
             weecfg.print_drivers()
             sys.exit(0)
@@ -52,19 +52,19 @@ class ConfigEngine(object):
         # The install option does not take an old config file
         if options.install and (options.config_path or len(args)):
             sys.exit("The --install command does not require the config option.")
-            
+
         #
         # Error checking done. Now run the commands.
         #
-        
+
         # First, fiddle with option --altitude to convert it into a list:
         if options.altitude:
             options.altitude = options.altitude.split(",")
 
         if options.install or options.upgrade:
-            # These options require a distribution config file. 
+            # These options require a distribution config file.
             # Open it up and parse it:
-            try:        
+            try:
                 dist_config_dict = configobj.ConfigObj(options.dist_config,
                                                        file_error=True)
             except IOError as e:
@@ -96,7 +96,7 @@ class ConfigEngine(object):
 
             # Save to the specified output
             output_path = options.output
-            
+
         if options.install or options.reconfigure:
             # Modify the configuration contents
             self.modify_config(config_dict, options)
@@ -113,12 +113,12 @@ class ConfigEngine(object):
         """Modify the configuration dictionary according to any command
         line options. Give the user a chance too.
         """
-        
+
         # Extract stn_info from the config_dict and command-line options:
         stn_info = self.get_stn_info(config_dict, options)
 
         weecfg.modify_config(config_dict, stn_info, self.logger, options.debug)
-    
+
     def get_stn_info(self, config_dict, options):
         """Build the stn_info structure. This generally contains stuff
         that can be injected into the config_dict."""
@@ -146,7 +146,7 @@ class ConfigEngine(object):
             stn_info.update(weecfg.prompt_for_info(**stn_info))
             driver = weecfg.prompt_for_driver(stn_info.get('driver'))
             stn_info['driver'] = driver
-            stn_info.update(weecfg.prompt_for_driver_settings(driver))
+            stn_info.update(weecfg.prompt_for_driver_settings(driver, config_dict))
 
         return stn_info
 
@@ -154,7 +154,7 @@ class ConfigEngine(object):
         """Save the config file, backing up as necessary."""
 
         backup_path = weecfg.save(config_dict, config_path, backup)
-        if backup_path:        
+        if backup_path:
             self.logger.log("Saved backup to %s" % backup_path)
-            
+
         self.logger.log("Saved configuration to %s" % config_path)

--- a/bin/weewx/drivers/__init__.py
+++ b/bin/weewx/drivers/__init__.py
@@ -9,31 +9,31 @@ import syslog
 import weewx
 
 class AbstractDevice(object):
-    """Device drivers should inherit from this class."""    
+    """Device drivers should inherit from this class."""
 
     @property
     def hardware_name(self):
         raise NotImplementedError("Property 'hardware_name' not implemented")
-    
+
     @property
     def archive_interval(self):
         raise NotImplementedError("Property 'archive_interval' not implemented")
 
     def genStartupRecords(self, last_ts):
         return self.genArchiveRecords(last_ts)
-    
+
     def genLoopPackets(self):
         raise NotImplementedError("Method 'genLoopPackets' not implemented")
-    
+
     def genArchiveRecords(self, lastgood_ts):
         raise NotImplementedError("Method 'genArchiveRecords' not implemented")
-        
+
     def getTime(self):
         raise NotImplementedError("Method 'getTime' not implemented")
-    
+
     def setTime(self):
         raise NotImplementedError("Method 'setTime' not implemented")
-    
+
     def closePort(self):
         pass
 
@@ -56,7 +56,7 @@ class AbstractConfigurator(object):
     def epilog(self):
         return "Be sure to stop weewx first before using. Mutating actions will"\
             " request confirmation before proceeding.\n"
-                
+
 
     def configure(self, config_dict):
         parser = self.get_parser()
@@ -97,9 +97,9 @@ class AbstractConfEditor(object):
     @property
     def default_stanza(self):
         """Return a plain text stanza. This will look something like:
-        
+
 [Acme]
-    # This section is for the Acme weather station 
+    # This section is for the Acme weather station
 
     # The station model
     model = acme100
@@ -117,10 +117,10 @@ class AbstractConfEditor(object):
         that will work with the current version of the device driver.
 
         The default behavior is to return the original stanza, unmodified.
-        
+
         Derived classes should override this if they need to modify previous
         configuration options or warn about deprecated or harmful options.
-        
+
         The return value should be a long string. See default_stanza above
         for an example string stanza."""
         return self.default_stanza if orig_stanza is None else orig_stanza
@@ -131,6 +131,8 @@ class AbstractConfEditor(object):
         return dict()
 
     def _prompt(self, label, dflt=None, opts=None):
+        if label in self.existing_options:
+            dflt = self.existing_options[label]
         import weecfg
         val = weecfg.prompt_with_options(label, dflt, opts)
         del weecfg

--- a/setup.py
+++ b/setup.py
@@ -57,18 +57,18 @@ stn_info = {'station_type' : 'Simulator',
 #==============================================================================
 # install
 #==============================================================================
- 
+
 class weewx_install(install):
     """Specialized version of install, which adds a --no-prompt option to
     the 'install' command."""
 
     # Add an option for --no-prompt:
     user_options = install.user_options + [('no-prompt', None, 'Do not prompt for station info')]
-  
+
     def initialize_options(self, *args, **kwargs):
         install.initialize_options(self, *args, **kwargs)
         self.no_prompt = None
-        
+
     def finalize_options(self):
         install.finalize_options(self)
         if self.no_prompt is None:
@@ -79,7 +79,7 @@ class weewx_install(install):
 #==============================================================================
 
 class weewx_install_lib(install_lib):
-    """Specialized version of install_lib, which backs up old bin subdirectories.""" 
+    """Specialized version of install_lib, which backs up old bin subdirectories."""
 
     def run(self):
         # Determine whether the user is still using an old-style schema
@@ -94,7 +94,7 @@ class weewx_install_lib(install_lib):
 
         # Run the superclass's version. This will install all incoming files.
         install_lib.run(self)
-        
+
         # If the bin subdirectory previously existed, and if it included
         # a 'user' subsubdirectory, then restore it
         if bin_savedir:
@@ -117,7 +117,7 @@ class weewx_install_lib(install_lib):
 class weewx_install_data(install_data):
     """Specialized version of install_data. Mostly, it deals with upgrading
     and merging any old weewx.conf configuration files."""
-    
+
     def initialize_options(self):
         # Initialize my superclass's options:
         install_data.initialize_options(self)
@@ -140,7 +140,7 @@ class weewx_install_data(install_data):
         else:
             rv = install_data.copy_file(self, f, install_dir, **kwargs)
         return rv
-    
+
     def run(self):
         # If there is an existing skins subdirectory, do not overwrite it.
         if os.path.exists(os.path.join(self.install_dir, 'skins')):
@@ -149,15 +149,15 @@ class weewx_install_data(install_data):
             self.data_files = filter(lambda dat : not dat[0].startswith('skins/'), self.data_files)
 
         remove_obsolete_files(self.install_dir)
-        
+
         # Run the superclass's run():
         install_data.run(self)
-       
+
     def process_config_file(self, f, install_dir, **kwargs):
         global stn_info
 
         # Open up and parse the distribution config file:
-        try:        
+        try:
             dist_config_dict = configobj.ConfigObj(f, file_error=True)
         except IOError as e:
             sys.exit(str(e))
@@ -187,7 +187,7 @@ class weewx_install_data(install_data):
                 stn_info = weecfg.prompt_for_info()
                 driver = weecfg.prompt_for_driver(stn_info.get('driver'))
                 stn_info['driver'] = driver
-                stn_info.update(weecfg.prompt_for_driver_settings(driver))
+                stn_info.update(weecfg.prompt_for_driver_settings(driver, config_dict))
                 if DEBUG:
                     print "Station info =", stn_info
             weecfg.modify_config(config_dict, stn_info, DEBUG)
@@ -228,10 +228,10 @@ class weewx_install_data(install_data):
         return rv
 
     def massage_start_file(self, f, install_dir, **kwargs):
-    
+
             outname = os.path.join(install_dir, os.path.basename(f))
             sre = re.compile(r"WEEWX_ROOT\s*=")
-    
+
             with open(f, 'r') as infile:
                 with tempfile.NamedTemporaryFile("w") as tmpfile:
                     for line in infile:
@@ -246,7 +246,7 @@ class weewx_install_data(install_data):
             # Set the permission bits unless this is a dry run:
             if not self.dry_run:
                 shutil.copymode(f, outname)
-    
+
             return rv
 
 #==============================================================================
@@ -309,43 +309,43 @@ class weewx_sdist(sdist):
 def remove_obsolete_files(install_dir):
     """Remove no longer needed files from the installation
     directory, nominally /home/weewx."""
-    
+
     # If the file #upstream.last exists, delete it, as it is no longer used.
     try:
         os.remove(os.path.join(install_dir, 'public_html/#upstream.last'))
     except OSError:
         pass
-        
+
     # If the file $WEEWX_INSTALL/readme.htm exists, delete it. It's
     # the old readme (since replaced with README)
     try:
         os.remove(os.path.join(install_dir, 'readme.htm'))
     except OSError:
         pass
-    
+
     # If the file $WEEWX_INSTALL/CHANGES.txt exists, delete it. It's
     # been moved to the docs subdirectory and renamed
     try:
         os.remove(os.path.join(install_dir, 'CHANGES.txt'))
     except OSError:
         pass
-    
+
     # The directory start_scripts is no longer used
     shutil.rmtree(os.path.join(install_dir, 'start_scripts'), True)
-    
+
     # The file docs/README.txt is now gone
     try:
         os.remove(os.path.join(install_dir, 'docs/README.txt'))
     except OSError:
         pass
-    
+
     # If the file docs/CHANGES.txt exists, delete it. It's been renamed
     # to docs/changes.txt
     try:
         os.remove(os.path.join(install_dir, 'docs/CHANGES.txt'))
     except OSError:
         pass
-    
+
     # setup.py is no longer left in WEEWX_ROOT.
     try:
         os.remove(os.path.join(install_dir, 'setup.py'))
@@ -355,9 +355,9 @@ def remove_obsolete_files(install_dir):
 def get_schema_type(bin_dir):
     """Checks whether the schema in user.schemas is a new style or old style
     schema.
-    
+
     bin_dir: The directory to be checked. This is nominally /home/weewx/bin.
-    
+
     Returns:
       'none': There is no schema at all.
       'old' : It is an old-style schema.
@@ -365,7 +365,7 @@ def get_schema_type(bin_dir):
     """
     tmp_path = list(sys.path)
     sys.path.insert(0, bin_dir)
-    
+
     try:
         import user.schemas
     except ImportError:
@@ -378,7 +378,7 @@ def get_schema_type(bin_dir):
             # a new-style schema
             _ = user.schemas.drop_list # @UnusedVariable @UndefinedVariable
         except AttributeError:
-            # New style schema 
+            # New style schema
             result = 'new'
         else:
             # It did not fail. Must be an old-style schema
@@ -386,9 +386,9 @@ def get_schema_type(bin_dir):
         finally:
             del user.schemas
 
-    # Restore the path        
+    # Restore the path
     sys.path = tmp_path
-    
+
     return result
 
 #==============================================================================


### PR DESCRIPTION
Changes as per Matthew's email of 2 October. One change I found necessary though, `weecfg.prompt_for_driver_settings()` needs a `config_dict` to obtain the driver settings rather than `stn_info`.

Tested against a driver that does prompt for driver settings and one that does not. Both behaved as expected.

PS. Sorry about all the whitespace removal, but that must be a good thing musn't  it?