### PR TITLE
First cut of python logging in wee_import

### DIFF
--- a/bin/wee_import
+++ b/bin/wee_import
@@ -815,7 +815,7 @@ def main():
 
         # advise the user we are starting up
         print("Starting wee_import...")
-        log.log(logging.INFO, "Starting wee_import...")
+        log.info("Starting wee_import...")
 
         # If we got this far we must want to import something so get a Source
         # object from our factory and try to import. Be prepared to catch any
@@ -826,42 +826,41 @@ def main():
             source_obj.run()
         except weeimport.weeimport.WeeImportOptionError as e:
             print("**** Command line option error.")
-            log.log(logging.INFO, "**** Command line option error.")
+            log.info("**** Command line option error.")
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportIOError as e:
             print("**** Unable to load source file.")
-            log.log(logging.INFO, "**** Unable to load source file.")
+            log.info("**** Unable to load source file.")
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportFieldError as e:
             print("**** Unable to map source data.")
-            log.log(logging.INFO, "**** Unable to map source data.")
+            log.info("**** Unable to map source data.")
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportMapError as e:
             print("**** Unable to parse source-to-WeeWX field map.")
-            log.log(logging.INFO,
-                    "**** Unable to parse source-to-WeeWX field map.")
+            log.info("**** Unable to parse source-to-WeeWX field map.")
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
         except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             print()
             parser.print_help()
             exit(1)
@@ -870,17 +869,17 @@ def main():
             exit(0)
         except (ValueError, weewx.UnitError) as e:
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
         except IOError as e:
             print("**** Unable to load config file.")
-            log.log(logging.INFO, "**** Unable to load config file.")
+            log.info("**** Unable to load config file.")
             print("**** %s" % e)
-            log.log(logging.INFO, "**** %s" % e)
+            log.info("**** %s" % e)
             print("**** Nothing done, exiting.")
-            log.log(logging.INFO, "**** Nothing done.")
+            log.info("**** Nothing done.")
             exit(1)
     else:
         # we have no import config file so display a suitable message followed

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -808,54 +808,60 @@ def main():
         print("wee_import version: %s" % WEE_IMPORT_VERSION)
         exit(0)
 
-    # set up wee_import logging
-    wlog = weeimport.weeimport.WeeImportLog(log, options)
-
     # to do anything more we need an import config file, check if one was
     # provided
     if options.import_config_path:
         # we have something so try to start
 
         # advise the user we are starting up
-        wlog.printlog(logging.INFO, "Starting wee_import...")
+        print("Starting wee_import...")
+        log.log(logging.INFO, "Starting wee_import...")
 
         # If we got this far we must want to import something so get a Source
         # object from our factory and try to import. Be prepared to catch any
         # errors though.
         try:
             source_obj = weeimport.weeimport.Source.sourceFactory(options,
-                                                                  args,
-                                                                  wlog)
+                                                                  args)
             source_obj.run()
         except weeimport.weeimport.WeeImportOptionError as e:
-            wlog.printlog(logging.INFO, "**** Command line option error.")
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Command line option error.")
+            log.log(logging.INFO, "**** Command line option error.")
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportIOError as e:
-            wlog.printlog(logging.INFO, "**** Unable to load source file.")
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Unable to load source file.")
+            log.log(logging.INFO, "**** Unable to load source file.")
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportFieldError as e:
-            wlog.printlog(logging.INFO, "**** Unable to map source data.")
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Unable to map source data.")
+            log.log(logging.INFO, "**** Unable to map source data.")
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
         except weeimport.weeimport.WeeImportMapError as e:
-            wlog.printlog(logging.INFO,
-                          "**** Unable to parse source-to-WeeWX field map.")
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Unable to parse source-to-WeeWX field map.")
+            log.log(logging.INFO,
+                    "**** Unable to parse source-to-WeeWX field map.")
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
         except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             print()
             parser.print_help()
             exit(1)
@@ -863,15 +869,18 @@ def main():
             print(e)
             exit(0)
         except (ValueError, weewx.UnitError) as e:
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
         except IOError as e:
-            wlog.printlog(logging.INFO, "**** Unable to load config file.")
-            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Unable to load config file.")
+            log.log(logging.INFO, "**** Unable to load config file.")
+            print("**** %s" % e)
+            log.log(logging.INFO, "**** %s" % e)
             print("**** Nothing done, exiting.")
-            wlog.logonly(logging.INFO, "**** Nothing done.")
+            log.log(logging.INFO, "**** Nothing done.")
             exit(1)
     else:
         # we have no import config file so display a suitable message followed

--- a/bin/wee_import
+++ b/bin/wee_import
@@ -9,47 +9,51 @@
 
 Compatibility:
 
-   wee_import can import from a Comma Separated Values (CSV) format file,
-   directly from the historical records of a Weather Underground Personal
-   Weather Station or from one or more Cumulus monthly log files. CSV format
-   files must have a comma separated list of field names on the first line.
+    wee_import can import from:
+        - a Comma Separated Values (CSV) format file
+        - the historical records of a Weather Underground Personal
+          Weather Station
+        - one or more Cumulus monthly log files
+        - one or more Weather Display monthly log files
 
 Design
 
-   wee_import utilises a config file (the import config file) and a number of
-   command line options to control the import. The config file defines the type
-   of input to be performed and the import data source as well as more advanced
-   options such as field maps etc. Details of the supported command line
-   parameters/options can be viewed by entering wee_import --help at the command
-   line. Details of the wee_import config file settings can be found in example
-   import config files distributed in the weewx/util/import directory.
+    wee_import utilises an import config file and a number of command line
+    options to control the import. The import config file defines the type of
+    input to be performed and the import data source as well as more advanced
+    options such as field maps etc. Details of the supported command line
+    parameters/options can be viewed by entering wee_import --help at the
+    command line. Details of the wee_import import config file settings can be
+    found in the example import config files distributed in the
+    weewx/util/import directory.
 
