### PR TITLE
Changed .conf and .htm to use "#rrggbb" format rather than 0xbbggrr. …

### DIFF
--- a/bin/weewx/tests/test_skins/StandardTest/skin.conf
+++ b/bin/weewx/tests/test_skins/StandardTest/skin.conf
@@ -133,36 +133,36 @@
     
     image_width = 300
     image_height = 180
-    image_background_color = 0xf5f5f5
+    image_background_color = "#f5f5f5"
     
-    chart_background_color = 0xd8d8d8
-    chart_gridline_color = 0xa0a0a0
+    chart_background_color = "#d8d8d8"
+    chart_gridline_color = "#a0a0a0"
     
     top_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     top_label_font_size = 10
     
     unit_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     unit_label_font_size = 10
-    unit_label_font_color = 0x000000
+    unit_label_font_color = "#000000"
     
     bottom_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     bottom_label_font_size = 12
-    bottom_label_font_color = 0x000000
+    bottom_label_font_color = "#000000"
     
     axis_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     axis_label_font_size = 10
-    axis_label_font_color = 0x000000
+    axis_label_font_color = "#000000"
     
     # Options for the compass rose, used for progressive vector plots
     rose_label = N
     rose_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     rose_label_font_size  = 10
-    rose_label_font_color = 0x000000
+    rose_label_font_color = "#000000"
     
     
     # Default colors for the plot lines. These can be overridden for
     # individual lines using option 'color'
-    chart_line_colors = 0xb48242, 0x4242b4, 0x42b442
+    chart_line_colors = "#4282b4", "#b44242", "#42b442"
     
     ##
     ## What follows is a list of subsections, each specifying a time span, such

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -3513,17 +3513,17 @@ class MyStats(SearchList):                                                   # 1
     ...
     image_width = 500
     image_height = 180
-    image_background_color = 0xf5f5f5
+    image_background_color = #f5f5f5
 
-    chart_background_color = 0xd8d8d8
-    chart_gridline_color = 0xa0a0a0
+    chart_background_color = #d8d8d8
+    chart_gridline_color = #a0a0a0
     ...</pre>
         <p>
             The options right under the section name <span class="code">[ImageGenerator]</span> will apply to
             <em>all</em> plots, unless overridden in subsections. So, unless otherwise changed, all plots will be 500
-            pixels in width, 180 pixels in height, and will have an RGB background color of 0xf5f5f5, a very light gray
-            (HTML color "WhiteSmoke"). The chart itself will have a background color of 0xd8d8d8 (a little darker gray),
-            and the gridlines will be 0xa0a0a0 (still darker). The other options farther down (not shown) will also
+            pixels in width, 180 pixels in height, and will have an RGB background color of #f5f5f5, a very light gray
+            (HTML color "WhiteSmoke"). The chart itself will have a background color of #d8d8d8 (a little darker gray),
+            and the gridlines will be #a0a0a0 (still darker). The other options farther down (not shown) will also
             apply to all plots.
         </p>
 
@@ -5881,20 +5881,20 @@ growing_base = 50.0, degree_F</pre>
         <p class="config_option">image_background_color</p>
 
         <p>
-            The background color of the whole image. Optional. Default is <span class='code'>0xf5f5f5</span>
+            The background color of the whole image. Optional. Default is <span class='code'>#f5f5f5</span>
             ("SmokeGray")
         </p>
 
         <p class="config_option">chart_background_color</p>
 
         <p>
-            The background color of the chart itself. Optional. Default is <span class='code'>0xd8d8d8</span>.
+            The background color of the chart itself. Optional. Default is <span class='code'>#d8d8d8</span>.
         </p>
 
         <p class="config_option">chart_gridline_color</p>
 
         <p>
-            The color of the chart grid lines. Optional. Default is <span class='code'>0xa0a0a0</span>
+            The color of the chart grid lines. Optional. Default is <span class='code'>#a0a0a0</span>
         </p>
 
         <div class="image image-right" style="clear: right">
@@ -5930,20 +5930,20 @@ growing_base = 50.0, degree_F</pre>
         <p class="config_option">daynight_day_color</p>
 
         <p>
