### PR TITLE
log configuration errors

### DIFF
--- a/bin/weewxd
+++ b/bin/weewxd
@@ -17,6 +17,7 @@ import sys
 import time
 from optparse import OptionParser
 
+import configobj
 import daemon
 import weecfg
 import weedb
@@ -123,9 +124,11 @@ def main():
         try:
             # Pass in a copy of the command line arguments. read_config() will change it.
             config_path, config_dict = weecfg.read_config(options.config_path, list(args))
-        except IOError as e:
+        except (IOError, configobj.ConfigObjError) as e:
+            log.error("Error parsing config file: %s" % e)
+            weeutil.logger.log_traceback(log.critical, "    ****  ")
             print(e, file=sys.stderr)
-            sys.exit(weewx.CMD_ERROR)
+            sys.exit(weewx.CMD_ERROR)      
 
         log.info("Using configuration file %s", config_path)
         weewx.debug = int(config_dict.get('debug', 0))


### PR DESCRIPTION
When running as a daemon/service and there configuration errors, WeeWX ‘just dies’ with nothing logged. This might happen when a person has WeeWX running, adds a service, and has an error in weewx.conf.
This pull request is more to explain the problem. Feel free to close and implement a better solution. 