### PR TITLE
Fix incorrect `log_success` operation in ftp, rsync, copy and image generators

### DIFF
--- a/bin/weewx/imagegenerator.py
+++ b/bin/weewx/imagegenerator.py
@@ -17,6 +17,7 @@ import weeplot.utilities
 import weeutil.weeutil
 import weewx.reportengine
 import weewx.units
+from weeutil.config import search_up
 from weeutil.weeutil import to_bool, to_int, to_float
 from weewx.units import ValueTuple
 
@@ -60,6 +61,9 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
         """
         t1 = time.time()
         ngen = 0
+
+        # determine how much logging is desired
+        log_success = to_bool(search_up(self.image_dict, 'log_success', True))
 
         # Loop over each time span class (day, week, month, etc.):
         for timespan in self.image_dict.sections:
@@ -259,7 +263,7 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
                     syslog.syslog(syslog.LOG_CRIT, "imagegenerator: Unable to save to file '%s' %s:" % (img_file, e))
         t2 = time.time()
 
-        if self.skin_dict.get('log_success', True):
+        if log_success:
             syslog.syslog(syslog.LOG_INFO, "imagegenerator: Generated %d images for %s in %.2f seconds" % (ngen, self.skin_dict['REPORT_NAME'], t2 - t1))
 
 def skipThisPlot(time_ts, aggregate_interval, img_file):

--- a/bin/weewx/reportengine.py
+++ b/bin/weewx/reportengine.py
@@ -24,6 +24,7 @@ import traceback
 import weeutil.weeutil
 import weewx.defaults
 import weewx.manager
+from weeutil.config import search_up
 from weeutil.weeutil import to_bool
 
 # spans of valid values for each CRON like field
@@ -319,7 +320,7 @@ class FtpGenerator(ReportGenerator):
         import weeutil.ftpupload
 
         # determine how much logging is desired
-        log_success = to_bool(self.skin_dict.get('log_success', True))
+        log_success = to_bool(search_up(self.skin_dict, 'log_success', True))
 
         t1 = time.time()
         try:
@@ -384,7 +385,7 @@ class RsyncGenerator(ReportGenerator):
                 ssh_options=self.skin_dict.get('ssh_options'),
                 compress=to_bool(self.skin_dict.get('compress', False)),
                 delete=to_bool(self.skin_dict.get('delete', False)),
-                log_success=to_bool(self.skin_dict.get('log_success', True)))
+                log_success=to_bool(search_up(self.skin_dict, 'log_success', True)))
         except KeyError:
             syslog.syslog(syslog.LOG_DEBUG,
                           "rsyncgenerator: rsync upload not requested. Skipped.")
@@ -411,7 +412,7 @@ class CopyGenerator(ReportGenerator):
     def run(self):
         copy_dict = self.skin_dict['CopyGenerator']
         # determine how much logging is desired
-        log_success = to_bool(copy_dict.get('log_success', True))
+        log_success = to_bool(search_up(copy_dict, 'log_success', True))
 
         copy_list = []
 


### PR DESCRIPTION
Partially addresses the issues raised under #370.
As far as I can tell these changes work correctly under the new override hierarchy, submitted as a PR so @tkeffer or @matthewwall can verify.