-            The color to be used for the daylight band. Optional. Default is <span class="code">0xffffff</span>.
+            The color to be used for the daylight band. Optional. Default is <span class="code">#ffffff</span>.
         </p>
 
         <p class="config_option">daynight_night_color</p>
 
         <p>
-            The color to be used for the nighttime band. Optional. Default is <span class="code">0xf0f0f0</span>, a dark
+            The color to be used for the nighttime band. Optional. Default is <span class="code">#f0f0f0</span>, a dark
             gray.
         </p>
 
         <p class="config_option">daynight_edge_color</p>
 
         <p>
-            The color to be used in the transition zone between night and day. Optional. Default is <span class="code">0xefefef</span>,
+            The color to be used in the transition zone between night and day. Optional. Default is <span class="code">#efefef</span>,
             a mid-gray.
         </p>
 
@@ -6152,7 +6152,7 @@ growing_base = 50.0, degree_F</pre>
         <p>
             Each chart line is drawn in a different color. This option is a list of those colors. If the number of lines
             exceeds the length of the list, then the colors wrap around to the beginning of the list. Optional. In the case of bar
-            charts, this is the color of the outline of the bar. Default is <span class="code">0xff0000, 0x00ff00, 0x0000ff</span>.
+            charts, this is the color of the outline of the bar. Default is <span class="code">#0000ff, #00ff00, #ff0000</span>.
             <br/>
             <br/>
             Individual line color can be overridden by using option <span class="code">color</span>.

--- a/examples/basic/skins/basic/skin.conf
+++ b/examples/basic/skins/basic/skin.conf
@@ -57,38 +57,38 @@
 [ImageGenerator]
     image_width = 700
     image_height = 150
-    image_background_color = 0xffffff
+    image_background_color = "#ffffff"
 
-    chart_background_color = 0xffffff
-    chart_gridline_color = 0xeaeaea
+    chart_background_color = "#ffffff"
+    chart_gridline_color = "#eaeaea"
     
     top_label_font_path = /usr/share/fonts/truetype/ttf-dejavu/DejaVuSansCondensed-Bold.ttf
     top_label_font_size = 10
     
     unit_label_font_path = /usr/share/fonts/truetype/ttf-dejavu/DejaVuSansCondensed.ttf
     unit_label_font_size = 10
-    unit_label_font_color = 0xaaaaaa
+    unit_label_font_color = "#aaaaaa"
     
     bottom_label_font_path = /usr/share/fonts/truetype/ttf-dejavu/DejaVuSansCondensed.ttf
     bottom_label_font_size = 10
-    bottom_label_font_color = 0xaaaaaa
+    bottom_label_font_color = "#aaaaaa"
  
     axis_label_font_path = /usr/share/fonts/truetype/ttf-dejavu/DejaVuSansCondensed.ttf   
     axis_label_font_size = 10
-    axis_label_font_color = 0xaaaaaa
+    axis_label_font_color = "#aaaaaa"
     
     rose_label = N
     rose_label_font_path = /usr/share/fonts/truetype/ttf-dejavu/DejaVuSansCondensed.ttf
     rose_label_font_size  = 8
-    rose_label_font_color = 0x888888
-    rose_color = 0xaaaaaa
+    rose_label_font_color = "#888888"
+    rose_color = "#aaaaaa"
 
-    chart_line_colors = 0xa0a030, 0xd0d080, 0x0a0a01
-    chart_fill_colors = 0xd0d090, 0xdfdfd0, 0x5a5a51
+    chart_line_colors = "#30a0a0", "#80d0d0", "#010a0a"
+    chart_fill_colors = "#90d0d0", "#d0dfdf", "#515a5a"
 
-    daynight_day_color = 0xffffff
-    daynight_night_color = 0xf6f6f8
-    daynight_edge_color = 0xafefef
+    daynight_day_color = "#ffffff"
+    daynight_night_color = "#f8f6f6"
+    daynight_edge_color = "#efefaf"
 
     line_type = 'solid'
 

--- a/examples/pmon/skins/pmon/skin.conf
+++ b/examples/pmon/skins/pmon/skin.conf
@@ -13,13 +13,13 @@
     data_binding = pmon_binding
     image_width = 700
     image_height = 200
