### PR TITLE
better handling of accented characters in strict_ascii encoded reports

### DIFF
--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -61,6 +61,7 @@ import datetime
 import logging
 import os.path
 import time
+import unicodedata
 
 import Cheetah.Filters
 import Cheetah.Template
@@ -323,11 +324,14 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                 unicode_string = compiled_template.respond()
 
                 # Time to write it out. Determine the strategy for encoding any non-ascii
-                # chartacters.
+                # characters.
                 if encoding == 'html_entities':
                     byte_string = unicode_string.encode('ascii', 'xmlcharrefreplace')
                 elif encoding == 'strict_ascii':
-                    byte_string = unicode_string.encode('ascii', 'ignore')
+                    # normalize the string first to replace accented characters with 
+                    # non-accented equivalents
+                    _normalized = unicodedata.normalize('NFD', unicode_string)
+                    byte_string = _normalized.encode('ascii', 'ignore')
                 else:
                     byte_string = unicode_string.encode('utf8')
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -9,6 +9,9 @@ records, or both. PR #630. Thanks to user g-eddy!
 Introduced aggregate types "avg_ge" and "avg_le". PR #631. Thanks again to user
 g-eddy!
 
+Accented (diacritic) characters in strict_ascii encoded reports are now
+replaced with an ascii equivalent rather than deleted.
+
 
 4.3.0 01/04/2020
 

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -5926,7 +5926,10 @@ growing_base = 50.0, degree_F</pre>
             </tr>
             <tr>
                 <td class="code first_col">utf8</td>
-                <td>Non 7-bit characters will be represented in UTF-8.</td>
+                <td>Non 7-bit characters will be ignored or replaced with an ASCII equivalent (<i>e.g.</i>, accented
+                    characters such as <span class="code">ä</span> are replaced with a non-accented equivalent
+                    such as <span class="code">a</span>)
+                </td>
             </tr>
             <tr>
                 <td class="code first_col">strict_ascii</td>


### PR DESCRIPTION
Converts accented characters in `strict_ascii` encoded report output to non-accented equivalents. I believe there are better/more complete solutions but they involve another dependency. This solution is simple, utlilises an existing library and will handle most common cases. 

Tested against the current development branch under python 2.7 and python 3.7.

Refer issue #644.