-   wee_import utilises an abstract base class Source that defines the majority
-   of the wee_import functionality. The abstract base class and other supporting
-   structures are in bin/weeimport/weeimport.py. Child classes are created from
-   the base class for each different import type supported by wee_import. The
-   child classes set a number of import type specific properties as well as
-   defining a getData() method that reads the raw data to be imported and a
-   period_generator() method that generates a sequence of objects to be imported
-   (eg monthly log files). This way wee_import can be extended to support other
-   sources by defining a new child class, its specific properties as well as
-   getData() and period_generator() methods. The child class for a given import
-   type are defined in the bin/weeimport/xxximport.py files.
+    wee_import utilises an abstract base class Source that defines the majority
+    of the wee_import functionality. The abstract base class and other
+    supporting structures are in bin/weeimport/weeimport.py. Child classes are
+    created from the base class for each different import type supported by
+    wee_import. The child classes set a number of import type specific
+    properties as well as defining getData() and period_generator() methods that
+    read the raw data to be imported and generates a sequence of objects to be
+    imported (eg monthly log files) respectively. This way wee_import can be
+    extended to support other sources by defining a new child class, its
+    specific properties as well as getData() and period_generator() methods. The
+    child class for a given import type are defined in the
+    bin/weeimport/xxximport.py files.
 
-   As with other WeeWX utilities, wee_import advises the user of basic
-   configuration, action taken and results via stdout. However, since
-   wee_import can make substantial changes to the WeeWX archive, wee_import also
-   logs to file by default. This functionality is controlled via a command
-   line option.
+    As with other WeeWX utilities, wee_import advises the user of basic
+    configuration, action taken and results via the console. However, since
+    wee_import can make substantial changes to the WeeWX archive, wee_import
+    also logs to WeeWX log system file. Console and log output can be controlled
+    via a number of command line options.
 
 Prerequisites
 
-   wee_import uses a number of WeeWX API calls and therefore must have a
-   functional WeeWX installation. wee_import requires WeeWX 3.6.0 or later.
+    wee_import uses a number of WeeWX API calls and therefore must have a
+    functional WeeWX installation. wee_import requires WeeWX 4.0.0 or later.
 
 Configuration
 
-   A number of parameters can be defined in the import config file as follows:
+    A number of parameters can be defined in the import config file as follows:
 
 # EXAMPLE WEE_IMPORT CONFIGURATION FILE
 #
@@ -63,7 +67,7 @@ Configuration
 #   WU - import obs from a Weather Underground PWS history
 #   Cumulus - import obs from a one or more Cumulus monthly log files
 # Format is:
-#   source = (CSV | WU | Cumulus)
+#   source = (CSV | WU | Cumulus | WD)
 source = CSV
 
 ##############################################################################
@@ -511,10 +515,10 @@ source = CSV
     #   inTemp
     #   outHumidity
     #   outTemp
-    #   radiation   (if Cumulus data available)
-    #   rain        (requires Cumulus 1.9.4 or later)
+    #   radiation   (if WD radiation data available)
+    #   rain
     #   rainRate
-    #   UV          (if Cumulus data available)
+    #   UV          (if WD UV data available)
     #   windDir
     #   windGust
     #   windSpeed
@@ -557,8 +561,8 @@ source = CSV
     #            setting is best used if the records to be imported are
     #            equally based in time but there are some missing records.
     #            This setting is recommended for WU imports.
-    # To import Cumulus records it is recommended that the interval setting
-    # be set to the value used in Cumulus as the 'data log interval'.
+    # To import WD records it is recommended that the interval setting be set to
+    # the value used in WD as the 'data log interval'.
     # Format is:
     #   interval = (derive | conf | x)
     interval = x
@@ -580,17 +584,17 @@ source = CSV
     #   calc_missing = (True | False)
     calc_missing = True
 
-    # Specify the character used as the field delimiter as Cumulus monthly log
-    # files may not always use a comma to delimit fields in the monthly log
-    # files. The character must be enclosed in quotes. Must not be the same
-    # as the decimal setting below. Format is:
+    # Specify the character used as the field delimiter as WD monthly log files
+    # may not always use a comma to delimit fields in the monthly log files. The
+    # character must be enclosed in quotes. Must not be the same as the decimal
+    # setting below. Format is:
     #   delimiter = ','
     delimiter = ','
 
-    # Specify the character used as the decimal point. Cumulus monthly log
-    # files may not always use a fullstop character as the decimal point. The
-    # character must be enclosed in quotes. Must not be the same as the
-    # delimiter setting. Format is:
+    # Specify the character used as the decimal point. WD monthly log file may
+    # not always use a full stop character as the decimal point. The character
+    # must be enclosed in quotes. Must not be the same as the delimiter setting.
+    # Format is:
     #   decimal = '.'
     decimal = '.'
 
@@ -705,20 +709,27 @@ Adding a New Import Source
 # Python imports
 from __future__ import absolute_import
 from __future__ import print_function
+
+import logging
 import optparse
-import syslog
 
 from distutils.version import StrictVersion
 
 # WeeWX imports
+import weecfg
 import weewx
 import weeimport
 import weeimport.weeimport
+import weeutil.logger
+import weeutil.weeutil
+
+
+log = logging.getLogger(__name__)
 
 # wee_import version number
-WEE_IMPORT_VERSION = '0.3'
+WEE_IMPORT_VERSION = '0.4'
 # minimum WeeWX version required for this version of wee_import
-REQUIRED_WEEWX = "3.6.0"
+REQUIRED_WEEWX = "4.0.0a7"
 
 description = """Import observation data into a WeeWX archive."""
 
@@ -730,7 +741,6 @@ usage = """wee_import --help
             [--dry-run]
             [--verbose]
             [--suppress-warnings]
-            [--log=-]
 """
 
 epilog = """wee_import will import data from an external source into a WeeWX
@@ -742,6 +752,9 @@ epilog = """wee_import will import data from an external source into a WeeWX
 def main():
     """The main routine that kicks everything off."""
 
+    # Set defaults for logging:
+    weeutil.logger.setup('wee_import', {})
+
     # Create a command line parser:
     parser = optparse.OptionParser(description=description,
                                    usage=usage,
@@ -749,8 +762,8 @@ def main():
 
     # Add the various options:
     parser.add_option("--config", dest="config_path", type=str,
-                      metavar="CONFIG_FILE", default="weewx.conf",
-                      help="Use WeeWX configuration file CONFIG_FILE.")
+                      metavar="CONFIG_FILE",
+                      help="Use configuration file CONFIG_FILE.")
     parser.add_option("--import-config", dest="import_config_path", type=str,
                       metavar="IMPORT_CONFIG_FILE",
                       help="Use import configuration file IMPORT_CONFIG_FILE.")
