### PR TITLE
make graph order configurable on Seasons skin

### DIFF
--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -6,41 +6,56 @@
 #encoding UTF-8
 ##
 
-#set global graphOrder = $getVar('Extras.Graphs.order', 'barometer,outsideTemp,feelsLikeTemp,outsideHumidity,wind,windDirection,windVector,rain,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality').split(',')
+#set global plotOrder = $getVar('Extras.Plots.order', 'barometer,outsideTemp,feelsLikeTemp,outsideHumidity,wind,windDirection,windVector,rain,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality').replace(' ', '').split(',')
 
-#def dataSettings($field, $image, $label)
-#return {"field": field, "image": image, "alt": label}
+#def plotSettings($hasData, $image, $label)
+#return {"hasData": hasData, "image": image, "alt": label}
 #end def
 
-##  Still need special case for extraTemp1.has_data or extraTemp2.has_data or extraTemp3.has_data
-#set global graphData = { \
-  "outsideTemp":     $dataSettings(None, "tempdew.png", $obs.label.outTemp), \
-  "wind":            $dataSettings(None, "wind.png", $obs.label.windSpeed), \
-  "windDirection":   $dataSettings(None, "winddir.png", $obs.label.windDir), \
-  "windVector":      $dataSettings(None, "windvec.png", $obs.label.windvec), \
-  "rain":            $dataSettings(None, "rain.png", $obs.label.rain), \
-  "feelsLikeTemp":   $dataSettings(None, "tempfeel.png", $obs.label.feel), \
-  "barometer":       $dataSettings(None, "barometer.png", $obs.label.barometer), \
-  "outsideHumidity": $dataSettings(None, "hum.png", $obs.label.outHumidity), \
-  "uvIndex":         $dataSettings('UV', "uv.png", $obs.label.UV), \
-  "radiation":       $dataSettings('radiation', "radiation.png", $obs.label.radiation), \
-  "insideTemp":      $dataSettings('daytempin', "tempin.png", $obs.label.inTemp), \
-  "insideHumidity":  $dataSettings('inHumidity', "humin.png", $obs.label.inHumidity), \
-  "signalQuality":   $dataSettings('rxCheckPercent', "rx.png", $obs.label.rxCheckPercent), \
-  "extraTemp":       $dataSettings('extraTemp1', "temp.png", $obs.label.extraTemp1) \
+## Settings of each plot. Each row of the table contains the settings
+## for a plot of an individual weather reading.
+##                                  +--- Is there valid data in the plot?
+##                                  |        +--- The plot image to display. This is appended
+##                                  |        |         to the range (day, week, month, year) to
+##                                  |        |         build a full image file name. I.e. 'daywind.png'
+##                                  |        |                +--- The "alt" text of the image
+##                                  V        V                V
+#set global plotSettings = { \
+  "outsideTemp":     $plotSettings(True, "tempdew.png", $obs.label.outTemp), \
+  "wind":            $plotSettings(True, "wind.png", $obs.label.windSpeed), \
+  "windDirection":   $plotSettings(True, "winddir.png", $obs.label.windDir), \
+  "windVector":      $plotSettings(True, "windvec.png", $obs.label.windvec), \
+  "rain":            $plotSettings(True, "rain.png", $obs.label.rain), \
+  "feelsLikeTemp":   $plotSettings(True, "tempfeel.png", $obs.label.feel), \
+  "barometer":       $plotSettings(True, "barometer.png", $obs.label.barometer), \
+  "outsideHumidity": $plotSettings(True, "hum.png", $obs.label.outHumidity), \
+  "uvIndex":         $plotSettings($day.UV.has_data, "uv.png", $obs.label.UV), \
+  "radiation":       $plotSettings($day.radiation.has_data, "radiation.png", $obs.label.radiation), \
+  "insideTemp":      $plotSettings($day.daytempin.has_data, "tempin.png", $obs.label.inTemp), \
+  "insideHumidity":  $plotSettings($day.inHumidity.has_data, "humin.png", $obs.label.inHumidity), \
+  "signalQuality":   $plotSettings($day.rxCheckPercent.has_data, "rx.png", $obs.label.rxCheckPercent), \
+  "extraTemp":       $plotSettings($day.extraTemp1.has_data, "temp.png", $obs.label.extraTemp1) \
 }
 
