### PR TITLE
4.0.x wunderfixer Change to new API KEY method of querying historical data

### DIFF
--- a/bin/weewx/drivers/wmr300.py
+++ b/bin/weewx/drivers/wmr300.py
@@ -1978,8 +1978,8 @@ if __name__ == '__main__':
     if options.get_history:
         ts = time.time() - 3600 # get last hour of data
         for pkt in stn.genStartupRecords(ts):
-            print(to_sorted_string(pkt))
+            print(to_sorted_string(pkt).encode('utf-8'))
 
     if options.get_current:
         for packet in stn.genLoopPackets():
-            print(to_sorted_string(packet))
+            print(to_sorted_string(packet).encode('utf-8'))

--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -771,6 +771,7 @@ class AmbientThread(RESTThread):
                  post_indoor_observations=False,
                  protocol_name="Unknown-Ambient",
                  essentials={},
+                 apikey=None,
                  post_interval=None, max_backlog=six.MAXSIZE, stale=None,
                  log_success=True, log_failure=True,
                  timeout=10, max_tries=3, retry_wait=5, retry_login=3600,
@@ -901,6 +902,7 @@ class AmbientLoopThread(AmbientThread):
                  station, password, server_url,
                  protocol_name="Unknown-Ambient",
                  essentials={},
+                 apikey=None,
                  post_interval=None, max_backlog=six.MAXSIZE, stale=None,
                  log_success=True, log_failure=True,
                  timeout=10, max_tries=3, retry_wait=5, rtfreq=2.5):

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -17,6 +17,9 @@ Weather Underground with the missing data.
 
 CHANGE HISTORY
 --------------------------------
+1.4.1 05/14/2019
+Made WunderStation class consistent with restx.AmbientThread parameters
+
 1.4.0 05/07/2019
 Ported to Python 3
 
@@ -93,7 +96,7 @@ a new record on the Weather Underground with the missing data.
 Be sure to use the --test switch first to see whether you like what it 
 proposes!"""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 # The number of seconds difference in the timestamp between two records
 # and still have them considered to be the same: 
@@ -210,7 +213,7 @@ def main() :
         print("Number of archive records:    ", len(archive_results))
 
     # Get a WunderStation object so we can interact with Weather Underground
-    wunder = WunderStation(queue=None,  # Bogus queue. We will not be using it.
+    wunder = WunderStation(q=None,  # Bogus queue. We will not be using it.
                            manager_dict=dbmanager_t,
                            station=options.station,
                            password=options.password,

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -17,6 +17,9 @@ Weather Underground with the missing data.
 
 CHANGE HISTORY
 --------------------------------
+1.4.2 05/22/2019
+Change User-Agent to avoid HTTP 403 when querying WU
+
 1.4.1 05/14/2019
 Made WunderStation class consistent with restx.AmbientThread parameters
 
@@ -340,13 +343,15 @@ class WunderStation(weewx.restx.AmbientThread):
         """
         dayRequested_tt = dayRequested.timetuple()
         
-        _url = "http://www.wunderground.com/weatherstation/WXDailyHistory.asp?ID=%s" \
+        _url = "https://www.wunderground.com/weatherstation/WXDailyHistory.asp?ID=%s" \
                "&month=%d&day=%d&year=%d&format=1" % (self.station, dayRequested_tt[1],
                                                       dayRequested_tt[2], dayRequested_tt[0])
-        
+
+        _wureq = urllib.request.Request(_url, headers={'User-Agent': 'Mozilla'})
+
         try :
             # Hit the weather underground site:
-            _wudata = urllib.request.urlopen(_url)
+            _wudata = urllib.request.urlopen(_wureq)
         except urllib.error.URLError as e :
             print("Unable to open Weather Underground station " + self.station, " or ", e, file=sys.stderr)
             wlog.slog(syslog.LOG_ERR, "Unable to open Weather Underground station %s or %s" % (self.station, e))

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -99,7 +99,7 @@ a new record on the Weather Underground with the missing data.
 Be sure to use the --test switch first to see whether you like what it 
 proposes!"""
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 # The number of seconds difference in the timestamp between two records
 # and still have them considered to be the same: 

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -131,7 +131,7 @@ def main() :
     parser.add_option("-p", "--password", type="string", dest="password",
                       help="Weather Underground station password. Optional. "
                       "Default is to take from configuration file.")
-    parser.add_option("-k", "--apikey", type="string", dest="apiKey",
+    parser.add_option("-k", "--apikey", type="string", dest="apikey",
                       help="Weather Underground station API Key. Optional. "
                       "Default is to take from configuration file.")
     parser.add_option("-d", "--date", type="string", dest="date", metavar="YYYY-mm-dd",
@@ -166,20 +166,20 @@ def main() :
     print("Using configuration file %s." % config_fn)
     wlog.slog(syslog.LOG_INFO, "Using weewx configuration file %s." % config_fn)
 
-    # Retrieve the station ID, password, and apiKey from the config file
+    # Retrieve the station ID, password, and apikey from the config file
     try:
         if not options.station:
             options.station = config_dict['StdRESTful']['Wunderground']['station']
         if not options.password and not options.simulate:
             options.password = config_dict['StdRESTful']['Wunderground']['password'] 
-        if not options.apiKey and not options.simulate:
-            options.apiKey = config_dict['StdRESTful']['Wunderground']['apiKey'] 
+        if not options.apikey:
+            options.apikey = config_dict['StdRESTful']['Wunderground']['apikey'] 
     except KeyError:
-        wlog.slog(syslog.LOG_ERR, "Missing Wunderground station, password, and/or apiKey")
-        exit("Missing Wunderground station, password, and/or apiKey")
+        wlog.slog(syslog.LOG_ERR, "Missing Wunderground station, password, and/or apikey")
+        exit("Missing Wunderground station, password, and/or apikey")
     
     # exit if any essential arguments are not present
-    if not options.station or (not options.password and not options.simulate):
+    if not options.station or not options.apikey or (not options.password and not options.simulate):
         print("Missing argument(s).\n")
         print(parser.parse_args(["--help"]))
         wlog.slog(syslog.LOG_ERR, "Missing argument(s). Wunderfixer exiting.")
@@ -237,7 +237,7 @@ def main() :
 
     try:
         # Get all the time stamps on the Weather Underground for the given day:
-        wunder_results = wunder.getDayTimeStamps(date_date, options.apiKey)
+        wunder_results = wunder.getDayTimeStamps(date_date, options.apikey)
     except Exception as e:
         print("Could not get Weather Underground data.")
         print("Reason: %s" % e)
@@ -344,7 +344,7 @@ class WunderStation(weewx.restx.AmbientThread):
     # match any HTML tag of the form <...>
     _tags = re.compile(r'\<.*\>')
     
-    def getDayTimeStamps(self, dayRequested, apiKey) :
+    def getDayTimeStamps(self, dayRequested, apikey) :
         """Returns all time stamps for a given weather underground station for a given day
         
         dayRequested: An instance of datetime.date with the requested date
@@ -354,7 +354,7 @@ class WunderStation(weewx.restx.AmbientThread):
         dayRequested_tt = dayRequested.timetuple()
         
         _url = "https://api.weather.com/v2/pws/history/all?stationId=%s&format=json&units=m&date=%4.4d%2.2d%2.2d&apiKey=%s" \
-                % (self.station, dayRequested_tt[0], dayRequested_tt[1], dayRequested_tt[2], apiKey)
+                % (self.station, dayRequested_tt[0], dayRequested_tt[1], dayRequested_tt[2], apikey)
 
         _wureq = urllib.request.Request(_url, headers={'User-Agent': 'Mozilla'})
 

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -17,6 +17,10 @@ Weather Underground with the missing data.
 
 CHANGE HISTORY
 --------------------------------
+1.5.0 05/24/2019
+Change to new API KEY method of querying historical data
+NOTE: Re-uploading missing records still uses old method (password-based).
+
 1.4.2 05/22/2019
 Change User-Agent to avoid HTTP 403 when querying WU
 
@@ -74,6 +78,7 @@ import socket
 import sys
 import syslog
 import time
+import json
 
 # Python 2/3 compatiblity shims
 import six
@@ -86,7 +91,7 @@ import weewx.restx
 
 usagestr = """%prog CONFIG_FILE|--config=CONFIG_FILE
                   [--binding=BINDING]
-                  [--station=STATION] [--password=PASSWORD]
+                  [--station=STATION] [--password=PASSWORD] [--apikey=APIKEY]
                   [--date=YYYY-mm-dd] [--epsilon=SECONDS] [--timeout=SECONDS]
                   [--verbose] [--log LOG_FACILITY] [--test] [--query]
                   [--help]
@@ -99,7 +104,7 @@ a new record on the Weather Underground with the missing data.
 Be sure to use the --test switch first to see whether you like what it 
 proposes!"""
 
-__version__ = "1.4.2"
+__version__ = "1.5.0"
 
 # The number of seconds difference in the timestamp between two records
 # and still have them considered to be the same: 
@@ -125,6 +130,8 @@ def main() :
                       "Default is to take from configuration file.")
     parser.add_option("-p", "--password", type="string", dest="password",
                       help="Weather Underground station password. Optional. "
+                      "Default is to take from configuration file.")
+                      help="Weather Underground station API Key. Optional. "
                       "Default is to take from configuration file.")
     parser.add_option("-d", "--date", type="string", dest="date", metavar="YYYY-mm-dd",
                       help="Date to check as a string of form YYYY-mm-dd. Default is today.")
@@ -158,15 +165,17 @@ def main() :
     print("Using configuration file %s." % config_fn)
     wlog.slog(syslog.LOG_INFO, "Using weewx configuration file %s." % config_fn)
 
