### PR TITLE
Updated accumulator to extract lightning strike counts as a sum from LOOP packets

### DIFF
--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -91,6 +91,8 @@ DEFAULTS_INI = """
         extractor = last
     [[yearRain]]
         extractor = last
+    [[lightning_strike_count]]
+        extractor = sum
 """
 defaults_dict = configobj.ConfigObj(StringIO(DEFAULTS_INI), encoding='utf-8')
 

--- a/docs/accum.md
+++ b/docs/accum.md
@@ -103,51 +103,55 @@ The accumulators come with a set of defaults that covers most situations.
 [Accumulator]
     [[dateTime]]
         adder = noop
-    [[usUnits]]
-        adder = check_units
-    [[rain]]
-        extractor = sum
-    [[ET]]
-        extractor = sum
     [[dayET]]
-        extractor = last
-    [[monthET]]
-        extractor = last
-    [[yearET]]
-        extractor = last
-    [[hourRain]]
         extractor = last
     [[dayRain]]
         extractor = last
+    [[ET]]
+        extractor = sum
+    [[hourRain]]
+        extractor = last
+    [[rain]]
+        extractor = sum
     [[rain24]]
+        extractor = last
+    [[monthET]]
         extractor = last
     [[monthRain]]
         extractor = last
-    [[yearRain]]
+    [[stormRain]]
         extractor = last
     [[totalRain]]
         extractor = last
-    [[stormRain]]
-        extractor = last
+    [[usUnits]]
+        adder = check_units
     [[wind]]
         accumulator = vector
         extractor = wind
-    [[windSpeed]]
-        adder = add_wind
-        merger = avg
-        extractor = noop
     [[windDir]]
         extractor = noop
     [[windGust]]
         extractor = noop
     [[windGustDir]]
         extractor = noop
-    [[windSpeed2]]
-        extractor = last
-    [[windSpeed10]]
-        extractor = last
     [[windGust10]]
         extractor = last
     [[windGustDir10]]
         extractor = last
+    [[windrun]]
+        extractor = sum
+    [[windSpeed]]
+        adder = add_wind
+        merger = avg
+        extractor = noop
+    [[windSpeed2]]
+        extractor = last
+    [[windSpeed10]]
+        extractor = last
+    [[yearET]]
+        extractor = last
+    [[yearRain]]
+        extractor = last
+    [[lightning_strike_count]]
+        extractor = sum
 ```  


### PR DESCRIPTION
I also synchronized `accum.md` w/ the current default configuration. If that's undesired, let me know and I'll pull it out.

This Pull Request changes the accumulator to use summing for lightning strike counts, since the loop packets report counts, the archive record needs to sum up all those counts for the archival period.

@matthewwall looping you in, in case you have an opinion, since you had created a driver for the AS3935 at one point.