### PR TITLE
Fix cut and paste error in FirstLastAccum.

### DIFF
--- a/bin/weewx/accum.py
+++ b/bin/weewx/accum.py
@@ -354,7 +354,7 @@ class FirstLastAccum(object):
 
     def setStats(self, stats_tuple=None):
         self.first, self.firsttime, self.last, self.lasttime = stats_tuple \
-            if stats_tuple else ScalarStats.default_init
+            if stats_tuple else FirstLastAccum.default_init
 
     def getStatsTuple(self):
         """Return a stats-tuple. That is, a tuple containing the gathered statistics.


### PR DESCRIPTION
FirstLastAccum.setStats() was using the wrong default_init.