### PR TITLE
Send rain with precision of 3 to WOW

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1043,7 +1043,7 @@ class WOWThread(AmbientThread):
                 'windGustDir': 'windgustdir=%.0f',
                 'dewpoint'   : 'dewptf=%.1f',
                 'hourRain'   : 'rainin=%.2f',
-                'dayRain'    : 'dailyrainin=%.2f'}
+                'dayRain'    : 'dailyrainin=%.3f'}
 
     def format_url(self, incoming_record):
         """Return an URL for posting using WOW's version of the Ambient


### PR DESCRIPTION
The unit that's used to send the rain data to WOW is inches. There are devices that have a resolution of 0.1 mm, which is about 0.004 inch.

I'm not sure if other places in the same file need the same change.