@@ -764,15 +777,8 @@ def main():
     parser.add_option("--to", dest="date_to", type=str, metavar="YYYY-mm-dd[THH:MM]",
                       help="Import data up until this date or date-time. Format "
                            "is YYYY-mm-dd[THH:MM].")
-    parser.add_option("--log", dest="logging", type=str, metavar="-",
-                      help="Control wee_import log output. By default log output "
-                           "is sent to the WeeWX log file. Log output may be "
-                           "disabled by using '--log=-'. Some WeeWX API log "
-                           "output cannot be controlled by wee_import and will "
-                           "be sent to the default log file irrespective of the "
-                           "'--log' option.")
     parser.add_option("--verbose", action="store_true", dest="verbose",
-                      help="Print useful extra output.")
+                      help="Print and log useful extra output.")
     parser.add_option("--suppress-warnings", action="store_true", dest="suppress",
                       help="Suppress warnings to stdout. Warnings are still logged.")
     parser.add_option("--version", dest="version", action="store_true",
@@ -787,74 +793,95 @@ def main():
                                                                                      weewx.__version__))
         exit(1)
 
+    # get config_dict to use
+    config_path, config_dict = weecfg.read_config(options.config_path, args)
+    print("Using WeeWX configuration file %s" % config_path)
+
+    # Set weewx.debug as necessary:
+    weewx.debug = weeutil.weeutil.to_int(config_dict.get('debug', 0))
+
+    # Now we can set up the user customized logging:
+    weeutil.logger.setup('wee_import', config_dict)
+
     # display wee_import version info
     if options.version:
         print("wee_import version: %s" % WEE_IMPORT_VERSION)
         exit(0)
 
-    # Set up logging
-    wlog = weeimport.weeimport.WeeImportLog(options.logging,
-                                            options.verbose,
-                                            options.suppress,
-                                            options.dry_run)
+    # set up wee_import logging
+    wlog = weeimport.weeimport.WeeImportLog(log, options)
 
-    # advise the user we are starting up
-    wlog.printlog(syslog.LOG_INFO, "Starting wee_import...")
+    # to do anything more we need an import config file, check if one was
+    # provided
+    if options.import_config_path:
+        # we have something so try to start
 
-    # If we got this far we must want to import something so get a Source
-    # object from our factory and try to import. Be prepared to catch any
-    # errors though.
-    try:
-        source_obj = weeimport.weeimport.Source.sourceFactory(options,
-                                                              args,
-                                                              wlog)
-        source_obj.run()
-    except weeimport.weeimport.WeeImportOptionError as e:
-        wlog.printlog(syslog.LOG_INFO, "**** Command line option error.")
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
-    except weeimport.weeimport.WeeImportIOError as e:
-        wlog.printlog(syslog.LOG_INFO, "**** Unable to load source file.")
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
-    except weeimport.weeimport.WeeImportFieldError as e:
-        wlog.printlog(syslog.LOG_INFO, "**** Unable to map source data.")
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
-    except weeimport.weeimport.WeeImportMapError as e:
-        wlog.printlog(syslog.LOG_INFO,
-                      "**** Unable to parse source-to-WeeWX field map.")
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
-    except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
+        # advise the user we are starting up
+        wlog.printlog(logging.INFO, "Starting wee_import...")
+
+        # If we got this far we must want to import something so get a Source
+        # object from our factory and try to import. Be prepared to catch any
+        # errors though.
+        try:
+            source_obj = weeimport.weeimport.Source.sourceFactory(options,
+                                                                  args,
+                                                                  wlog)
+            source_obj.run()
+        except weeimport.weeimport.WeeImportOptionError as e:
+            wlog.printlog(logging.INFO, "**** Command line option error.")
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+        except weeimport.weeimport.WeeImportIOError as e:
+            wlog.printlog(logging.INFO, "**** Unable to load source file.")
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+        except weeimport.weeimport.WeeImportFieldError as e:
+            wlog.printlog(logging.INFO, "**** Unable to map source data.")
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+        except weeimport.weeimport.WeeImportMapError as e:
+            wlog.printlog(logging.INFO,
+                          "**** Unable to parse source-to-WeeWX field map.")
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+        except (weewx.ViolatedPrecondition, weewx.UnsupportedFeature) as e:
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            print()
+            parser.print_help()
+            exit(1)
+        except SystemExit as e:
+            print(e)
+            exit(0)
+        except (ValueError, weewx.UnitError) as e:
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+        except IOError as e:
+            wlog.printlog(logging.INFO, "**** Unable to load config file.")
+            wlog.printlog(logging.INFO, "**** %s" % e)
+            print("**** Nothing done, exiting.")
+            wlog.logonly(logging.INFO, "**** Nothing done.")
+            exit(1)
+    else:
+        # we have no import config file so display a suitable message followed
+        # by the help text then exit
+        print("**** No import config file specified.")
+        print("**** Nothing done.")
         print()
         parser.print_help()
         exit(1)
-    except SystemExit as e:
-        print(e)
-        exit(0)
-    except (ValueError, weewx.UnitError) as e:
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
-    except IOError as e:
-        wlog.printlog(syslog.LOG_INFO, "**** Unable to load config file.")
-        wlog.printlog(syslog.LOG_INFO, "**** %s" % e)
-        print("**** Nothing done, exiting.")
-        wlog.logonly(syslog.LOG_INFO, "**** Nothing done.")
-        exit(1)
+
 
 # execute our main code
 if __name__ == "__main__":

--- a/bin/weeimport/csvimport.py
+++ b/bin/weeimport/csvimport.py
@@ -15,8 +15,8 @@ from __future__ import print_function
 
 # Python imports
 import csv
+import logging
 import os
-import syslog
 
 # WeeWX imports
 from . import weeimport
@@ -86,12 +86,12 @@ class CSVSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "A CSV import from source file '%s' has been requested." % self.source
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         if options.date:
             _msg = "     source=%s, date=%s" % (self.source, options.date)
         else:
@@ -99,37 +99,43 @@ class CSVSource(weeimport.Source):
             _msg = "     source=%s, from=%s, to=%s" % (self.source,
                                                        options.date_from,
                                                        options.date_to)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s, date/time_string_format=%s" % (self.tranche,
                                                                              self.interval,
                                                                              self.raw_datetime_format)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     rain=%s, wind_direction=%s" % (self.rain, self.wind_dir)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         if self.calc_missing:
-            print("Missing derived observations will be calculated.")
+            self.wlog.printlog(logging.INFO,
+                               "Missing derived observations will be calculated.")
         if not self.UV_sensor:
-            print("All WeeWX UV fields will be set to None.")
+            self.wlog.printlog(logging.INFO,
+                               "All WeeWX UV fields will be set to None.")
         if not self.solar_sensor:
-            print("All WeeWX radiation fields will be set to None.")
+            self.wlog.printlog(logging.INFO,
+                               "All WeeWX radiation fields will be set to None.")
         if options.date or options.date_from:
-            print("Observations timestamped after %s and up to and" % timestamp_to_string(self.first_ts))
-            print("including %s will be imported." % timestamp_to_string(self.last_ts))
+            self.wlog.printlog(logging.INFO,
+                               "Observations timestamped after %s and up to and" % timestamp_to_string(self.first_ts))
+            self.wlog.printlog(logging.INFO,
+                               "including %s will be imported." % timestamp_to_string(self.last_ts))
         if self.dry_run:
-            print("This is a dry run, imported data will not be saved to archive.")
+            self.wlog.printlog(logging.INFO,
+                               "This is a dry run, imported data will not be saved to archive.")
 
     def getRawData(self, period):
         """Obtain an iterable containing the raw data to be imported.

--- a/bin/weeimport/csvimport.py
+++ b/bin/weeimport/csvimport.py
@@ -88,16 +88,16 @@ class CSVSource(weeimport.Source):
         # tell the user/log what we intend to do
         _msg = "A CSV import from source file '%s' has been requested." % self.source
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "The following options will be used:"
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         if options.date:
             _msg = "     source=%s, date=%s" % (self.source, options.date)
         else:
@@ -107,60 +107,60 @@ class CSVSource(weeimport.Source):
                                                        options.date_to)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     tranche=%s, interval=%s, date/time_string_format=%s" % (self.tranche,
                                                                              self.interval,
                                                                              self.raw_datetime_format)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     rain=%s, wind_direction=%s" % (self.rain, self.wind_dir)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         if self.calc_missing:
             _msg = "Missing derived observations will be calculated."
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
 
         if not self.UV_sensor:
             _msg = "All WeeWX UV fields will be set to None."
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
         if not self.solar_sensor:
             _msg = "All WeeWX radiation fields will be set to None."
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
         if options.date or options.date_from:
             _msg = "Observations timestamped after %s and up to and" % timestamp_to_string(self.first_ts)
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
             _msg = "including %s will be imported." % timestamp_to_string(self.last_ts)
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
         if self.dry_run:
             _msg = "This is a dry run, imported data will not be saved to archive."
             print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
 
     def getRawData(self, period):
         """Obtain an iterable containing the raw data to be imported.

--- a/bin/weeimport/csvimport.py
+++ b/bin/weeimport/csvimport.py
@@ -25,6 +25,8 @@ import weewx
 from weeutil.weeutil import timestamp_to_string, option_as_list
 from weewx.units import unit_nicknames
 
+log = logging.getLogger(__name__)
+
 
 # ============================================================================
 #                             class CSVSource
@@ -42,13 +44,12 @@ class CSVSource(weeimport.Source):
     # these details are specified by the user in the wee_import config file.
     _header_map = None
 
-    def __init__(self, config_dict, config_path, csv_config_dict, import_config_path, options, log):
+    def __init__(self, config_dict, config_path, csv_config_dict, import_config_path, options):
 
         # call our parents __init__
         super(CSVSource, self).__init__(config_dict,
                                         csv_config_dict,
-                                        options,
-                                        log)
+                                        options)
 
         # save our import config path
         self.import_config_path = import_config_path
@@ -86,12 +87,17 @@ class CSVSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "A CSV import from source file '%s' has been requested." % self.source
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         if options.date:
             _msg = "     source=%s, date=%s" % (self.source, options.date)
         else:
@@ -99,43 +105,62 @@ class CSVSource(weeimport.Source):
             _msg = "     source=%s, from=%s, to=%s" % (self.source,
                                                        options.date_from,
                                                        options.date_to)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s, date/time_string_format=%s" % (self.tranche,
                                                                              self.interval,
                                                                              self.raw_datetime_format)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     rain=%s, wind_direction=%s" % (self.rain, self.wind_dir)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         if self.calc_missing:
-            self.wlog.printlog(logging.INFO,
-                               "Missing derived observations will be calculated.")
+            _msg = "Missing derived observations will be calculated."
+            print(_msg)
+            log.log(logging.INFO, _msg)
+
         if not self.UV_sensor:
-            self.wlog.printlog(logging.INFO,
-                               "All WeeWX UV fields will be set to None.")
+            _msg = "All WeeWX UV fields will be set to None."
+            print(_msg)
+            log.log(logging.INFO, _msg)
         if not self.solar_sensor:
-            self.wlog.printlog(logging.INFO,
-                               "All WeeWX radiation fields will be set to None.")
+            _msg = "All WeeWX radiation fields will be set to None."
+            print(_msg)
+            log.log(logging.INFO, _msg)
         if options.date or options.date_from:
-            self.wlog.printlog(logging.INFO,
-                               "Observations timestamped after %s and up to and" % timestamp_to_string(self.first_ts))
-            self.wlog.printlog(logging.INFO,
-                               "including %s will be imported." % timestamp_to_string(self.last_ts))
+            _msg = "Observations timestamped after %s and up to and" % timestamp_to_string(self.first_ts)
+            print(_msg)
+            log.log(logging.INFO, _msg)
+            _msg = "including %s will be imported." % timestamp_to_string(self.last_ts)
+            print(_msg)
+            log.log(logging.INFO, _msg)
         if self.dry_run:
-            self.wlog.printlog(logging.INFO,
-                               "This is a dry run, imported data will not be saved to archive.")
+            _msg = "This is a dry run, imported data will not be saved to archive."
+            print(_msg)
+            log.log(logging.INFO, _msg)
 
     def getRawData(self, period):
         """Obtain an iterable containing the raw data to be imported.

--- a/bin/weeimport/cumulusimport.py
+++ b/bin/weeimport/cumulusimport.py
@@ -226,16 +226,16 @@ class CumulusSource(weeimport.Source):
         # tell the user/log what we intend to do
         _msg = "Cumulus monthly log files in the '%s' directory will be imported" % self.source
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "The following options will be used:"
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
@@ -243,31 +243,31 @@ class CumulusSource(weeimport.Source):
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/bin/weeimport/cumulusimport.py
+++ b/bin/weeimport/cumulusimport.py
@@ -26,6 +26,8 @@ import weewx
 from weeutil.weeutil import timestamp_to_string
 from weewx.units import unit_nicknames
 
+log = logging.getLogger(__name__)
+
 # Dict to lookup rainRate units given rain units
 rain_units_dict = {'inch': 'inch_per_hour', 'mm': 'mm_per_hour'}
 
@@ -89,13 +91,12 @@ class CumulusSource(weeimport.Source):
                    'cur_app_temp': {'map_to': 'appTemp'}
                    }
 
-    def __init__(self, config_dict, config_path, cumulus_config_dict, import_config_path, options, log):
+    def __init__(self, config_dict, config_path, cumulus_config_dict, import_config_path, options):
 
         # call our parents __init__
         super(CumulusSource, self).__init__(config_dict,
                                             cumulus_config_dict,
-                                            options,
-                                            log)
+                                            options)
 
         # save our import config path
         self.import_config_path = import_config_path
@@ -224,34 +225,49 @@ class CumulusSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Cumulus monthly log files in the '%s' directory will be imported" % self.source
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
             # we must have --from and --to
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/bin/weeimport/cumulusimport.py
+++ b/bin/weeimport/cumulusimport.py
@@ -15,8 +15,8 @@ from __future__ import print_function
 # Python imports
 import csv
 import glob
+import logging
 import os
-import syslog
 import time
 
 # WeeWX imports
@@ -207,7 +207,8 @@ class CumulusSource(weeimport.Source):
         try:
             self.source = cumulus_config_dict['directory']
         except KeyError:
-            raise weewx.ViolatedPrecondition("Cumulus monthly logs directory not specified in '%s'." % import_config_path)
+            _msg = "Cumulus monthly logs directory not specified in '%s'." % import_config_path
+            raise weewx.ViolatedPrecondition(_msg)
 
         # property holding the current log file name being processed
         self.file_name = None
@@ -223,34 +224,34 @@ class CumulusSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Cumulus monthly log files in the '%s' directory will be imported" % self.source
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
             # we must have --from and --to
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s" % (self.UV_sensor, self.solar_sensor)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/bin/weeimport/wdimport.py
+++ b/bin/weeimport/wdimport.py
@@ -17,9 +17,9 @@ import collections
 import csv
 import datetime
 import glob
+import logging
 import operator
 import os
-import syslog
 import time
 
 # WeeWX imports
@@ -397,48 +397,48 @@ class WDSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Weather Display monthly log files in the '%s' directory will be imported" % self.source
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
             # we must have --from and --to
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         if log_unit_sys is not None and log_unit_sys.upper() in ['METRIC', 'US']:
             # valid unit system specified
             _msg = "     monthly logs are in %s units" % log_unit_sys.upper()
-            self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+            self.wlog.verboselog(logging.DEBUG, _msg)
         else:
             # group units specified
             _msg = "     monthly logs use the following units:"
-            self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+            self.wlog.verboselog(logging.DEBUG, _msg)
             _msg = "       temperature=%s pressure=%s" % (temp_u, press_u)
-            self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+            self.wlog.verboselog(logging.DEBUG, _msg)
             _msg = "       rain=%s speed=%s" % (rain_u, speed_u)
-            self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+            self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s ignore extreme temperature and humidity=%s" % (self.UV_sensor,
                                                                                         self.solar_sensor,
                                                                                         self.ignore_extreme_temp_hum)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:
@@ -512,7 +512,7 @@ class WDSource(weeimport.Source):
                     _msg = "Unexpected number of columns found in '%s': %s v %s" % (_fn,
                                                                                     len(_row.split(_del)),
                                                                                     len(self.logs[lg]['fields']))
-                    self.wlog.printlog(syslog.LOG_INFO, _msg)
+                    self.wlog.printlog(logging.INFO, _msg)
                 # make sure we have full stops as decimal points
                 _clean_data.append(_row.replace(self.decimal, '.'))
 

--- a/bin/weeimport/wdimport.py
+++ b/bin/weeimport/wdimport.py
@@ -398,16 +398,16 @@ class WDSource(weeimport.Source):
         # tell the user/log what we intend to do
         _msg = "Weather Display monthly log files in the '%s' directory will be imported" % self.source
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "The following options will be used:"
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
@@ -415,53 +415,53 @@ class WDSource(weeimport.Source):
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         if log_unit_sys is not None and log_unit_sys.upper() in ['METRIC', 'US']:
             # valid unit system specified
             _msg = "     monthly logs are in %s units" % log_unit_sys.upper()
             if self.verbose:
                 print(_msg)
-            log.log(logging.DEBUG, _msg)
+            log.debug(_msg)
         else:
             # group units specified
             _msg = "     monthly logs use the following units:"
             if self.verbose:
                 print(_msg)
-            log.log(logging.DEBUG, _msg)
+            log.debug(_msg)
             _msg = "       temperature=%s pressure=%s" % (temp_u, press_u)
             if self.verbose:
                 print(_msg)
-            log.log(logging.DEBUG, _msg)
+            log.debug(_msg)
             _msg = "       rain=%s speed=%s" % (rain_u, speed_u)
             if self.verbose:
                 print(_msg)
-            log.log(logging.DEBUG, _msg)
+            log.debug(_msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     UV=%s, radiation=%s ignore extreme temperature and humidity=%s" % (self.UV_sensor,
                                                                                         self.solar_sensor,
                                                                                         self.ignore_extreme_temp_hum)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:
@@ -536,7 +536,7 @@ class WDSource(weeimport.Source):
                                                                                     len(_row.split(_del)),
                                                                                     len(self.logs[lg]['fields']))
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                 # make sure we have full stops as decimal points
                 _clean_data.append(_row.replace(self.decimal, '.'))
 

--- a/bin/weeimport/wdimport.py
+++ b/bin/weeimport/wdimport.py
@@ -30,6 +30,7 @@ import weewx
 from weeutil.weeutil import timestamp_to_string
 from weewx.units import unit_nicknames
 
+log = logging.getLogger(__name__)
 
 # ============================================================================
 #                             class WDSource
@@ -183,11 +184,10 @@ class WDSource(weeimport.Source):
                    'hum7': {'units': 'percent', 'map_to': 'extraHumid7'}
                    }
 
-    def __init__(self, config_dict, config_path, wd_config_dict, import_config_path, options, log):
+    def __init__(self, config_dict, config_path, wd_config_dict, import_config_path, options):
 
         # call our parents __init__
-        super(WDSource, self).__init__(config_dict, wd_config_dict,
-                                       options, log)
+        super(WDSource, self).__init__(config_dict, wd_config_dict, options)
 
         # save the import config path
         self.import_config_path = import_config_path
@@ -397,48 +397,71 @@ class WDSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Weather Display monthly log files in the '%s' directory will be imported" % self.source
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         if options.date:
             _msg = "     date=%s" % options.date
         else:
             # we must have --from and --to
             _msg = "     from=%s, to=%s" % (options.date_from, options.date_to)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         if log_unit_sys is not None and log_unit_sys.upper() in ['METRIC', 'US']:
             # valid unit system specified
             _msg = "     monthly logs are in %s units" % log_unit_sys.upper()
-            self.wlog.verboselog(logging.DEBUG, _msg)
+            if self.verbose:
+                print(_msg)
+            log.log(logging.DEBUG, _msg)
         else:
             # group units specified
             _msg = "     monthly logs use the following units:"
-            self.wlog.verboselog(logging.DEBUG, _msg)
+            if self.verbose:
+                print(_msg)
+            log.log(logging.DEBUG, _msg)
             _msg = "       temperature=%s pressure=%s" % (temp_u, press_u)
-            self.wlog.verboselog(logging.DEBUG, _msg)
+            if self.verbose:
+                print(_msg)
+            log.log(logging.DEBUG, _msg)
             _msg = "       rain=%s speed=%s" % (rain_u, speed_u)
-            self.wlog.verboselog(logging.DEBUG, _msg)
+            if self.verbose:
+                print(_msg)
+            log.log(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s" % (self.tranche,
                                                  self.interval)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     UV=%s, radiation=%s ignore extreme temperature and humidity=%s" % (self.UV_sensor,
                                                                                         self.solar_sensor,
                                                                                         self.ignore_extreme_temp_hum)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:
@@ -512,7 +535,8 @@ class WDSource(weeimport.Source):
                     _msg = "Unexpected number of columns found in '%s': %s v %s" % (_fn,
                                                                                     len(_row.split(_del)),
                                                                                     len(self.logs[lg]['fields']))
-                    self.wlog.printlog(logging.INFO, _msg)
+                    print(_msg)
+                    log.log(logging.INFO, _msg)
                 # make sure we have full stops as decimal points
                 _clean_data.append(_row.replace(self.decimal, '.'))
 

--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -376,23 +376,23 @@ class Source(object):
                 _msg = 'Obtaining raw import data for period %d...' % self.period_no
                 if self.verbose:
                     print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
                 _raw_data = self.getRawData(period)
                 _msg = 'Raw import data read successfully for period %d.' % self.period_no
                 if self.verbose:
                     print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
 
                 # map the raw data to a WeeWX archive compatible dictionary
                 _msg = 'Mapping raw import data for period %d...' % self.period_no
                 if self.verbose:
                     print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
                 _mapped_data = self.mapRawData(_raw_data, self.archive_unit_sys)
                 _msg = 'Raw import data mapped successfully for period %d.' % self.period_no
                 if self.verbose:
                     print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
 
                 # save the mapped data to archive
                 # first advise the user and log, but only if its not a dry run
@@ -400,14 +400,14 @@ class Source(object):
                     _msg = 'Saving mapped data to archive for period %d...' % self.period_no
                     if self.verbose:
                         print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                 self.saveToArchive(archive, _mapped_data)
                 # advise the user and log, but only if its not a dry run
                 if not self.dry_run:
                     _msg = 'Mapped data saved to archive successfully for period %d.' % self.period_no
                     if self.verbose:
                         print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                 # increment our period counter
                 self.period_no += 1
             # Provide some summary info now that we have finished the import.
@@ -417,7 +417,7 @@ class Source(object):
                 # nothing imported so say so
                 _msg = 'No records were identified for import. Exiting. Nothing done.'
                 print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
             else:
                 # we imported something
                 total_rec = self.total_rec_proc + self.total_duplicate_rec
@@ -425,39 +425,39 @@ class Source(object):
                     # but it was a dry run
                     _msg = "Finished dry run import"
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     _msg = "%d records were processed and %d unique records would "\
                            "have been imported." % (total_rec,
                                                     self.total_rec_proc)
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     if self.total_duplicate_rec > 1:
                         _msg = "%d duplicate records were ignored." % self.total_duplicate_rec
                         print(_msg)
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                     elif self.total_duplicate_rec == 1:
                         _msg = "1 duplicate record was ignored."
                         print(_msg)
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                 else:
                     # something should have been saved to database
                     _msg = "Finished import"
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     _msg = "%d records were processed and %d unique records " \
                            "imported in %.2f seconds." % (total_rec,
                                                           self.total_rec_proc,
                                                           self.tdiff)
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     if self.total_duplicate_rec > 1:
                         _msg = "%d duplicate records were ignored." % self.total_duplicate_rec
                         print(_msg)
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                     elif self.total_duplicate_rec == 1:
                         _msg = "1 duplicate record was ignored."
                         print(_msg)
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                     print("Those records with a timestamp already in the archive will not have been")
                     print("imported. Confirm successful import in the WeeWX log file.")
 
@@ -600,7 +600,7 @@ class Source(object):
             _msg = "The following imported field-to-WeeWX field map will be used:"
             if self.verbose:
                 print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
             for _key, _val in six.iteritems(_map):
                 if 'field_name' in _val:
                     _units_msg = ""
@@ -611,7 +611,7 @@ class Source(object):
                                                                               _key)
                     if self.verbose:
                         print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
         else:
             # no [[FieldMap]] stanza and no _header_map so raise an error as we
             # don't know what to map
@@ -840,16 +840,16 @@ class Source(object):
                                                            _field)
                             if not self.suppress:
                                 print(_msg)
-                            log.log(logging.INFO, _msg)
+                            log.info(_msg)
                             _msg = "         import field '%s' could not be found " \
                                    "in one or more records." % self.map[_field]['field_name']
                             if not self.suppress:
                                 print(_msg)
-                            log.log(logging.INFO, _msg)
+                            log.info(_msg)
                             _msg = "         WeeWX field '%s' will be set to 'None' in these records." % _field
                             if not self.suppress:
                                 print(_msg)
-                            log.log(logging.INFO, _msg)
+                            log.info(_msg)
                             # make sure we do this warning once only
                             _warned.append(self.map[_field]['field_name'])
             # if we have a mapped field for a unit system with a valid value,
@@ -890,7 +890,7 @@ class Source(object):
                 _msg = "Warning: Records to be imported contain multiple " \
                        "different 'interval' values."
                 print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
                 print("         This may mean the imported data is missing some records and it may lead")
                 print("         to data integrity issues. If the raw data has a known, fixed interval")
                 print("         value setting the relevant 'interval' setting in wee_import config to")
@@ -912,12 +912,12 @@ class Source(object):
                             print("Import aborted by user. No records saved to archive.")
                         _msg = "User chose to abort import. %d records were processed. " \
                                "Exiting." % self.total_rec_proc
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                     raise SystemExit('Exiting. Nothing done.')
             _msg = "Mapped %d records." % len(_records)
             if self.verbose:
                 print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
             # the user wants to continue or we have only one unique value for
             # interval so return the records
             return _records
@@ -925,7 +925,7 @@ class Source(object):
             _msg = "Mapped 0 records."
             if self.verbose:
                 print(_msg)
-            log.log(logging.INFO, _msg)
+            log.info(_msg)
             # we have no records to return so return None
             return None
 
@@ -976,7 +976,7 @@ class Source(object):
                     # so raise an error
                     _msg = "Cannot derive 'interval' for record timestamp: %s." % timestamp_to_string(current_ts)
                     print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     raise ValueError("Raw data is not in ascending date time order.")
             except TypeError:
                 _interval = None
@@ -1165,12 +1165,12 @@ class Source(object):
                                                                                            self.period_no)
                     if not self.suppress:
                         print(_msg)
-                    log.log(logging.INFO, _msg)
+                    log.info(_msg)
                     for ts in sorted(self.period_duplicates):
                         _msg = "        %s" % timestamp_to_string(ts)
                         if not self.suppress:
                             print(_msg)
-                        log.log(logging.INFO, _msg)
+                        log.info(_msg)
                     # add the period duplicates to the overall duplicates
                     self.duplicates |= self.period_duplicates
                     # reset the period duplicates
@@ -1180,7 +1180,7 @@ class Source(object):
                 # ask to exit
                 _msg = "User chose not to import records. Exiting. Nothing done."
                 print(_msg)
-                log.log(logging.INFO, _msg)
+                log.info(_msg)
                 raise SystemExit('Exiting. Nothing done.')
         else:
             # we have no records to import, advise the user but what we say

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -15,8 +15,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 import csv
 import datetime
+import logging
 import socket
-import syslog
 from datetime import datetime as dt
 
 from six.moves import urllib
@@ -92,7 +92,8 @@ class WUSource(weeimport.Source):
         try:
             self.station_id = wu_config_dict['station_id']
         except KeyError:
-            raise weewx.ViolatedPrecondition("Weather Underground station ID not specified in '%s'." % import_config_path)
+            _msg = "Weather Underground station ID not specified in '%s'." % import_config_path
+            raise weewx.ViolatedPrecondition(_msg)
 
         # wind dir bounds
         _wind_direction = option_as_list(wu_config_dict.get('wind_direction',
@@ -130,12 +131,12 @@ class WUSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Observation history for Weather Underground station '%s' will be imported." % self.station_id
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         if options.date:
             _msg = "     station=%s, date=%s" % (self.station_id, options.date)
         else:
@@ -143,22 +144,22 @@ class WUSource(weeimport.Source):
             _msg = "     station=%s, from=%s, to=%s" % (self.station_id,
                                                         options.date_from,
                                                         options.date_to)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s, wind_direction=%s" % (self.tranche,
                                                                     self.interval,
                                                                     self.wind_dir)
-        self.wlog.verboselog(syslog.LOG_DEBUG, _msg)
+        self.wlog.verboselog(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(syslog.LOG_INFO, _msg)
+        self.wlog.printlog(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if options.date or options.date_from:
@@ -188,7 +189,8 @@ class WUSource(weeimport.Source):
                     which raw obs data will be read.
         """
 