-#def showGraph($dataVar, $key, $imgPrefix)
-#set data = $graphData[$key]
-#if $data.field == None or $getVar($dataVar+'.'+$data.field+'.has_data')
-<img src="$imgPrefix${$data.image}" alt="${$data.alt}"/>
-#end if
-#end def
-
-#def graphs($dataVar, $imgPrefix)
-#for $graph in $graphOrder
-$showGraph($dataVar, $graph, $imgPrefix)
-#end for
+##
+## This function displays all of the requested plots for a particular range (day,week,month,year).
+## Request plots and order with [[Plots]][[[order]]] in skin.conf
+##
+#def plots($imgPrefix)
+    ## Loop through each plot to display
+    #for $plot in $plotOrder
+        ## Ensure we have settings for that plot
+        #if $plot in $plotSettings
+            ## Ensure there is valid data for that weather reading
+            #if $plotSettings[$plot].hasData
+                <img src="$imgPrefix${$plotSettings[$plot].image}" alt="${$plotSettings[$plot].alt}"/>
+            #end if
+        #else
+            ## An unknown weather reading plot was present in the requested plots
+            ## Show an error right on the page
+            <br/>Unknown plot type $plot<br/>
+        #end if
+    #end for
 #end def
 
 <!DOCTYPE html>
@@ -82,16 +97,16 @@ $showGraph($dataVar, $graph, $imgPrefix)
                onclick="choose_history('year')">Year</a>
           </div>
           <div id="history_day" class="plot_container">
-            $graphs('day', 'day')
+            $plots('day')
           </div>
           <div id="history_week" class="plot_container" style="display:none">
-            $graphs('week','week')
+            $plots('week')
           </div>
           <div id="history_month" class="plot_container" style="display:none">
-            $graphs('month','month')
+            $plots('month')
           </div>
           <div id="history_year" class="plot_container" style="display:none">
-            $graphs('year','month')
+            $plots('year')
           </div>
         </div>
       </div>

--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -5,6 +5,43 @@
 ## Specifying an encoding of UTF-8 is usually safe:
 #encoding UTF-8
 ##
+
+#set global graphOrder = $Extras.Graphs.order.split(',')
+
+#def dataSettings($hasData, $image, $label)
+#return {"hasData": hasData, "image": image, "alt": label}
+#end def
+
+#set global graphData = { \
+  "outsideTemp":     $dataSettings(True, "tempdew.png", $obs.label.outTemp), \
+  "wind":            $dataSettings(True, "wind.png", $obs.label.windSpeed), \
+  "windDirection":   $dataSettings(True, "winddir.png", $obs.label.windDir), \
+  "windVector":      $dataSettings(True, "windvec.png", $obs.label.windvec), \
+  "rain":            $dataSettings(True, "rain.png", $obs.label.rain), \
+  "feelsLikeTemp":   $dataSettings(True, "tempfeel.png", $obs.label.feel), \
+  "barometer":       $dataSettings(True, "barometer.png", $obs.label.barometer), \
+  "outsideHumidity": $dataSettings(True, "hum.png", $obs.label.outHumidity), \
+  "uvIndex":         $dataSettings($day.UV.has_data, "uv.png", $obs.label.UV), \
+  "radiation":       $dataSettings($day.radiation.has_data, "radiation.png", $obs.label.radiation), \
+  "insideTemp":      $dataSettings($day.daytempin.has_data, "tempin.png", $obs.label.inTemp), \
+  "insideHumidity":  $dataSettings($day.inHumidity.has_data, "humin.png", $obs.label.inHumidity), \
+  "signalQuality":   $dataSettings($day.rxCheckPercent.has_data, "rx.png", $obs.label.rxCheckPercent), \
+  "extraTemp":       $dataSettings($day.extraTemp1.has_data or $day.extraTemp2.has_data or $day.extraTemp3.has_data, "temp.png", $obs.label.extraTemp1) \
+}
+
+#def imgElement($key, $range)
+#set data = $graphData[$key]
+#if $data.hasData
+<img src="$range${data.image}" alt="${data.alt}"/>
+#end if
+#end def
+
+#def graphs($range)
+#for $graph in $graphOrder
+$imgElement($graph, $range)
+#end for
+#end def
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -44,116 +81,16 @@
                onclick="choose_history('year')">Year</a>
           </div>
           <div id="history_day" class="plot_container">
