### PR TITLE
Bugfix : Wrong behaviour of to_float under Python2

### DIFF
--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -1245,7 +1245,7 @@ def to_float(x):
     >>> print(to_float(None))
     None
     """
-    if isinstance(x, str) and x.lower() == 'none':
+    if isinstance(x, six.string_types) and x.lower() == 'none':
         x = None
     return float(x) if x is not None else None
 


### PR DESCRIPTION
The to_float function was not interpreting unicode strings properly under Python 2. The function now uses the six.string_types method like to_int does