-        # the date for which we want the WU data is held in a datetime object, we need to convert it to a timetuple
+        # the date for which we want the WU data is held in a datetime object,
+        # we need to convert it to a timetuple
         date_tt = period.timetuple()
         # construct our URL using station ID and day, month, year
         _url = "http://www.wunderground.com/weatherstation/WXDailyHistory.asp?ID=%s&" \
@@ -200,14 +202,14 @@ class WUSource(weeimport.Source):
         try:
             _wudata = urllib.request.urlopen(_url)
         except urllib.error.URLError as e:
-            self.wlog.printlog(syslog.LOG_ERR,
+            self.wlog.printlog(logging.ERROR,
                                "Unable to open Weather Underground station %s" % self.station_id)
-            self.wlog.printlog(syslog.LOG_ERR, "   **** %s" % e)
+            self.wlog.printlog(logging.ERROR, "   **** %s" % e)
             raise
         except socket.timeout as e:
-            self.wlog.printlog(syslog.LOG_ERR,
+            self.wlog.printlog(logging.ERROR,
                                "Socket timeout for Weather Underground station %s" % self.station_id)
-            self.wlog.printlog(syslog.LOG_ERR, "   **** %s" % e)
+            self.wlog.printlog(logging.ERROR, "   **** %s" % e)
             raise
 
         # because the data comes back with lots of HTML tags and whitespace we

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -28,6 +28,7 @@ import weewx
 from weeutil.weeutil import timestamp_to_string, option_as_list, startOfDay
 from weewx.units import unit_nicknames
 
+log = logging.getLogger(__name__)
 
 # ============================================================================
 #                             class WUSource
@@ -75,13 +76,12 @@ class WUSource(weeimport.Source):
                                                'map_to': 'radiation'}
                    }
 