-            <img src="daybarometer.png" alt="$obs.label.barometer"/>
-            <img src="daytempdew.png"   alt="$obs.label.outTemp" />
-            <img src="daytempfeel.png"  alt="$obs.label.feel" />
-            <img src="dayhum.png"       alt="$obs.label.outHumidity" />
-            <img src="daywind.png"      alt="$obs.label.windSpeed" />
-            <img src="daywinddir.png"   alt="$obs.label.windDir" />
-            <img src="daywindvec.png"   alt="$obs.label.windvec" />
-            <img src="dayrain.png"      alt="$obs.label.rain" />
-            #if $day.UV.has_data
-            <img src="dayuv.png"        alt="$obs.label.UV" />
-            #end if
-            #if $day.radiation.has_data
-            <img src="dayradiation.png" alt="$obs.label.radiation" />
-            #end if
-            #if $day.inTemp.has_data
-            <img src="daytempin.png"    alt="$obs.label.inTemp" />
-            #end if
-            #if $day.inHumidity.has_data
-            <img src="dayhumin.png"    alt="$obs.label.inHumidity" />
-            #end if
-            #if $day.extraTemp1.has_data or $day.extraTemp2.has_data or $day.extraTemp3.has_data
-            <img src="daytemp.png"      alt="$obs.label.extraTemp1" />
-            #end if
-            #if $day.rxCheckPercent.has_data
-            <img src="dayrx.png"        alt="$obs.label.rxCheckPercent"/>
-            #end if
+            $graphs('day')
           </div>
           <div id="history_week" class="plot_container" style="display:none">
-            <img src="weekbarometer.png" alt="$obs.label.barometer"/>
-            <img src="weektempdew.png"   alt="$obs.label.outTemp" />
-            <img src="weektempfeel.png"  alt="$obs.label.feel" />
-            <img src="weekhum.png"       alt="$obs.label.outHumidity" />
-            <img src="weekwind.png"      alt="$obs.label.windSpeed" />
-            <img src="weekwinddir.png"   alt="$obs.label.windDir" />
-            <img src="weekwindvec.png"   alt="$obs.label.windvec" />
-            <img src="weekrain.png"      alt="$obs.label.rain" />
-            #if $week.UV.has_data
-            <img src="weekuv.png"        alt="$obs.label.UV" />
-            #end if
-            #if $week.radiation.has_data
-            <img src="weekradiation.png" alt="$obs.label.radiation" />
-            #end if
-            #if $week.inTemp.has_data
-            <img src="weektempin.png"    alt="$obs.label.inTemp" />
-            #end if
-            #if $week.inHumidity.has_data
-            <img src="weekhumin.png"    alt="$obs.label.inHumidity" />
-            #end if
-            #if $week.extraTemp1.has_data or $week.extraTemp2.has_data or $week.extraTemp3.has_data
-            <img src="weektemp.png"      alt="$obs.label.extraTemp1" />
-            #end if
-            #if $week.rxCheckPercent.has_data
-            <img src="weekrx.png"        alt="$obs.label.rxCheckPercent"/>
-            #end if
+            $graphs('week')
           </div>
           <div id="history_month" class="plot_container" style="display:none">
-            <img src="monthbarometer.png" alt="$obs.label.barometer"/>
-            <img src="monthtempdew.png"   alt="$obs.label.outTemp" />
-            <img src="monthtempfeel.png"  alt="$obs.label.feel" />
-            <img src="monthhum.png"       alt="$obs.label.outHumidity" />
-            <img src="monthwind.png"      alt="$obs.label.windSpeed" />
-            <img src="monthwinddir.png"   alt="$obs.label.windDir" />
-            <img src="monthwindvec.png"   alt="$obs.label.windvec" />
-            <img src="monthrain.png"      alt="$obs.label.rain" />
-            #if $month.UV.has_data
-            <img src="monthuv.png"        alt="$obs.label.UV" />
-            #end if
-            #if $month.radiation.has_data
-            <img src="monthradiation.png" alt="$obs.label.radiation" />
-            #end if
-            #if $month.inTemp.has_data
-            <img src="monthtempin.png"    alt="$obs.label.inTemp" />
-            #end if
-            #if $month.inHumidity.has_data
-            <img src="monthhumin.png"    alt="$obs.label.inHumidity" />
-            #end if
-            #if $month.extraTemp1.has_data or $month.extraTemp2.has_data or $month.extraTemp3.has_data
-            <img src="monthtemp.png"      alt="$obs.label.extraTemp1" />
-            #end if
-            #if $month.rxCheckPercent.has_data
-            <img src="monthrx.png"        alt="$obs.label.rxCheckPercent"/>
-            #end if
+            $graphs('month')
           </div>
           <div id="history_year" class="plot_container" style="display:none">
