### PR TITLE
Fix to vector average wind speed calculation

### DIFF
--- a/bin/weewx/manager.py
+++ b/bin/weewx/manager.py
@@ -1166,7 +1166,7 @@ class DaySummaryManager(Manager):
         'sum': "SELECT SUM(sum) FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
         'sum_ge': "SELECT SUM(sum >= %(val)s) FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
         'sum_le': "SELECT SUM(sum <= %(val)s) FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
-        'vecavg': "SELECT SUM(xsum),SUM(ysum),SUM(dirsumtime)  FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
+        'vecavg': "SELECT SUM(xsum),SUM(ysum),SUM(sumtime)  FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
         'vecdir': "SELECT SUM(xsum),SUM(ysum) FROM %(table_name)s_day_%(obs_key)s WHERE dateTime >= %(start)s AND dateTime < %(stop)s",
     }
 


### PR DESCRIPTION
The vector average wind speed (vecavg) I see displayed is often higher than the average wind speed, but the triangle inequality implies that the vector sum should always be less than or equal to the straight sum. It looks like weewx is dividing the vector sum components (xsum and ysum) by the time the wind vector was nonzero (dirsumtime), not by the time there is wind data (sumtime, including times when the wind is not blowing). This means that, eg, wind at <0,0> for one minute followed by <20,0> for one minute has a computed vector average of 20 (and a straight average of 10, which is what the vector average should have been too in this case) while wind at <0.1, 0> then <20,0> has a vector average of 10.05 (and straight average of 10.05). This fix just changes weewx to use sumtime instead of dirsumtime for that calculation.