### PR TITLE
WS1 driver TCP mode issues

### DIFF
--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -307,6 +307,7 @@ class StationSocket(object):
         import socket
 
         log.debug("Connecting to %s:%d." % (self.conn_info[0], self.conn_info[1]))
+
         for conn_attempt in range(self.max_tries):
             try:
                 if conn_attempt > 1:
@@ -515,8 +516,8 @@ if __name__ == '__main__':
         exit(0)
 
     if options.debug:
-        weewx.debug = 1
-        DEBUG_READ = 1
+        weewx.debug = 2
+        DEBUG_READ = 2
 
     weeutil.logger.setup('ws1', {})
 

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -344,50 +344,50 @@ class StationSocket(object):
         if DEBUG_READ >= 2:
             log.debug("Attempting to find record start..")
 
-        buff = ''
+        buf = ''
         while True:
             data = self.get_data()
             if DEBUG_READ >= 2:
-                log.debug("(searching...) buff: %s" % buff)
+                log.debug("(searching...) buf: %s" % buf)
             # split on line breaks and take everything after the line break
             data = data.splitlines()[-1]
             if "!!" in data:
                 # if it contains !!, take everything after the last occurance of !! (we sometimes see a whole bunch of !)
-                buff = data.rpartition("!!")[-1]
-                if len(buff) > 0:
+                buf = data.rpartition("!!")[-1]
+                if len(buf) > 0:
                     # if there is anything left, add the !! back on and break
                     # we have effectively found everything between a line break and !!
-                    buff = "!!" + buff
+                    buf = "!!" + buf
                     if DEBUG_READ >= 2:
                         log.debug("Record start found!")
                     break
-        return buff
+        return buf
 
 
-    def fill_buffer(self, buff):
+    def fill_buffer(self, buf):
         if DEBUG_READ >= 2:
             log.debug("filling buffer with rest of record")
         while True:
             data = self.get_data()
             # split on line breaks and take everything before it
             data = data.splitlines()[0]
-            buff = buff + data
+            buf = buf + data
             if DEBUG_READ >= 2:
-                log.debug("buff is %s" % buff)
-            if len(buff) == 50:
+                log.debug("buf is %s" % buf)
+            if len(buf) == 50:
                 if DEBUG_READ >= 2:
-                    log.debug("filled record %s" % buff)
+                    log.debug("filled record %s" % buf)
                 break
-        return buff
+        return buf
 
     def get_readings(self):
-        buff = self.find_record_start()
+        buf = self.find_record_start()
         if DEBUG_READ >= 2:
-            log.debug("record start: %s" % buff)
-        buff = self.fill_buffer(buff)
+            log.debug("record start: %s" % buf)
+        buf = self.fill_buffer(buf)
         if DEBUG_READ >= 1:
-            log.debug("Got data record: %s" % buff)
-        return buff
+            log.debug("Got data record: %s" % buf)
+        return buf
 
     def get_readings_with_retry(self, max_tries=5, wait_before_retry=10):
         for _ in range(max_tries):
@@ -406,7 +406,7 @@ class StationSocket(object):
                 # errors and timeouts.
 
                 if DEBUG_READ >= 1:
-                    log.debug("buf: %s (%d bytes)" % (buff, len(buff)))
+                    log.debug("buf: %s (%d bytes)" % (buf, len(buf)))
 
                 time.sleep(wait_before_retry)
         else:

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -29,7 +29,7 @@ import weewx.wxformulas
 log = logging.getLogger(__name__)
 
 DRIVER_NAME = 'WS1'
-DRIVER_VERSION = '0.41'
+DRIVER_VERSION = '0.5'
 
 
 def loader(config_dict, _):

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -273,9 +273,6 @@ class StationSocket(object):
                  wait_before_retry=10):
         import socket
 
-        ip_addr = None
-        ip_port = None
-
         self.max_tries = max_tries
         self.wait_before_retry = wait_before_retry
 
@@ -284,9 +281,7 @@ class StationSocket(object):
             self.conn_info[1] = int(self.conn_info[1], 10)
             self.conn_info = tuple(self.conn_info)
         else:
-            ip_addr = addr
-            ip_port = DEFAULT_TCP_PORT
-            self.conn_info = (ip_addr, ip_port)
+            self.conn_info = (addr, DEFAULT_TCP_PORT)
 
         try:
             if protocol == 'tcp':

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -328,10 +328,17 @@ class StationSocket(object):
                       % (self.conn_info[0], self.conn_info[1], ex))
             raise weewx.WeeWxIOError(ex)
 
-    def get_data(self, bytes=8):
+    def get_data(self, num_bytes=8):
+        """Get data from the socket connection
+        Args:
+            num_bytes: The number of bytes to request.
+        Returns:
+            bytes: The data from the remote device.
+        """
+
         import socket
         try:
-            data = self.net_socket.recv(bytes, socket.MSG_WAITALL)
+            data = self.net_socket.recv(num_bytes, socket.MSG_WAITALL)
         except Exception as ex:
             raise weewx.WeeWxIOError(ex)
         else:
@@ -341,6 +348,11 @@ class StationSocket(object):
             return data
 
     def find_record_start(self):
+        """Find the start of a data record by requesting data from the remote
+           device until we find it.
+        Returns:
+            bytes: The start of a data record from the remote device.
+        """
         if DEBUG_READ >= 2:
             log.debug("Attempting to find record start..")
 
@@ -366,6 +378,12 @@ class StationSocket(object):
 
 
     def fill_buffer(self, buf):
+        """Get the remainder of the data record from the remote device.
+        Args:
+            buf: The beginning of the data record.
+        Returns:
+            bytes: The data from the remote device.
+        """
         if DEBUG_READ >= 2:
             log.debug("filling buffer with rest of record")
         while True:

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -361,7 +361,7 @@ class StationSocket(object):
             data = self.get_data()
 
             if DEBUG_READ >= 2:
-                log.debug("(searching...) buf: %s" % buf)
+                log.debug("(searching...) buf: %s" % buf.decode('utf-8'))
             # split on line breaks and take everything after the line break
             data = data.splitlines()[-1]
             if b"!!" in data:
@@ -393,20 +393,20 @@ class StationSocket(object):
             data = data.splitlines()[0]
             buf = buf + data
             if DEBUG_READ >= 2:
-                log.debug("buf is %s" % buf)
+                log.debug("buf is %s" % buf.decode('utf-8'))
             if len(buf) == 50:
                 if DEBUG_READ >= 2:
-                    log.debug("filled record %s" % buf)
+                    log.debug("filled record %s" % buf.decode('utf-8'))
                 break
         return buf
 
     def get_readings(self):
         buf = self.find_record_start()
         if DEBUG_READ >= 2:
-            log.debug("record start: %s" % buf)
+            log.debug("record start: %s" % buf.decode('utf-8'))
         buf = self.fill_buffer(buf)
         if DEBUG_READ >= 1:
-            log.debug("Got data record: %s" % buf)
+            log.debug("Got data record: %s" % buf.decode('utf-8'))
         return buf
 
     def get_readings_with_retry(self, max_tries=5, wait_before_retry=10):
@@ -424,7 +424,7 @@ class StationSocket(object):
                 # errors and timeouts.
 
                 if DEBUG_READ >= 1:
-                    log.debug("buf: %s (%d bytes)" % (buf, len(buf)))
+                    log.debug("buf: %s (%d bytes)" % (buf.decode('utf-8'), len(buf)))
 
                 time.sleep(wait_before_retry)
         else:

--- a/bin/weewx/drivers/ws1.py
+++ b/bin/weewx/drivers/ws1.py
@@ -342,6 +342,9 @@ class StationSocket(object):
         buf = ''
         while True:
             data = self.get_data()
+            if len(data) == 0:
+                raise weewx.WeeWxIOError("No data recieved")
+
             if DEBUG_READ >= 2:
                 log.debug("(searching...) buf: %s" % buf)
             # split on line breaks and take everything after the line break


### PR DESCRIPTION
Fix encoding errors, simplify data fetching, address unexpected buffer length errors.

I am using Python 3.

I've been using the WS1 driver in serial mode with no issues for a while. But when I switched to TCP mode it did not work at all.

I have my WS1 connected to a raspberry pi zero and exposed to the network with ser2net with this config:

`2000:raw:600:/dev/ttyUSB0:2400`

And I have weewx running on a pi 4.

When I enabled TCP mode, I ran into a couple of issues:

1. String encoding errors similar to #556 
2. Unexpected buffer length errors (like #372)

Regarding 2, in my testing here, the WS1 never seems to send more than 6 bytes at a time via ser2net. So when we do [this](https://github.com/weewx/weewx/blob/master/bin/weewx/drivers/ws1.py#L363) and expect to get the amount of data we asked for, we will be disappointed. Same thing [here](https://github.com/weewx/weewx/blob/master/bin/weewx/drivers/ws1.py#L394).

So what I would see is it would go along for a while getting data then about every minute or so, it would hit [this](https://github.com/weewx/weewx/blob/master/bin/weewx/drivers/ws1.py#L142) and that would cause it to wait 10 seconds before trying again.

This leads me to wonder, is nobody else using TCP mode or is there something funky about my setup here?

In any case, I rewrote some of the TCP mode stuff to be much simpler (at least to my eye). It works flawlessly here - it's been running for several hours. But I am worried that this might break for other people.

Feedback is welcome - I am not a Python developer, I write javascript for a living :)

Also, I notice that the [docs](http://weewx.com/docs/usersguide.htm#[WS1]) are out of date. They do not mention TCP mode but they do mention polling interval. I notice that polling interval was taken out of the WS1 driver some time ago. But for my purposes, using TCP mode, it would be useful. I am wondering, why was that taken out?