### PR TITLE
fixed windrun calculation to be for current period only

### DIFF
--- a/bin/weewx/wxservices.py
+++ b/bin/weewx/wxservices.py
@@ -375,32 +375,18 @@ class WXCalculate(object):
             pass
 
     def calc_windrun(self, data, data_type):
-        """Calculate the wind run since the beginning of the day.  Convert to
-        US if necessary since this service operates in US unit system."""
+        """Calculate the wind run for the archive interval. """
         # calculate windrun only for archive packets
         if data_type == 'loop':
             return
-        ets = data['dateTime']
-        sts = weeutil.weeutil.startOfDay(ets)
-        run = 0.0
-        try:
-            dbmanager = self.db_binder.get_manager(self.binding)
-            for row in dbmanager.genSql("SELECT `interval`,windSpeed,usUnits"
-                                        " FROM %s"
-                                        " WHERE dateTime>? AND dateTime<=?" %
-                                        dbmanager.table_name, (sts, ets)):
-                if row and None not in row:
-                    vals_us = weewx.units.to_US({'interval' : row[0],
-                                                 'windSpeed' : row[1],
-                                                 'usUnits' : row[2]})
-                    run += vals_us['windSpeed'] * vals_us['interval'] / 60.0
-        except weedb.DatabaseError:
-            data['windrun'] = None
+        # Calculate windrun for archive record
+        if 'windSpeed' in data and not data.get('windSpeed'):
+            #no wind data for archive period, therefore run = None
+            run = None
         else:
-            # Include the "current" record
-            if data.get('windSpeed') is not None:
-                run += data['windSpeed'] * data['interval'] / 60.0
-            data['windrun'] = run
+            # run is value * interval (seconds) / 60 to give run total in miles
+            run = data['windSpeed'] * data['interval'] / 60.0
+        data['windrun'] = run
 
     def _get_archive_interval(self, data):
         if 'interval' in data and data['interval']:

--- a/bin/weewx/wxservices.py
+++ b/bin/weewx/wxservices.py
@@ -380,12 +380,13 @@ class WXCalculate(object):
         if data_type == 'loop':
             return
         # Calculate windrun for archive record
-        if 'windSpeed' in data and not data.get('windSpeed'):
-            #no wind data for archive period, therefore run = None
-            run = None
-        else:
-            # run is value * interval (seconds) / 60 to give run total in miles
-            run = data['windSpeed'] * data['interval'] / 60.0
+        if 'windSpeed' in data:
+            if 'windSpeed' is None:
+                #no wind speed data for archive period, therefore run = None
+                run = None
+            else:
+                # run is value * interval (seconds) / 60 to give run total in miles
+                run = data['windSpeed'] * data['interval'] / 60.0
         data['windrun'] = run
 
     def _get_archive_interval(self, data):


### PR DESCRIPTION
I've made some changes to wxservices.py so that calc_windrun only calculates the run for the current archive period. This I believe fixes  #250. The method is somewhat simpler now as it doesn't have to query the db to find out previous windrun values, which I think is the new intent.

Being new to this whole process I'm not quite sure how to test it works. I flicked the code onto my test system and it didn't throw any errors, however, I can see that windrun is not actually in my db schema and I'm not actually sure how to get it there?

Comments and suggestions welcomed.