-    def __init__(self, config_dict, config_path, wu_config_dict, import_config_path, options, log):
+    def __init__(self, config_dict, config_path, wu_config_dict, import_config_path, options):
 
         # call our parents __init__
         super(WUSource, self).__init__(config_dict,
                                        wu_config_dict,
-                                       options,
-                                       log)
+                                       options)
 
         # save our import config path
         self.import_config_path = import_config_path
@@ -131,12 +131,17 @@ class WUSource(weeimport.Source):
 
         # tell the user/log what we intend to do
         _msg = "Observation history for Weather Underground station '%s' will be imported." % self.station_id
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "The following options will be used:"
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         if options.date:
             _msg = "     station=%s, date=%s" % (self.station_id, options.date)
         else:
@@ -144,22 +149,30 @@ class WUSource(weeimport.Source):
             _msg = "     station=%s, from=%s, to=%s" % (self.station_id,
                                                         options.date_from,
                                                         options.date_to)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "     tranche=%s, interval=%s, wind_direction=%s" % (self.tranche,
                                                                     self.interval,
                                                                     self.wind_dir)
-        self.wlog.verboselog(logging.DEBUG, _msg)
+        if self.verbose:
+            print(_msg)
+        log.log(logging.DEBUG, _msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
-        self.wlog.printlog(logging.INFO, _msg)
+        print(_msg)
+        log.log(logging.INFO, _msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if options.date or options.date_from:
@@ -202,14 +215,20 @@ class WUSource(weeimport.Source):
         try:
             _wudata = urllib.request.urlopen(_url)
         except urllib.error.URLError as e:
-            self.wlog.printlog(logging.ERROR,
-                               "Unable to open Weather Underground station %s" % self.station_id)
-            self.wlog.printlog(logging.ERROR, "   **** %s" % e)
+            _msg = "Unable to open Weather Underground station %s" % self.station_id
+            print(_msg)
+            log.log(logging.ERROR, _msg)
+            _msg = "   **** %s" % e
+            print(_msg)
+            log.log(logging.ERROR, _msg)
             raise
         except socket.timeout as e:
-            self.wlog.printlog(logging.ERROR,
-                               "Socket timeout for Weather Underground station %s" % self.station_id)
-            self.wlog.printlog(logging.ERROR, "   **** %s" % e)
+            _msg = "Socket timeout for Weather Underground station %s" % self.station_id
+            print(_msg)
+            log.log(logging.ERROR, _msg)
+            _msg = "   **** %s" % e
+            print(_msg)
+            log.log(logging.ERROR, _msg)
             raise
 
         # because the data comes back with lots of HTML tags and whitespace we

--- a/bin/weeimport/wuimport.py
+++ b/bin/weeimport/wuimport.py
@@ -132,16 +132,16 @@ class WUSource(weeimport.Source):
         # tell the user/log what we intend to do
         _msg = "Observation history for Weather Underground station '%s' will be imported." % self.station_id
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "The following options will be used:"
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     config=%s, import-config=%s" % (config_path,
                                                      self.import_config_path)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         if options.date:
             _msg = "     station=%s, date=%s" % (self.station_id, options.date)
         else:
@@ -151,28 +151,28 @@ class WUSource(weeimport.Source):
                                                         options.date_to)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     dry-run=%s, calc_missing=%s, ignore_invalid_data=%s" % (self.dry_run,
                                                                              self.calc_missing,
                                                                              self.ignore_invalid_data)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "     tranche=%s, interval=%s, wind_direction=%s" % (self.tranche,
                                                                     self.interval,
                                                                     self.wind_dir)
         if self.verbose:
             print(_msg)
