### PR TITLE
minor doc updates for debian installation instructions

### DIFF
--- a/docs/debian.htm
+++ b/docs/debian.htm
@@ -27,11 +27,17 @@
 Tell your system to trust weewx.com:
 <pre class='tty cmd'>wget -qO - https://weewx.com/keys.html | sudo apt-key add -</pre>
 
-For Debian10 and later, use python3:
-<pre class='tty cmd'>wget -qO - https://weewx.com/apt/weewx-python3.list | sudo tee /etc/apt/sources.list.d/weewx.list</pre>
+Run one of the following two commands to tell your system about the appropriate weewx repository.
 
-For Debian9 and earlier, use python2:
+<ul>
+<li> For Debian10 and later, use python3:
+<pre class='tty cmd'>wget -qO - https://weewx.com/apt/weewx-python3.list | sudo tee /etc/apt/sources.list.d/weewx.list</pre>
+</li>
+
+<li> 'or' for Debian9 and earlier, use python2:
 <pre class='tty cmd'>wget -qO - https://weewx.com/apt/weewx-python2.list | sudo tee /etc/apt/sources.list.d/weewx.list</pre>
+</li>
+</ul>
 
 <h2>Install</h2>
 <p>Use <span class="code">apt-get</span> to install WeeWX. The installer will prompt for a location, latitude/longitude, altitude, station type, and parameters specific to your station hardware.

--- a/docs/setup.htm
+++ b/docs/setup.htm
@@ -340,11 +340,11 @@ sudo /etc/init.d/weewx start</pre>
 </p>
 <pre class='tty cmd'>sudo rm -r /home/weewx
 
-# if you used the init.d startup file method in step (4)  above
-sudo rm /etc/init.d/weewx
-
-# or if you used the systemd startup file method in step (4) above
+# if you used the systemd startup file method in step (4) above
 sudo rm /etc/systemd/system/weewx.service
+
+# or if you used the init.d startup file method in step (4)  above
+sudo rm /etc/init.d/weewx
 </pre>
 
 <h2>Layout</h2>

--- a/docs/setup.htm
+++ b/docs/setup.htm
@@ -275,18 +275,18 @@ sudo ./bin/weewxd</pre>
         </button>
     </nav>
     <div id='startup-debian' class="tab-content">
-        <pre class="tty cmd"> #-- option 1 - use the old init.d method
+        <pre class="tty cmd"> #-- preferred option - use systemd
+cd /home/weewx
+sudo cp /home/weewx/util/systemd/weewx.service /etc/systemd/system
+sudo systemctl enable weewx
+sudo systemctl start weewx
+
+#-- option 2 - use the old init.d method if your os is ancient
 cd /home/weewx
 sudo cp util/init.d/weewx.debian /etc/init.d/weewx
 sudo chmod +x /etc/init.d/weewx
 sudo update-rc.d weewx defaults 98
-sudo /etc/init.d/weewx start
-
-#-- option 2 - or alternately use the newer systemd method
-cd /home/weewx
-sudo cp /home/weewx/util/systemd/weewx.service /etc/systemd/system
-sudo systemctl enable weewx
-sudo systemctl start weewx</pre>
+sudo /etc/init.d/weewx start </pre>
     </div>
     <div id='startup-redhat' class="tab-content">
         <pre class="tty cmd">cd /home/weewx

--- a/docs/setup.htm
+++ b/docs/setup.htm
@@ -275,11 +275,18 @@ sudo ./bin/weewxd</pre>
         </button>
     </nav>
     <div id='startup-debian' class="tab-content">
-        <pre class="tty cmd">cd /home/weewx
+        <pre class="tty cmd"> #-- option 1 - use the old init.d method
+cd /home/weewx
 sudo cp util/init.d/weewx.debian /etc/init.d/weewx
 sudo chmod +x /etc/init.d/weewx
 sudo update-rc.d weewx defaults 98
-sudo /etc/init.d/weewx start</pre>
+sudo /etc/init.d/weewx start
+
+#-- option 2 - or alternately use the newer systemd method
+cd /home/weewx
+sudo cp /home/weewx/util/systemd/weewx.service /etc/systemd/system
+sudo systemctl enable weewx
+sudo systemctl start weewx</pre>
     </div>
     <div id='startup-redhat' class="tab-content">
         <pre class="tty cmd">cd /home/weewx
@@ -328,11 +335,17 @@ sudo /etc/init.d/weewx start</pre>
 <h2>Uninstall</h2>
 
 <p>
-    To uninstall, simply delete the directory <span class='code'>/home/weewx</span>. This will delete WeeWX,
-    configuration files, and data.
+    To uninstall, simply stop weewx and delete the directory <span class='code'>/home/weewx</span>. This will delete WeeWX,
+    configuration files, and data.  Also remove the startup file previously put into place.
 </p>
 <pre class='tty cmd'>sudo rm -r /home/weewx
-sudo rm /etc/init.d/weewx</pre>
+
+# if you used the init.d startup file method in step (4)  above
+sudo rm /etc/init.d/weewx
+
+# or if you used the systemd startup file method in step (4) above
+sudo rm /etc/systemd/system/weewx.service
+</pre>
 
 <h2>Layout</h2>
 


### PR DESCRIPTION
This provides minor tweaks for debian based on rather frequently asked questions on weewx-users.

- make the apt related commands a little more obvious since we're still in the python2/python3 transition
- for setup.py users itemize how to use systemd as the init system