-            <img src="yearbarometer.png" alt="$obs.label.barometer"/>
-            <img src="yeartempdew.png"   alt="$obs.label.outTemp" />
-            <img src="yeartempfeel.png"  alt="$obs.label.feel" />
-            <img src="yearhum.png"       alt="$obs.label.outHumidity" />
-            <img src="yearwind.png"      alt="$obs.label.windSpeed" />
-            <img src="yearwinddir.png"   alt="$obs.label.windDir" />
-            <img src="yearwindvec.png"   alt="$obs.label.windvec" />
-            <img src="yearrain.png"      alt="$obs.label.rain" />
-            #if $year.UV.has_data
-            <img src="yearuv.png"        alt="$obs.label.UV" />
-            #end if
-            #if $year.radiation.has_data
-            <img src="yearradiation.png" alt="$obs.label.radiation" />
-            #end if
-            #if $year.inTemp.has_data
-            <img src="yeartempin.png"    alt="$obs.label.inTemp" />
-            #end if
-            #if $year.inHumidity.has_data
-            <img src="yearhumin.png"    alt="$obs.label.inHumidity" />
-            #end if
-            #if $year.extraTemp1.has_data or $year.extraTemp2.has_data or $year.extraTemp3.has_data
-            <img src="yeartemp.png"      alt="$obs.label.extraTemp1" />
-            #end if
-            #if $year.rxCheckPercent.has_data
-            <img src="yearrx.png"        alt="$obs.label.rxCheckPercent"/>
-            #end if
+            $graphs('year')
           </div>
         </div>
       </div>

--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -6,39 +6,40 @@
 #encoding UTF-8
 ##
 
-#set global graphOrder = $Extras.Graphs.order.split(',')
+#set global graphOrder = $getVar('Extras.Graphs.order', 'barometer,outsideTemp,feelsLikeTemp,outsideHumidity,wind,windDirection,windVector,rain,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality').split(',')
 
-#def dataSettings($hasData, $image, $label)
-#return {"hasData": hasData, "image": image, "alt": label}
+#def dataSettings($field, $image, $label)
+#return {"field": field, "image": image, "alt": label}
 #end def
 
+##  Still need special case for extraTemp1.has_data or extraTemp2.has_data or extraTemp3.has_data
 #set global graphData = { \
-  "outsideTemp":     $dataSettings(True, "tempdew.png", $obs.label.outTemp), \
-  "wind":            $dataSettings(True, "wind.png", $obs.label.windSpeed), \
-  "windDirection":   $dataSettings(True, "winddir.png", $obs.label.windDir), \
-  "windVector":      $dataSettings(True, "windvec.png", $obs.label.windvec), \
-  "rain":            $dataSettings(True, "rain.png", $obs.label.rain), \
-  "feelsLikeTemp":   $dataSettings(True, "tempfeel.png", $obs.label.feel), \
-  "barometer":       $dataSettings(True, "barometer.png", $obs.label.barometer), \
-  "outsideHumidity": $dataSettings(True, "hum.png", $obs.label.outHumidity), \
-  "uvIndex":         $dataSettings($day.UV.has_data, "uv.png", $obs.label.UV), \
-  "radiation":       $dataSettings($day.radiation.has_data, "radiation.png", $obs.label.radiation), \
-  "insideTemp":      $dataSettings($day.daytempin.has_data, "tempin.png", $obs.label.inTemp), \
-  "insideHumidity":  $dataSettings($day.inHumidity.has_data, "humin.png", $obs.label.inHumidity), \
-  "signalQuality":   $dataSettings($day.rxCheckPercent.has_data, "rx.png", $obs.label.rxCheckPercent), \
-  "extraTemp":       $dataSettings($day.extraTemp1.has_data or $day.extraTemp2.has_data or $day.extraTemp3.has_data, "temp.png", $obs.label.extraTemp1) \
+  "outsideTemp":     $dataSettings(None, "tempdew.png", $obs.label.outTemp), \
+  "wind":            $dataSettings(None, "wind.png", $obs.label.windSpeed), \
+  "windDirection":   $dataSettings(None, "winddir.png", $obs.label.windDir), \
+  "windVector":      $dataSettings(None, "windvec.png", $obs.label.windvec), \
+  "rain":            $dataSettings(None, "rain.png", $obs.label.rain), \
+  "feelsLikeTemp":   $dataSettings(None, "tempfeel.png", $obs.label.feel), \
+  "barometer":       $dataSettings(None, "barometer.png", $obs.label.barometer), \
+  "outsideHumidity": $dataSettings(None, "hum.png", $obs.label.outHumidity), \
+  "uvIndex":         $dataSettings('UV', "uv.png", $obs.label.UV), \
+  "radiation":       $dataSettings('radiation', "radiation.png", $obs.label.radiation), \
+  "insideTemp":      $dataSettings('daytempin', "tempin.png", $obs.label.inTemp), \
+  "insideHumidity":  $dataSettings('inHumidity', "humin.png", $obs.label.inHumidity), \
+  "signalQuality":   $dataSettings('rxCheckPercent', "rx.png", $obs.label.rxCheckPercent), \
+  "extraTemp":       $dataSettings('extraTemp1', "temp.png", $obs.label.extraTemp1) \
 }
 
