### PR TITLE
daemon.py - replace `file` with `open`

### DIFF
--- a/bin/daemon.py
+++ b/bin/daemon.py
@@ -68,13 +68,13 @@ def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
 
     # Open file descriptors and print start message
     if not stderr: stderr = stdout
-    si = file(stdin, 'r')
-    so = file(stdout, 'a+')
-    se = file(stderr, 'a+', 0)
+    si = open(stdin, 'r')
+    so = open(stdout, 'a+')
+    se = open(stderr, 'a+')
     pid = str(os.getpid())
 #    sys.stderr.write("\n%s\n" % startmsg % pid)
 #    sys.stderr.flush()
-    if pidfile: file(pidfile,'w+').write("%s\n" % pid)
+    if pidfile: open(pidfile,'w+').write("%s\n" % pid)
     # Redirect standard file descriptors.
     os.dup2(si.fileno(), sys.stdin.fileno())
     os.dup2(so.fileno(), sys.stdout.fileno())


### PR DESCRIPTION
I tried to run WeeWX 4.0 as a daemon under Stretch 9.8 and received a python complaint:
```
Feb 25 16:11:31 stretch6 weewx[1209]:   File "/home/weewx/bin/weewxd", line 64, in <module>
Feb 25 16:11:31 stretch6 weewx[1209]:     weewx.engine.main(options, args)
Feb 25 16:11:31 stretch6 weewx[1209]:   File "/home/weewx/bin/weewx/engine.py", line 844, in main
Feb 25 16:11:31 stretch6 weewx[1209]:     daemon.daemonize(pidfile=options.pidfile)
Feb 25 16:11:31 stretch6 weewx[1209]:   File "/home/weewx/bin/daemon.py", line 71, in daemonize
Feb 25 16:11:31 stretch6 weewx[1209]:     si = file(stdin, 'r')
Feb 25 16:11:31 stretch6 weewx[1209]: NameError: name 'file' is not defined
```
In `bin/daemon.py` I replaced `file` with `open` and then received the complaint:
```
Feb 25 17:52:20 stretch6 weewx[1783]: Traceback (most recent call last):
Feb 25 17:52:20 stretch6 weewx[1783]:   File "/home/weewx/bin/weewxd", line 64, in <module>
Feb 25 17:52:20 stretch6 weewx[1783]:     weewx.engine.main(options, args)
Feb 25 17:52:20 stretch6 weewx[1783]:   File "/home/weewx/bin/weewx/engine.py", line 844, in main
Feb 25 17:52:20 stretch6 weewx[1783]:     daemon.daemonize(pidfile=options.pidfile)
Feb 25 17:52:20 stretch6 weewx[1783]:   File "/home/weewx/bin/daemon.py", line 73, in daemonize
Feb 25 17:52:20 stretch6 weewx[1783]:     se = open(stderr, 'a+', 0)
Feb 25 17:52:20 stretch6 weewx[1783]: ValueError: can't have unbuffered text I/O
```

A little less sure on this so after some Googling I changed:
```
se = open(stderr, 'a+', 0)
```
to
```
se = open(stderr, 'a+')
```