-    # Retrieve the station ID and password from the config file
+    # Retrieve the station ID, password, and apiKey from the config file
     try:
         if not options.station:
             options.station = config_dict['StdRESTful']['Wunderground']['station']
         if not options.password and not options.simulate:
             options.password = config_dict['StdRESTful']['Wunderground']['password'] 
+        if not options.apiKey and not options.simulate:
+            options.apiKey = config_dict['StdRESTful']['Wunderground']['apiKey'] 
     except KeyError:
-        wlog.slog(syslog.LOG_ERR, "Missing Wunderground station and/or password")
-        exit("Missing Wunderground station and/or password")
+        wlog.slog(syslog.LOG_ERR, "Missing Wunderground station, password, and/or apiKey")
+        exit("Missing Wunderground station, password, and/or apiKey")
     
     # exit if any essential arguments are not present
     if not options.station or (not options.password and not options.simulate):
@@ -227,7 +236,7 @@ def main() :
 
     try:
         # Get all the time stamps on the Weather Underground for the given day:
-        wunder_results = wunder.getDayTimeStamps(date_date)
+        wunder_results = wunder.getDayTimeStamps(date_date, options.apiKey)
     except Exception as e:
         print("Could not get Weather Underground data.")
         print("Reason: %s" % e)
@@ -334,7 +343,7 @@ class WunderStation(weewx.restx.AmbientThread):
     # match any HTML tag of the form <...>
     _tags = re.compile(r'\<.*\>')
     
-    def getDayTimeStamps(self, dayRequested) :
+    def getDayTimeStamps(self, dayRequested, apiKey) :
         """Returns all time stamps for a given weather underground station for a given day
         
         dayRequested: An instance of datetime.date with the requested date
@@ -343,9 +352,8 @@ class WunderStation(weewx.restx.AmbientThread):
         """
         dayRequested_tt = dayRequested.timetuple()
         
-        _url = "https://www.wunderground.com/weatherstation/WXDailyHistory.asp?ID=%s" \
-               "&month=%d&day=%d&year=%d&format=1" % (self.station, dayRequested_tt[1],
-                                                      dayRequested_tt[2], dayRequested_tt[0])
+        _url = "https://api.weather.com/v2/pws/history/all?stationId=%s&format=json&units=m&date=%4.4d%2.2d%2.2d&apiKey=%s" \
+                % (self.station, dayRequested_tt[0], dayRequested_tt[1], dayRequested_tt[2], apiKey)
 
         _wureq = urllib.request.Request(_url, headers={'User-Agent': 'Mozilla'})
 
@@ -361,27 +369,20 @@ class WunderStation(weewx.restx.AmbientThread):
             wlog.slog(syslog.LOG_ERR, "Socket timeout for Weather Underground station %s" % self.station)
             raise
 
-        # Because the data comes back with lots of HTML tags and blank lines in it,
-        # we need a bit of logic to clean it up.
-        _cleanWUdata = []
-        for _row in _wudata :
-            _urow = _row.decode('ascii')
-            _line = ''.join(WunderStation._tags.split(_urow))  # Get rid of any HTML tags
-            if _line != "\n" :                                 # Get rid of any blank lines
-                _cleanWUdata.append(_line)                     # Save what's left
-    
-        # Now form a dictionary CSV reader, using the first line as the set of keys
-        _csvreader = csv.DictReader(_cleanWUdata)
-        
-        # We are only interested in the time stamps. Decode them
-        # and return as a list
+
+        # Convert _wudata HTTPresponse to string type and string type to list
+        _wustring = _wudata.read().decode('utf-8')
+        _wujson = json.loads(_wustring)
+
+        # We just need the timeStamps that the WU API stores as "epoch" keys
         _timeStamps = []
-        for _row in _csvreader :
-            _datetm = time.strptime(_row["Time"], "%Y-%m-%d %H:%M:%S")
-            _time_t = int(time.mktime(_datetm))
+        for _row in _wujson['observations']:
+            # the epoch values are of type string, so we need to convert them
+            _time_t = int(_row['epoch'])
+
             # Add to timeStamps
             _timeStamps.append(TimeStamp(_time_t))
-            
+    
         return _timeStamps
 
 #===============================================================================

--- a/bin/wunderfixer
+++ b/bin/wunderfixer
@@ -131,6 +131,7 @@ def main() :
     parser.add_option("-p", "--password", type="string", dest="password",
                       help="Weather Underground station password. Optional. "
                       "Default is to take from configuration file.")
+    parser.add_option("-k", "--apikey", type="string", dest="apiKey",
                       help="Weather Underground station API Key. Optional. "
                       "Default is to take from configuration file.")
     parser.add_option("-d", "--date", type="string", dest="date", metavar="YYYY-mm-dd",


### PR DESCRIPTION
Tested on python2 and python3.
Can't help WU's sporadic 404 and 503 errors, but at least the 403 is gone.