### PR TITLE
Implement strftime() format codes in Cheetah template file names

### DIFF
--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -386,8 +386,10 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
 
     def _getFileName(self, template, ref_tt):
         """Calculate a destination filename given a template filename.
-        Replace 'YYYY' with the year, 'MM' with the month, 'DD' with the day.
-        Strip off any trailing .tmpl"""
+
+        For backwards compatibility replace 'YYYY' with the year, 'MM' with the
+        month, 'DD' with the day. Also observe any strftime format strings in
+        the filename. Finally, strip off any trailing .tmpl."""
 
         _filename = os.path.basename(template).replace('.tmpl', '')
 
@@ -406,6 +408,11 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
             _filename = _filename.replace('WW', _week_str)
             # ... and the day
             _filename = _filename.replace('DD', _day_str)
+        # observe any strftime format strings in the base file name
+        # first obtain a datetime object from our timetuple
+        ref_dt = datetime.datetime.fromtimestamp(time.mktime(ref_tt))
+        # then apply any strftime formatting
+        _filename = ref_dt.strftime(_filename)
 
         return _filename
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -102,6 +102,10 @@ oddball archive intervals. Fixes issue #469.
 
 NOAA reports are now more tolerant of missing data. Fixes issue #300.
 
+Use of strftime() date and time format codes in template file names is now
+supported as an alternative to the legacy 'YYYY', 'MM' and 'DD'. The legacy
+codes continue to be supported for backwards compatibility.
+
 
 3.9.2 07/14/2019
 

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -1594,6 +1594,32 @@ db_manager.getSql("SELECT SUM(rain) FROM %s "\
             <span class='code'>SummaryByYear</span>, and <span class='code'>ToDate</span>.
         </p>
 
+        <h3>Including time stamps in generated file names</h3>
+
+        <p>
+            The Cheetah generator includes the ability to include a time stamp in the generated file name
+            (e.g. <span class="code">NOAA-2017-01.txt</span>). This is achieved by inclusion of various codes in the
+            template file name. The Cheetah generator supports the inclusion
+            of <a href="https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"> strftime()<em> date
+            and time format codes</em> </a> in the template file name. The strftime() format codes provide a flaxible
+            means of including date and time information in the generated file name. The Cheetah generator also supports
+            the legacy <span class="code">YYYY</span>, <span class="code">MM</span> and <span class="code">DD</span> codes
+            that include the year, month and day numbers.
+        </p>
+
+        <p class="note">
+            Care is required when using strftime() date and time format codes in template names to ensure that the
+            resulting file name is a valid file name. For example, the commonly used literal diagonal character,
+            <span class="code">/</span>, should be avoided as this would likely result in an invalid path or file name.
+        </p>
+
+        <p class="note">
+            When determining the file name to be used the Cheetah generator first processes legacy date codes,
+            <span class="code">YYYY</span>, <span class="code">MM</span> and <span class="code">DD</span>, before
+            processing strftime() format codes. So the template file name <span class="code">NOAA-%YYYY.txt.tmpl</span>
+            would result in the generated file name <span class="code">NOAA-%2017.txt</span>.
+        </p>
+
         <h3>Specifying template files</h3>
 
         <p>
@@ -1671,7 +1697,10 @@ db_manager.getSql("SELECT SUM(rain) FROM %s "\
         <h3><span class="code" id="SummaryByYear">[[SummaryByYear]]</span></h3>
 
         <p>
-            Use <span class="code">SummaryByYear</span> to generate a set of files, one file per year.  The name of the template file should contain <span class="code">YYYY</span>; this will be replaced with the year of the data in the file.
+            Use <span class="code">SummaryByYear</span> to generate a set of files, one file per year.  The name of the
+            template file should contain <span class="code">YYYY</span> or a
+            <a href="https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"> strftime()</a> year
+            format code; this will be replaced with the year of the data in the file.
         </p>
         <pre class="tty">
 [CheetahGenerator]
@@ -1697,7 +1726,10 @@ $record.dateTime $record.outTemp $record.outHumidity
         <h3><span class="code" id="SummaryByMonth">[[SummaryByMonth]]</span></h3>
 
         <p>
-            Use <span class="code">SummaryByMonth</span> to generate a set of files, one file per month.  The name of the template file should contain <span class="code">YYYY</span> and <span class="code">MM</span>; these will be replaced with the year and month of the data in the file.
+            Use <span class="code">SummaryByMonth</span> to generate a set of files, one file per month.  The name of the
+            template file should contain <span class="code">YYYY</span> and <span class="code">MM</span> or
+            <a href="https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"> strftime()</a> year and
+            month codes; these will be replaced with the year and month of the data in the file.
         </p>
         <pre class="tty">
 [CheetahGenerator]
@@ -1723,7 +1755,11 @@ $record.dateTime $record.outTemp $record.outHumidity
         <h3><span class="code" id="SummaryByDay">[[SummaryByDay]]</span></h3>
         <p>
             While the <em>Seasons</em> skin does not make use of it, there is also a <span
-            class="code">SummaryByDay</span> capability. As the name suggests, this results in one file per day.   The name of the template file should contain <span class="code">YYYY</span>, <span class="code">MM</span>, and <span class="code">DD</span>; these will be replaced with the year, month, and day of the data in the file.
+            class="code">SummaryByDay</span> capability. As the name suggests, this results in one file per day.   The
+            name of the template file should contain <span class="code">YYYY</span>, <span class="code">MM</span>, and
+            <span class="code">DD</span> or
+            <a href="https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"> strftime()</a> year,
+            month and day codes; these will be replaced with the year, month, and day of the data in the file.
         </p>
         <pre class="tty">
 [CheetahGenerator]


### PR DESCRIPTION
Refer issue #415. 

Pretty simple change in the end that is far more flexible than the legacy codes.

Not sure about Customization Guide changes, seems a bit woolly and suspect they need further work.