### PR TITLE
Handle the case where the user provides a single CWOP server only

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1151,7 +1151,9 @@ class CWOPThread(RESTThread):
                                          skip_upload=skip_upload)
         self.station = station
         self.passcode = passcode
-        self.server_list = server_list
+        # In case we have a single server that would likely appear as a string
+        # not a list
+        self.server_list = weeutil.weeutil.option_as_list(server_list)
         self.latitude = to_float(latitude)
         self.longitude = to_float(longitude)
         self.station_type = station_type


### PR DESCRIPTION
Refer #520. 

A user specifying a single CWOP server will likely not include the trailing comma to force `configobj` to return a list. In such cases `configobj` will return a string which will cause the CWOP uploader to fail. The simple fix is to run the server list through `weeutil.weeutil.option_as_list()`.

