### PR TITLE
Added Inside Humidity to Seasons skin (if sensor provides it)

### DIFF
--- a/skins/Seasons/current.inc
+++ b/skins/Seasons/current.inc
@@ -73,6 +73,12 @@
         <td class="data">$current.inTemp</td>
       </tr>
 #end if
+#if $day.inHumidity.has_data
+      <tr>
+        <td class="label">$obs.label.inHumidity</td>
+        <td class="data">$current.inHumidity</td>
+      </tr>
+#end if
 #if $day.extraTemp1.has_data
       <tr>
         <td class="label">$obs.label.extraTemp1</td>

--- a/skins/Seasons/hilo.inc
+++ b/skins/Seasons/hilo.inc
@@ -221,6 +221,21 @@
       </tr>
       #end if
 
+      #if $day.inHumidity.has_data
+      <tr>
+        <td class="label">$obs.label.inHumidity</td>
+        #for $archive in $archive_data
+        <td class="data new_row hilo_$archive[0]">
+          <span title="$archive[1].inHumidity.maxtime">
+            $archive[1].inHumidity.max.format(add_label=False)</span><br/>
+          <span title="$archive[1].inHumidity.mintime">
+            $archive[1].inHumidity.min.format(add_label=False)</span>
+        </td>
+        #end for
+        <td class="units">$unit.label.inHumidity</td>
+      </tr>
+      #end if
+
       #if $day.extraTemp1.has_data
       <tr>
         <td class="label">$obs.label.extraTemp1</td>

--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -61,6 +61,9 @@
             #if $day.inTemp.has_data
             <img src="daytempin.png"    alt="$obs.label.inTemp" />
             #end if
+            #if $day.inHumidity.has_data
+            <img src="dayhumin.png"    alt="$obs.label.inHumidity" />
+            #end if
             #if $day.extraTemp1.has_data or $day.extraTemp2.has_data or $day.extraTemp3.has_data
             <img src="daytemp.png"      alt="$obs.label.extraTemp1" />
             #end if
@@ -85,6 +88,9 @@
             #end if
             #if $week.inTemp.has_data
             <img src="weektempin.png"    alt="$obs.label.inTemp" />
+            #end if
+            #if $week.inHumidity.has_data
+            <img src="weekhumin.png"    alt="$obs.label.inHumidity" />
             #end if
             #if $week.extraTemp1.has_data or $week.extraTemp2.has_data or $week.extraTemp3.has_data
             <img src="weektemp.png"      alt="$obs.label.extraTemp1" />
@@ -111,6 +117,9 @@
             #if $month.inTemp.has_data
             <img src="monthtempin.png"    alt="$obs.label.inTemp" />
             #end if
+            #if $month.inHumidity.has_data
+            <img src="monthhumin.png"    alt="$obs.label.inHumidity" />
+            #end if
             #if $month.extraTemp1.has_data or $month.extraTemp2.has_data or $month.extraTemp3.has_data
             <img src="monthtemp.png"      alt="$obs.label.extraTemp1" />
             #end if
@@ -135,6 +144,9 @@
             #end if
             #if $year.inTemp.has_data
             <img src="yeartempin.png"    alt="$obs.label.inTemp" />
+            #end if
+            #if $year.inHumidity.has_data
+            <img src="yearhumin.png"    alt="$obs.label.inHumidity" />
             #end if
             #if $year.extraTemp1.has_data or $year.extraTemp2.has_data or $year.extraTemp3.has_data
             <img src="yeartemp.png"      alt="$obs.label.extraTemp1" />

--- a/skins/Seasons/skin.conf
+++ b/skins/Seasons/skin.conf
@@ -259,6 +259,9 @@
 
         [[[dayhum]]]
             [[[[outHumidity]]]]
+
+        [[[dayhumin]]]
+            [[[[inHumidity]]]]
         
         [[[dayrain]]]
             # Make sure the y-axis increment is at least 0.02 for the rain plot
@@ -332,6 +335,9 @@
         [[[weekhum]]]
             [[[[outHumidity]]]]
 
+        [[[weekhumin]]]
+            [[[[inHumidity]]]]
+
         [[[weekrain]]]
             yscale = None, None, 0.02
             plot_type = bar
@@ -404,6 +410,9 @@
         [[[monthhum]]]
             [[[[outHumidity]]]]
 
+        [[[monthhumin]]]
+            [[[[inHumidity]]]]
+
         [[[monthrain]]]
             yscale = None, None, 0.02
             plot_type = bar
@@ -475,6 +484,9 @@
 
         [[[yearhum]]]
             [[[[outHumidity]]]]
+
+        [[[yearhumin]]]
+            [[[[inHumidity]]]]
         
         [[[yearrain]]]
             yscale = None, None, 0.02

--- a/skins/Seasons/statistics.inc
+++ b/skins/Seasons/statistics.inc
@@ -202,6 +202,21 @@
         </tr>
         #end if
 
+        #if $day.inHumidity.has_data
+        <tr>
+          <td class="label">$obs.label.inHumidity</td>
+          <td class="units">$unit.label.inHumidity</td>
+          #for $archive in $archive_data
+          <td class="data new_row">
+            $archive.inHumidity.max.format(add_label=False)<br/>
+            <span class="timestamp">$archive.inHumidity.maxtime</span><br/>
+            $archive.inHumidity.min.format(add_label=False)<br/>
+            <span class="timestamp">$archive.inHumidity.mintime</span>
+          </td>
+          #end for
+        </tr>
+        #end if
+
         #if $day.extraTemp1.has_data
         <tr>
           <td class="label">$obs.label.extraTemp1</td>


### PR DESCRIPTION
Added the Inside Humidity to the Seasons skin. All Inside Humidity
entries are wrapped in a has_data if statement so that they only
up if the sensor is generating the underlying data.

I have made this change on my own build, and thought it would be useful for others whose weather station has an inside humidity sensor.