### PR TITLE
Don’t cache “now” before potentially long running catchup.

### DIFF
--- a/bin/weewx/engine.py
+++ b/bin/weewx/engine.py
@@ -627,10 +627,9 @@ class StdArchive(StdService):
             # records may not be on the same boundaries as the archive
             # interval. Reject any records that have a timestamp in the
             # future, but provide some lenience for clock drift.
-            now = time.time()
             for record in generator(lastgood_ts):
                 ts = record.get('dateTime')
-                if ts and ts < now + self.archive_delay:
+                if ts and ts < time.time() + self.archive_delay:
                     self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
                                                           record=record,
                                                           origin='hardware'))


### PR DESCRIPTION
I’m not sure if this is a problem with other stations, but the CC3000 will return records that are created after a download of records is initiated.  From the CC3000 doc on the DOWNLOAD command:

“It should be noted, the CC-3000 will record even while outputting. This means that should a logging interval occur during the download this record will also be output.”

As such, with an accurate clock, records are ignored if they were created self.archive_delay seconds after the catchup was initiated.