### PR TITLE
Add some control to logging before configuration file is processed

### DIFF
--- a/bin/weewxd
+++ b/bin/weewxd
@@ -68,6 +68,8 @@ def main():
     parser.add_option("-n", "--log-label", type="string", dest="log_label",
                       help="Label to use in syslog entries",
                       default="weewx", metavar="LABEL")
+    parser.add_option("-c", "--log-to-console", action="store_true", dest="log_to_console",
+                      help="Default logging is sent to the console.")    
 
     # Get the command line options and arguments:
     (options, args) = parser.parse_args()
@@ -77,7 +79,7 @@ def main():
         sys.exit(0)
 
     # Set up a minimal logging facility to be used until we read the config file.
-    weeutil.logger.setup(options.log_label, {})
+    weeutil.logger.setup(options.log_label, {}, log_to_console=options.log_to_console)
 
     if args and options.config_path:
         print("Specify CONFIG_PATH as an argument, or by using --config, not both",
@@ -133,7 +135,7 @@ def main():
 
         # Now that we have the config_dict and debug setting, we can customize the
         # logging with user additions
-        weeutil.logger.setup(options.log_label, config_dict)
+        weeutil.logger.setup(options.log_label, config_dict, log_to_console=options.log_to_console)
 
         # If no command line --loop-on-init was specified, look in the config file.
         if options.loop_on_init is None:


### PR DESCRIPTION
Background:
I’ve got both the Simulator and MQTTSubscribe drivers using the Seasons skin running on an iPad under Pythonista and also under a-Shell. But, in both cases the ‘default’ logging doesn’t work. 
Under Pythonista, sys.platform returns ’ios’.  Using the pattern to support ‘darwin’, logger.py could be updated to support ‘ios’. But under a-Shell, sys.platform returns ‘darwin’ and access to /var/log is denied. So, I’m thinking a more general way to do the ‘initial’ (before the configuration file is read) logging setup might be useful.

A few ideas I’ve thought of are:
- Add a command line option (—skip-initial-logging?) to skip the ‘initial’ logging. This would consist of if statements around the logging calls and the obvious loss of information.
- Add a command line option (—initial-logging-to-console?) to have the ‘initial’ logging go to the console. When setting up the logger, the necessary information to log to the console would be passed in instead of an empty dictionary. This would result in default logging being in two places. First to the console then to either syslog or a rotating file.
- Add a command line option (—log-to-console?) to make logging to the console the default. If there is no [Logging] stanza in the configuration file, all logging will go the console.  This might have the added benefit that all necessary information (log information, loop packets, and archive records) to help people is in one  place, the console. This pull request is an attempt at implementing this idea.

If supporting running on the iPad is too ‘one off’’, it is easy enough to hack logger.py to remove the SyslogHandler and RotatingFileHandler if/when logger.py is updated.

Note, all of the development for this pull request was done on my iPad. WeeWX continues to amaze me.