-#def imgElement($key, $range)
+#def showGraph($dataVar, $key, $imgPrefix)
 #set data = $graphData[$key]
-#if $data.hasData
-<img src="$range${data.image}" alt="${data.alt}"/>
+#if $data.field == None or $getVar($dataVar+'.'+$data.field+'.has_data')
+<img src="$imgPrefix${$data.image}" alt="${$data.alt}"/>
 #end if
 #end def
 
-#def graphs($range)
+#def graphs($dataVar, $imgPrefix)
 #for $graph in $graphOrder
-$imgElement($graph, $range)
+$showGraph($dataVar, $graph, $imgPrefix)
 #end for
 #end def
 
@@ -81,16 +82,16 @@ $imgElement($graph, $range)
                onclick="choose_history('year')">Year</a>
           </div>
           <div id="history_day" class="plot_container">
-            $graphs('day')
+            $graphs('day', 'day')
           </div>
           <div id="history_week" class="plot_container" style="display:none">
-            $graphs('week')
+            $graphs('week','week')
           </div>
           <div id="history_month" class="plot_container" style="display:none">
-            $graphs('month')
+            $graphs('month','month')
           </div>
           <div id="history_year" class="plot_container" style="display:none">
-            $graphs('year')
+            $graphs('year','month')
           </div>
         </div>
       </div>

--- a/skins/Seasons/skin.conf
+++ b/skins/Seasons/skin.conf
@@ -27,8 +27,25 @@
     # the analytics code will be included in your generated HTML files:
     #googleAnalyticsId = UA-12345678-1
 
-    [[Graphs]]
-        order = "barometer,outsideTemp,feelsLikeTemp,outsideHumidity,wind,windDirection,windVector,rain,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality"
+    #
+    # Configure the weather reading plots to display, as well as what order to display them in.
+    # Valid plot names are:
+    #     barometer
+    #     outsideTemp
+    #     feelsLikeTemp
+    #     outsideHumidity
+    #     wind
+    #     windDirection
+    #     windVector
+    #     rain
+    #     uvIndex
+    #     radiation
+    #     insideTemp
+    #     insideHumidity
+    #     extraTemp
+    #     signalQuality
+    [[Plots]]
+        order = "outsideTemp,wind,windDirection,windVector,rain,feelsLikeTemp,barometer,outsideHumidity,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality"
 
 ###############################################################################
 

--- a/skins/Seasons/skin.conf
+++ b/skins/Seasons/skin.conf
@@ -27,6 +27,9 @@
     # the analytics code will be included in your generated HTML files:
     #googleAnalyticsId = UA-12345678-1
 
+    [[Graphs]]
+        order = "barometer,outsideTemp,feelsLikeTemp,outsideHumidity,wind,windDirection,windVector,rain,uvIndex,radiation,insideTemp,insideHumidity,extraTemp,signalQuality"
+
 ###############################################################################
 
 [Labels]


### PR DESCRIPTION
I prefer a different order to the graphs on the default Seasons skin. This makes that order configurable in the `skins.conf` file. The default in `skins.conf` preserves the original order from `index.html.tmpl`.

One note is that this assumes that if the `$day` graph `has_data`, the `$week`, `$month` and `$year` graphs will also have data.