-        log.log(logging.DEBUG, _msg)
+        log.debug(_msg)
         _msg = "Using database binding '%s', which is bound to database '%s'" % (self.db_binding_wx,
                                                                                  self.dbm.database_name)
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         _msg = "Destination table '%s' unit system is '%#04x' (%s)." % (self.dbm.table_name,
                                                                         self.archive_unit_sys,
                                                                         unit_nicknames[self.archive_unit_sys])
         print(_msg)
-        log.log(logging.INFO, _msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if options.date or options.date_from:
@@ -217,18 +217,18 @@ class WUSource(weeimport.Source):
         except urllib.error.URLError as e:
             _msg = "Unable to open Weather Underground station %s" % self.station_id
             print(_msg)
-            log.log(logging.ERROR, _msg)
+            log.error(_msg)
             _msg = "   **** %s" % e
             print(_msg)
-            log.log(logging.ERROR, _msg)
+            log.error(_msg)
             raise
         except socket.timeout as e:
             _msg = "Socket timeout for Weather Underground station %s" % self.station_id
             print(_msg)
-            log.log(logging.ERROR, _msg)
+            log.error(_msg)
             _msg = "   **** %s" % e
             print(_msg)
-            log.log(logging.ERROR, _msg)
+            log.error(_msg)
             raise
 
         # because the data comes back with lots of HTML tags and whitespace we


### PR DESCRIPTION
Further to our emails I have removed the `--log` option completely. Since the new logging system prepends `wee_import` to all log entries, `--dry-run` has been changed to log as per a non-dry run with the exception of the entries relating to actually saving records (since this does not occur in a dry run).

The Utilities Guide will need updates re removal of `--log` and various screen captures. Will do this once this PR is finalised.