### PR TITLE
Fix inconsistent cheetah/image generator logging

### DIFF
--- a/bin/weewx/imagegenerator.py
+++ b/bin/weewx/imagegenerator.py
@@ -271,7 +271,7 @@ class ImageGenerator(weewx.reportengine.ReportGenerator):
         t2 = time.time()
 
         if log_success:
-            log.info("Generated %d images for %s in %.2f seconds", ngen, self.skin_dict['REPORT_NAME'], t2 - t1)
+            log.info("Generated %d images for report %s in %.2f seconds", ngen, self.skin_dict['REPORT_NAME'], t2 - t1)
 
 def skipThisPlot(time_ts, aggregate_interval, img_file):
     """A plot can be skipped if it was generated recently and has not changed.


### PR DESCRIPTION
Sorry, but once I have noticed this I cannot un-notice it and it is annoying the pedant in me:

```
Feb  3 12:48:17 buster48 weewx[6304] INFO weewx.cheetahgenerator: Generated 8 files for report SeasonsReport in 0.44 seconds
Feb  3 12:48:18 buster48 weewx[6304] INFO weewx.imagegenerator: Generated 56 images for SeasonsReport in 1.62 seconds
```