### PR TITLE
cc3000 udev rule doesn't work on Raspbian.

### DIFF
--- a/util/udev/rules.d/cc3000.rules
+++ b/util/udev/rules.d/cc3000.rules
@@ -1,2 +1,2 @@
 # udev rules for rainwise cc3000
-ACTION=="add", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="cc3000"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="cc3000"

--- a/util/udev/rules.d/weewx.rules
+++ b/util/udev/rules.d/weewx.rules
@@ -20,6 +20,6 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0FDE", ATTRS{idProduct}=="CA08", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="6666", ATTRS{idProduct}=="5555", MODE="0666"
 
 # make symlink for rainwise cc3000 connected via usb-serial
-ACTION=="add", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="cc3000"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="cc3000"
 # make symlink for davis vantage connected via usb-serial
 ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="vantage"


### PR DESCRIPTION
Raspberry Pi OS (Buster) needs the subsystem to be specified on this rule (peculiarly, the unmodified rules work fine on Debian Buster on my NUCs).