### PR TITLE
Fixed TypeError caused by ord() function when on Python 3

### DIFF
--- a/bin/weewx/drivers/wmr9x8.py
+++ b/bin/weewx/drivers/wmr9x8.py
@@ -240,7 +240,7 @@ class WMR9x8(weewx.drivers.AbstractDevice):
         wm918max = max(list(wm918_packet_type_size_map.items()), key=operator.itemgetter(1))[1]
         preBufferSize = max(wmr9x8max, wm918max)
         while True:
-            buf.extend(list(map(ord, self.port.read(preBufferSize - len(buf)))))
+            buf.extend(list(self.port.read(preBufferSize - len(buf))))
             # WMR-9x8/968 packets are framed by 0xFF characters
             if buf[0] == 0xFF and buf[1] == 0xFF and buf[2] in wmr9x8_packet_type_size_map:
                 # Look up packet type, the expected size of this packet type


### PR DESCRIPTION
After dist-upgrade debian stretch -> buster I had an issue with weewx and WMR918 weather station:

May  7 22:24:13 host weewx[1721] CRITICAL __main__:     ****    File "/usr/share/weewx/weewx/drivers/wmr9x8.py", line 243, in genLoopPackets
May  7 22:24:13 host weewx[1721] CRITICAL __main__:     ****      buf.extend(list(map(ord, self.port.read(preBufferSize - len(buf)))))
May  7 22:24:13 host weewx[1721] CRITICAL __main__:     ****  TypeError: ord() expected string of length 1, but int found
May  7 22:24:13 host weewx[1721] CRITICAL __main__:     ****  Exiting.

After removing map() and ord() functions everything works as expected again.