-    image_background_color = 0xffffff
-    chart_background_color = 0xffffff
-    chart_gridline_color = 0xeaeaea
-    unit_label_font_color = 0xaaaaaa
-    bottom_label_font_color = 0xaaaaaa
-    axis_label_font_color = 0xaaaaaa
-    chart_line_colors = 0x30a030, 0x90d080, 0x111a11, 0x3030a0, 0x8090d0, 0x11111a, 0xa03030
+    image_background_color = "#ffffff"
+    chart_background_color = "#ffffff"
+    chart_gridline_color = "#eaeaea"
+    unit_label_font_color = "#aaaaaa"
+    bottom_label_font_color = "#aaaaaa"
+    axis_label_font_color = "#aaaaaa"
+    chart_line_colors = "#30a030", "#80d090", "#111a11", "#a03030", "#d09080", "#1a1111", "#3030a0"
     marker_type = 'none'
 
     [[day_images]]

--- a/skins/Mobile/skin.conf
+++ b/skins/Mobile/skin.conf
@@ -86,38 +86,38 @@
 [ImageGenerator]
     image_width = 300
     image_height = 180
-    image_background_color = 0xf5f5f5
+    image_background_color = "#f5f5f5"
     
-    chart_background_color = 0xd8d8d8
-    chart_gridline_color = 0xa0a0a0
+    chart_background_color = "#d8d8d8"
+    chart_gridline_color = "#a0a0a0"
     
     top_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     top_label_font_size = 10
     
     unit_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     unit_label_font_size = 10
-    unit_label_font_color = 0x000000
+    unit_label_font_color = "#000000"
     
     bottom_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     bottom_label_font_size = 12
-    bottom_label_font_color = 0x000000
+    bottom_label_font_color = "#000000"
     bottom_label_offset = 3
     
     axis_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     axis_label_font_size = 10
-    axis_label_font_color = 0x000000
+    axis_label_font_color = "#000000"
     
     rose_label = N
     rose_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     rose_label_font_size  = 10
-    rose_label_font_color = 0x000000
+    rose_label_font_color = "#000000"
     
     line_type = 'solid'
     marker_size = 8
     marker_type ='none'
 
-    chart_line_colors = 0xb48242, 0x4242b4, 0x42b442    
-    chart_fill_colors = 0xc4b272, 0x7272c4, 0x72c472
+    chart_line_colors = "#4282b4", "#b44242", "#42b442"    
+    chart_fill_colors = "#72b2c4", "#c47272", "#72c472"
         
     yscale = None, None, None
 
@@ -126,9 +126,9 @@
     line_gap_fraction = 0.01
 
     show_daynight = true
-    daynight_day_color   = 0xdfdfdf
-    daynight_night_color = 0xbbbbbb
-    daynight_edge_color  = 0xd0d0d0
+    daynight_day_color   = "#dfdfdf"
+    daynight_night_color = "#bbbbbb"
+    daynight_edge_color  = "#d0d0d0"
 
     plot_type = line
     aggregate_type = none

--- a/skins/Seasons/skin.conf
+++ b/skins/Seasons/skin.conf
@@ -131,10 +131,10 @@
     
     image_width = 500
     image_height = 180
-    image_background_color = 0xffffff
+    image_background_color = "#ffffff"
     
-    chart_background_color = 0xffffff
-    chart_gridline_color = 0xd0d0d0
+    chart_background_color = "#ffffff"
+    chart_gridline_color = "#d0d0d0"
 
     # Setting to 2 or more might give a sharper image with fewer jagged edges
     anti_alias = 1
@@ -144,30 +144,30 @@
 
     unit_label_font_path = font/OpenSans-Bold.ttf
     unit_label_font_size = 12
-    unit_label_font_color = 0x787878
+    unit_label_font_color = "#787878"
 
     bottom_label_font_path = font/OpenSans-Regular.ttf
     bottom_label_font_size = 12
-    bottom_label_font_color = 0x787878
+    bottom_label_font_color = "#787878"
     bottom_label_offset = 3
 
     axis_label_font_path = font/OpenSans-Regular.ttf
     axis_label_font_size = 10
