### PR TITLE
Corrected wunderfixer use of restx.AmbientThread class

### DIFF
--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -779,16 +779,16 @@ examples:
 from __future__ import with_statement
 from __future__ import absolute_import
 from __future__ import print_function
-import sys
 import time
 import usb
 
 import weewx.drivers
 import weewx.wxformulas
 from weeutil.weeutil import timestamp_to_string
+from weeutil.log import logdbg, loginf, logerr, logcrt
 
 DRIVER_NAME = 'WMR300'
-DRIVER_VERSION = '0.21'
+DRIVER_VERSION = '0.20'
 
 DEBUG_COMM = 0
 DEBUG_PACKET = 0
@@ -797,28 +797,6 @@ DEBUG_DECODE = 0
 DEBUG_HISTORY = 0
 DEBUG_RAIN = 0
 DEBUG_TIMING = 0
-
-# Check for Python 2 vs. 3 as the basis for WeeWX 3 vs. 4
-# This mainly affects how logging is handled
-
-if sys.version_info[0] < 3:
-    import syslog
-    def logmsg(level, msg):
-        syslog.syslog(level, 'wmr300: %s' % msg)
-    
-    def logdbg(msg):
-        logmsg(syslog.LOG_DEBUG, msg)
-    
-    def loginf(msg):
-        logmsg(syslog.LOG_INFO, msg)
-    
-    def logerr(msg):
-        logmsg(syslog.LOG_ERR, msg)
-    
-    def logcrt(msg):
-        logmsg(syslog.LOG_CRIT, msg)
-else:
-    from weeutil.log import logdbg, loginf, logerr, logcrt
 
 
 def loader(config_dict, _):

--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -779,16 +779,16 @@ examples:
 from __future__ import with_statement
 from __future__ import absolute_import
 from __future__ import print_function
+import sys
 import time
 import usb
 
 import weewx.drivers
 import weewx.wxformulas
 from weeutil.weeutil import timestamp_to_string
-from weeutil.log import logdbg, loginf, logerr, logcrt
 
 DRIVER_NAME = 'WMR300'
-DRIVER_VERSION = '0.20'
+DRIVER_VERSION = '0.21'
 
 DEBUG_COMM = 0
 DEBUG_PACKET = 0
@@ -797,6 +797,28 @@ DEBUG_DECODE = 0
 DEBUG_HISTORY = 0
 DEBUG_RAIN = 0
 DEBUG_TIMING = 0
+
+# Check for Python 2 vs. 3 as the basis for WeeWX 3 vs. 4
+# This mainly affects how logging is handled
+
+if sys.version_info[0] < 3:
+    import syslog
+    def logmsg(level, msg):
+        syslog.syslog(level, 'wmr300: %s' % msg)
+    
+    def logdbg(msg):
+        logmsg(syslog.LOG_DEBUG, msg)
+    
+    def loginf(msg):
+        logmsg(syslog.LOG_INFO, msg)
+    
+    def logerr(msg):
+        logmsg(syslog.LOG_ERR, msg)
+    
+    def logcrt(msg):
+        logmsg(syslog.LOG_CRIT, msg)
+else:
+    from weeutil.log import logdbg, loginf, logerr, logcrt
 
 
 def loader(config_dict, _):

--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -1978,8 +1978,8 @@ if __name__ == '__main__':
     if options.get_history:
         ts = time.time() - 3600 # get last hour of data
         for pkt in stn.genStartupRecords(ts):
-            print(to_sorted_string(pkt))
+            print(to_sorted_string(pkt).encode('utf-8'))
 
     if options.get_current:
         for packet in stn.genLoopPackets():
-            print(to_sorted_string(packet))
+            print(to_sorted_string(packet).encode('utf-8'))

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -214,12 +214,12 @@ def main() :
 
     # Get a WunderStation object so we can interact with Weather Underground
     wunder = WunderStation(q=None,  # Bogus queue. We will not be using it.
+                           manager_dict=dbmanager_t,
                            station=options.station,
                            password=options.password,
                            server_url=weewx.restx.StdWunderground.pws_url,
                            protocol_name = "wunderfixer",
                            essentials=_essentials_dict,
-                           manager_dict=None, # Bogus md. We will not be using it.
                            softwaretype = "wunderfixer-%s" % __version__)
 
     try:

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -17,6 +17,9 @@ Weather Underground with the missing data.
 
 CHANGE HISTORY
 --------------------------------
+1.4.1 05/14/2019
+Made WunderStation class consistent with restx.AmbientThread parameters
+
 1.4.0 05/07/2019
 Ported to Python 3
 
@@ -93,7 +96,7 @@ a new record on the Weather Underground with the missing data.
 Be sure to use the --test switch first to see whether you like what it 
 proposes!"""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 # The number of seconds difference in the timestamp between two records
 # and still have them considered to be the same: 
@@ -210,13 +213,13 @@ def main() :
         print("Number of archive records:    ", len(archive_results))
 
     # Get a WunderStation object so we can interact with Weather Underground
-    wunder = WunderStation(queue=None,  # Bogus queue. We will not be using it.
-                           manager_dict=dbmanager_t,
+    wunder = WunderStation(q=None,  # Bogus queue. We will not be using it.
                            station=options.station,
                            password=options.password,
                            server_url=weewx.restx.StdWunderground.pws_url,
                            protocol_name = "wunderfixer",
                            essentials=_essentials_dict,
+                           manager_dict=None, # Bogus md. We will not be using it.
                            softwaretype = "wunderfixer-%s" % __version__)
 
     try:


### PR DESCRIPTION
Corrected problem with wunderfixer use of restx.AmbientThread class being out of sync with actual restx.AmbientThread parameter requirements.

1.4.1 05/14/2019
Made WunderStation class consistent with restx.AmbientThread parameters
