### PR TITLE
Add tests for untested aggregates

### DIFF
--- a/bin/weewx/test/expected/StandardTest/index.html
+++ b/bin/weewx/test/expected/StandardTest/index.html
@@ -665,6 +665,38 @@
       </tr>
   </table>
     
+  <h1>Test for aggregates</h1>
+  <table>
+      <tr>
+        <td align="right">$month.outTemp.maxmin</td>
+        <td align="left">40.0&#176;F</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.maxmintime</td>
+        <td align="left">01-Sep-2010 07:00</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minmax</td>
+        <td align="left">63.3&#176;F</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minmaxtime</td>
+        <td align="left">03-Sep-2010 00:10</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minsum</td>
+        <td align="left">3097.8&#176;F</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minsumtime</td>
+        <td align="left">03-Sep-2010 07:00</td>
+      </tr>
+      <tr>
+        <td align="right">$year.rain.sum_le((0.1, 'inch', 'group_rain'))</td>
+        <td align="left">122.000000</td>
+      </tr>
+  </table>
+
   <h1>Day images</h1>
   <p>
   <img src="daytempdew.png" alt="temperatures" />

--- a/bin/weewx/test/expected/StandardTest/metric/index.html
+++ b/bin/weewx/test/expected/StandardTest/metric/index.html
@@ -665,6 +665,38 @@
       </tr>
   </table>
     
+  <h1>Test for aggregates</h1>
+  <table>
+      <tr>
+        <td align="right">$month.outTemp.maxmin</td>
+        <td align="left">4.5&#176;C</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.maxmintime</td>
+        <td align="left">01-Sep-2010 07:00</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minmax</td>
+        <td align="left">17.4&#176;C</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minmaxtime</td>
+        <td align="left">03-Sep-2010 00:10</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minsum</td>
+        <td align="left">1703.2&#176;C</td>
+      </tr>
+      <tr>
+        <td align="right">$month.outTemp.minsumtime</td>
+        <td align="left">03-Sep-2010 07:00</td>
+      </tr>
+      <tr>
+        <td align="right">$year.rain.sum_le((0.1, 'inch', 'group_rain'))</td>
+        <td align="left">122.000000</td>
+      </tr>
+  </table>
+
   <h1>Day images</h1>
   <p>
   <img src="daytempdew.png" alt="temperatures" />

--- a/bin/weewx/test/test_skins/StandardTest/index.html.tmpl
+++ b/bin/weewx/test/test_skins/StandardTest/index.html.tmpl
@@ -698,6 +698,38 @@
       </tr>
   </table>
     
+  <h1>Test for aggregates</h1>
+  <table>
+      <tr>
+        <td align="right">\$month.outTemp.maxmin</td>
+        <td align="left">$month.outTemp.maxmin</td>
+      </tr>
+      <tr>
+        <td align="right">\$month.outTemp.maxmintime</td>
+        <td align="left">$month.outTemp.maxmintime</td>
+      </tr>
+      <tr>
+        <td align="right">\$month.outTemp.minmax</td>
+        <td align="left">$month.outTemp.minmax</td>
+      </tr>
+      <tr>
+        <td align="right">\$month.outTemp.minmaxtime</td>
+        <td align="left">$month.outTemp.minmaxtime</td>
+      </tr>
+      <tr>
+        <td align="right">\$month.outTemp.minsum</td>
+        <td align="left">$month.outTemp.minsum</td>
+      </tr>
+      <tr>
+        <td align="right">\$month.outTemp.minsumtime</td>
+        <td align="left">$month.outTemp.minsumtime</td>
+      </tr>
+      <tr>
+        <td align="right">\$year.rain.sum_le((0.1, 'inch', 'group_rain'))</td>
+        <td align="left">$year.rain.sum_le((0.1, 'inch', 'group_rain'))</td>
+      </tr>
+  </table>
+
   <h1>Day images</h1>
   <p>
   <img src="daytempdew.png" alt="temperatures" />


### PR DESCRIPTION
Refer PR #382.

Existing `maxmin`, `maxmintime`, `minmax` and `minmaxtime` aggregates are not tested in the current test suite. New aggregates `minsum`, `minsumtime` and `sum_le` need to be added to the test suite.

`minsum` and `minsumtime` tests are nonsense (eg `$month.outTemp.minsum`) but with the periodic simulated data used in the test suite the more sensible (but not much more useful) `$month.rain.minsum` returns 0.0 which whilst deterministic could also result from incorrect operation of `minsum`.