### PR TITLE
Fixed issue #556

### DIFF
--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -140,7 +140,7 @@ class StationData(object):
     def validate_string(buf):
         if len(buf) != PACKET_SIZE:
             raise weewx.WeeWxIOError("Unexpected buffer length %d" % len(buf))
-        if buf[0:2] != '!!':
+        if buf[0:2] != b'!!':
             raise weewx.WeeWxIOError("Unexpected header bytes '%s'" % buf[0:2])
         return buf
 


### PR DESCRIPTION
Fixes the Python 3 string encoding issue by ensuring a test for the header bytes is a comparison with a proper byte string. I've tested this with my own install running 4.0.0 on a RPi 4 and it works. Have not tested it in Python 2.7