### PR TITLE
Support for canonical URL <link rel="canonical" … />

### DIFF
--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -309,7 +309,10 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                     pass
 
             searchList = self._getSearchList(encoding, timespan,
-                                             default_binding, section_name)
+                                             default_binding, section_name,
+                                             os.path.join(
+                                               os.path.dirname(report_dict['template']),
+                                               _filename))
             tmpname = _fullname + '.tmp'
 
             try:
@@ -370,7 +373,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
 
         return ngen
 
-    def _getSearchList(self, encoding, timespan, default_binding, section_name):
+    def _getSearchList(self, encoding, timespan, default_binding, section_name, file_name):
         """Get the complete search list to be used by Cheetah."""
 
         # Get the basic search list
@@ -378,7 +381,8 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
         searchList = [{'month_name' : time.strftime("%b", timespan_start_tt),
                        'year_name'  : timespan_start_tt[0],
                        'encoding'   : encoding,
-                       'page'       : section_name},
+                       'page'       : section_name,
+                       'filename'   : file_name},
                       self.outputted_dict]
 
         # Bind to the default_binding:

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -3113,7 +3113,15 @@ $month.outTemp.series(aggregate_type='max', aggregate_interval='day', time_serie
               for the report. You can use this tag in
               <span class="code">#if</span> expressions and
               to include language codes where the HTML
-              specification requires them.
+              specification requires them.</td>
+            </tr>
+            <tr>
+              <td class="code first_col">$filename</td>
+              <td>
+                Name of the file to be created including relative path.
+                Can be used to set the canonical URL for Google.
+                <pre class="tty">&lt;link rel="canonical" href="$station.station_url/$filename" /&gt;</pre>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/skins/Seasons/celestial.html.tmpl
+++ b/skins/Seasons/celestial.html.tmpl
@@ -9,6 +9,9 @@
     <title>$station.location Celestial Details</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
     <style>
 #celestial_widget th {

--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -10,6 +10,9 @@
     <title>$station.location</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
   </head>
 

--- a/skins/Seasons/statistics.html.tmpl
+++ b/skins/Seasons/statistics.html.tmpl
@@ -9,6 +9,9 @@
     <title>$station.location Statistics</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
     <style>
 #statistics_widget th {

--- a/skins/Seasons/tabular.html.tmpl
+++ b/skins/Seasons/tabular.html.tmpl
@@ -10,6 +10,9 @@
     <title>$station.location</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript" src="seasons.js"></script>
     <style>
 .tabular {

--- a/skins/Seasons/telemetry.html.tmpl
+++ b/skins/Seasons/telemetry.html.tmpl
@@ -24,6 +24,9 @@
     <title>$station.location $gettext["telemetry"]["Telemetry"]</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
   </head>
 

--- a/skins/Standard/index.html.tmpl
+++ b/skins/Standard/index.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Current Weather Conditions"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/month.html.tmpl
+++ b/skins/Standard/month.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Monthly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/week.html.tmpl
+++ b/skins/Standard/week.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Weekly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/year.html.tmpl
+++ b/skins/Standard/year.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Yearly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {


### PR DESCRIPTION
Google suggests to include a [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) into the header of HTML files. Often websites are available by HTTPS as well as HTTP, and with `www` and without. To help Google to sort out those variants and duplicate content, web administrators shall inform about the real URL bei setting up a canonical URL. 

To my knowledge the filename to be created (including relative path) is not available in Cheetah unfortunately. 

With the changes from this pull request setting a canonical URL would be possible like this:
```
<link rel="canonical" href="$station.station_url/$filename" />
```

One could argue that the filename could be set literally in the template. But that is not always possible:
* in case of templates in the `[[SummaryByMonth]]` or `[[SummaryByYear]]` section because the file name includes variable parts
* in case there is a single include file to define the HTML header section for all files to be created.