-    axis_label_font_color = 0x787878
+    axis_label_font_color = "#787878"
     
     # Options for the compass rose, used for progressive vector plots
     rose_label = N
     rose_label_font_path = font/OpenSans-Regular.ttf
     rose_label_font_size  = 9
-    rose_label_font_color = 0x222222
+    rose_label_font_color = "#222222"
 
     # Default colors for the plot lines. These can be overridden for
     # individual lines using option 'color'.
-    chart_line_colors = 0xb48242, 0x4242b4, 0x42b442, 0xb4b442, 0xb442b4
+    chart_line_colors = "#4282b4", "#b44242", "#42b442", "#42b4b4", "#b442b4"
     
     # Default fill colors for bar charts. These can be overridden for
     # individual bar plots using option 'fill_color'.
-    chart_fill_colors = 0xc4b272, 0x7272c4, 0x72c472, 0xc4c472, 0xc472c4
+    chart_fill_colors = "#72b2c4", "#c47272", "#72c472", "#72c4c4", "#c472c4"
     
     # Type of line. Options are 'solid' or 'none'.
     line_type = 'solid'
@@ -201,13 +201,13 @@
     show_daynight = true
     # These control the appearance of the bands if they are shown.
     # Here's a monochrome scheme:
-    daynight_day_color   = 0xfffafd
-    daynight_night_color = 0xe2dfdf
-    daynight_edge_color  = 0xd8d8e0
+    daynight_day_color   = "#fdfaff"
+    daynight_night_color = "#dfdfe2"
+    daynight_edge_color  = "#e0d8d8"
     # Here's an alternative, using a blue/yellow tint:
-    #daynight_day_color   = 0xf8ffff
-    #daynight_night_color = 0xfff8f8
-    #daynight_edge_color  = 0xf8f8ff
+    #daynight_day_color   = "#fffff8"
+    #daynight_night_color = "#f8f8ff"
+    #daynight_edge_color  = "#fff8f8"
 
     # What follows is a list of subsections, each specifying a time span, such
     # as a day, week, month, or year. There's nothing special about them or

--- a/skins/Smartphone/skin.conf
+++ b/skins/Smartphone/skin.conf
@@ -109,38 +109,38 @@
     
     image_width = 300
     image_height = 180
-    image_background_color = 0xf5f5f5
+    image_background_color = "#f5f5f5"
     
-    chart_background_color = 0xd8d8d8
-    chart_gridline_color = 0xa0a0a0
+    chart_background_color = "#d8d8d8"
+    chart_gridline_color = "#a0a0a0"
     
     top_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     top_label_font_size = 10
     
     unit_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     unit_label_font_size = 10
-    unit_label_font_color = 0x000000
+    unit_label_font_color = "#000000"
     
     bottom_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     bottom_label_font_size = 12
-    bottom_label_font_color = 0x000000
+    bottom_label_font_color = "#000000"
     bottom_label_offset = 3
     
     axis_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     axis_label_font_size = 10
-    axis_label_font_color = 0x000000
+    axis_label_font_color = "#000000"
     
     rose_label = N
     rose_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     rose_label_font_size  = 10
-    rose_label_font_color = 0x000000
+    rose_label_font_color = "#000000"
 
     line_type = 'solid'
     marker_size = 8
     marker_type ='none'
 
-    chart_line_colors = 0xb48242, 0x4242b4, 0x42b442    
-    chart_fill_colors = 0xc4b272, 0x7272c4, 0x72c472
+    chart_line_colors = "#4282b4", "#b44242", "#42b442"    
+    chart_fill_colors = "#72b2c4", "#c47272", "#72c472"
         
     yscale = None, None, None
 
@@ -149,9 +149,9 @@
     line_gap_fraction = 0.01
 
     show_daynight = true
-    daynight_day_color   = 0xdfdfdf
-    daynight_night_color = 0xbbbbbb
-    daynight_edge_color  = 0xd0d0d0
+    daynight_day_color   = "#dfdfdf"
+    daynight_night_color = "#bbbbbb"
+    daynight_edge_color  = "#d0d0d0"
     
     plot_type = line
     aggregate_type = none

