### PR TITLE
FileParse now handles cumulative rain

### DIFF
--- a/examples/fileparse/changelog
+++ b/examples/fileparse/changelog
@@ -1,3 +1,6 @@
+0.8 13may2020
+* now handles cumulative rain
+
 0.7 03jul2019
 * Port to Python 3
 

--- a/examples/fileparse/readme.txt
+++ b/examples/fileparse/readme.txt
@@ -35,7 +35,14 @@ cp /home/weewx/examples/fileparse/bin/fileparse.py /home/weewx/bin/user
     path = /var/tmp/datafile
     driver = user.fileparse
 
-3) If the variables in the file have names different from those in the database
+3) if cumulative rainfall data is included in the fileparse data file add the
+cumulative_rain setting to the [FileParse] stanza in weewx.conf:
+
+[FileParse]
+    ... (as before)
+    cumulative_rain = true
+
+4) If the variables in the file have names different from those in the database
 schema, then add a mapping section called label_map.  This will map the
 variables in the file to variables in the database columns.  For example:
 
@@ -49,14 +56,14 @@ variables in the file to variables in the database columns.  For example:
         in_temp = inTemp
         in_humid = inHumidity
 
-4) in the WeeWX configuration file, modify the station_type setting to use the
+5) in the WeeWX configuration file, modify the station_type setting to use the
 fileparse driver
 
 [Station]
     ...
     station_type = FileParse
 
-5) restart WeeWX
+6) restart WeeWX
 
 sudo /etc/init.d/weewx stop
 sudo /etc/init.d/weewx start


### PR DESCRIPTION
Appreciate that the fileparse driver is included as a basic driver example but I know of two cases now where users have wanted to read rain data and issues have arisen since fileparse expects per-period rain data. This can be problematic if the fileparse data file and fileparse driver polling end up out of sync (data will be missed).

This PR modifies the fileparse driver to accept cumulative rain data, this is much more tolerant of the data file generation and fileparse driver polling getting out of sync.

If there is no appetite to change the fileparse driver then by all means reject the PR.