--- a/skins/Standard/skin.conf
+++ b/skins/Standard/skin.conf
@@ -118,10 +118,10 @@
     
     image_width = 300
     image_height = 180
-    image_background_color = 0xf5f5f5
+    image_background_color = "#f5f5f5"
     
-    chart_background_color = 0xd8d8d8
-    chart_gridline_color = 0xa0a0a0
+    chart_background_color = "#d8d8d8"
+    chart_gridline_color = "#a0a0a0"
     
     # Setting to 2 or more might give a sharper image with fewer jagged edges.
     anti_alias = 1
@@ -131,26 +131,26 @@
     
     unit_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     unit_label_font_size = 10
-    unit_label_font_color = 0x000000
+    unit_label_font_color = "#000000"
     
     bottom_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     bottom_label_font_size = 12
-    bottom_label_font_color = 0x000000
+    bottom_label_font_color = "#000000"
     bottom_label_offset = 3
     
     axis_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     axis_label_font_size = 10
-    axis_label_font_color = 0x000000
+    axis_label_font_color = "#000000"
     
     # Options for the compass rose, used for progressive vector plots
     rose_label = N
     rose_label_font_path = /usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
     rose_label_font_size  = 10
-    rose_label_font_color = 0x000000
+    rose_label_font_color = "#000000"
 
     # Default colors for the plot lines. These can be overridden for
     # individual lines using option 'color'
-    chart_line_colors = 0xb48242, 0x4242b4, 0x42b442
+    chart_line_colors = "#4282b4", "#b44242", "#42b442"
     
 	# Type of line. Only 'solid' or 'none' is offered now    
     line_type = 'solid'
@@ -162,7 +162,7 @@
     
     # Default fill colors for bar charts. These can be overridden for
     # individual bar plots using option 'fill_color'
-    chart_fill_colors = 0xc4b272, 0x7272c4, 0x72c472
+    chart_fill_colors = "#72b2c4", "#c47272", "#72c472"
         
     # The following option merits an explanation. The y-axis scale used for
     # plotting can be controlled using option 'yscale'. It is a 3-way tuple,
@@ -187,13 +187,13 @@
     show_daynight = true
     # These control the appearance of the bands if they are shown.
     # Here's a monochrome scheme:
-    daynight_day_color   = 0xdfdfdf
-    daynight_night_color = 0xbbbbbb
-    daynight_edge_color  = 0xd0d0d0
+    daynight_day_color   = "#dfdfdf"
+    daynight_night_color = "#bbbbbb"
+    daynight_edge_color  = "#d0d0d0"
     # Here's an alternative, using a blue/yellow tint:
-    #daynight_day_color   = 0xf8ffff
-    #daynight_night_color = 0xfff8f8
-    #daynight_edge_color  = 0xf8f8ff
+    #daynight_day_color   = "#fffff8"
+    #daynight_night_color = "#f8f8ff"
+    #daynight_edge_color  = "#fff8f8"
 
     ## What follows is a list of subsections, each specifying a time span, such
     ## as a day, week, month, or year. There's nothing special about them or


### PR DESCRIPTION
Hi,

As chatted earlier, all .htm and .conf files should be replaced with #rrggbb format colors.  Quick to do, just took me longer to fight Git!  In the end seemed easier to cancel previous pull request, delete my weewx repository, re-clone, edit, re-push and submit new pull request.  Any tips on making that easier welcome :)

… Not tested, but looks sane.  Looked through all changes visually.

Some possibly helpful commands :-

Find files with 0xbbggrr :-
egrep -R '0x[0-f]{6}'

Replace .conf '= 0xbbggrr' with '"#rrggbb"'
perl -i -p -e 'if ( /= 0x[0-f]{6}/ ) { while ( $_ =~ s/0x([0-f]{2})([0-f]{2})([0-f]{2})/"#\3\2\1"/ ) { } }' `find . -name '*.conf'`

Replace .htm '0xbbggrr' with '#rrggbb'
perl -i -p -e 'if ( /0x[0-f]{6}/ ) { while ( $_ =~ s/0x([0-f]{2})([0-f]{2})([0-f]{2})/#\3\2\1/ ) { } }' `find . -name '*.htm'`