### PR TITLE
German Localization files for Mobile and Smartphone skins

### DIFF
--- a/bin/weewx/cheetahgenerator.py
+++ b/bin/weewx/cheetahgenerator.py
@@ -309,7 +309,10 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                     pass
 
             searchList = self._getSearchList(encoding, timespan,
-                                             default_binding, section_name)
+                                             default_binding, section_name,
+                                             os.path.join(
+                                               os.path.dirname(report_dict['template']),
+                                               _filename))
             tmpname = _fullname + '.tmp'
 
             try:
@@ -370,7 +373,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
 
         return ngen
 
-    def _getSearchList(self, encoding, timespan, default_binding, section_name):
+    def _getSearchList(self, encoding, timespan, default_binding, section_name, file_name):
         """Get the complete search list to be used by Cheetah."""
 
         # Get the basic search list
@@ -378,7 +381,8 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
         searchList = [{'month_name' : time.strftime("%b", timespan_start_tt),
                        'year_name'  : timespan_start_tt[0],
                        'encoding'   : encoding,
-                       'page'       : section_name},
+                       'page'       : section_name,
+                       'filename'   : file_name},
                       self.outputted_dict]
 
         # Bind to the default_binding:

--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -3113,7 +3113,15 @@ $month.outTemp.series(aggregate_type='max', aggregate_interval='day', time_serie
               for the report. You can use this tag in
               <span class="code">#if</span> expressions and
               to include language codes where the HTML
-              specification requires them.
+              specification requires them.</td>
+            </tr>
+            <tr>
+              <td class="code first_col">$filename</td>
+              <td>
+                Name of the file to be created including relative path.
+                Can be used to set the canonical URL for Google.
+                <pre class="tty">&lt;link rel="canonical" href="$station.station_url/$filename" /&gt;</pre>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/skins/Mobile/index.html.tmpl
+++ b/skins/Mobile/index.html.tmpl
@@ -38,10 +38,10 @@ function hideURLbar() {
       <td><a href="daytempdew.png">$obs.label.outTemp / $obs.label.dewpoint:</a></td><td class="data"> $current.outTemp / $current.dewpoint </td>
     </tr>
     <tr class="alt">
-      <td>High Temp:</td><td class="data"> $day.outTemp.max $gettext["at"] $day.outTemp.maxtime </td>
+      <td>$gettext["High Temp"]:</td><td class="data"> $day.outTemp.max $gettext["at"] $day.outTemp.maxtime </td>
     </tr>
     <tr>            
-      <td>Low Temp:</td><td class="data"> $day.outTemp.min $gettext["at"] $day.outTemp.mintime </td>
+      <td>$gettext["Low Temp"]:</td><td class="data"> $day.outTemp.min $gettext["at"] $day.outTemp.mintime </td>
     </tr>
     <tr class="alt">
       <td><a href="daytempfeel.png">$obs.label.heatindex / $obs.label.windchill:</a></td><td class="data"> $current.heatindex / $current.windchill </td>

--- a/skins/Mobile/lang/de.conf
+++ b/skins/Mobile/lang/de.conf
@@ -1,0 +1,24 @@
+###############################################################################
+# Localization File                                                           #
+#    Deutsch                                                                  #
+# Copyright (c) 2021 Tom Keffer <tkeffer@gmail.com>                           #
+# See the file LICENSE.txt for your rights.                                   #
+###############################################################################
+
+[Labels]
+    [[Generic]]
+        dewpoint = Taupunkt
+        heatindex= Hitzeindex
+        outHumidity = Außenluftfeuchte
+        outTemp = Außentemperatur
+        rain = Regen
+        windchill = Windchil
+        windGust = Windböen
+        windSpeed = Windstärke
+
+[Texts]
+    "at" = "um"     # Time context. E.g., 15.1C "at" 12:22
+    "High Rain Rate" = "max. Regenrate"
+    "High Wind"      = "max. Wind"
+    "High Temp"      = "max. Temp."
+    "Low Temp"       = "min. Temp."

--- a/skins/Mobile/lang/en.conf
+++ b/skins/Mobile/lang/en.conf
@@ -20,3 +20,6 @@
     "at" = "at"     # Time context. E.g., 15.1C "at" 12:22
     "High Rain Rate" = "High Rain Rate"
     "High Wind" = "High Wind"
+    "High Temp" = "High Temp"
+    "Low Temp"  = "Low Temp"
+

--- a/skins/Seasons/celestial.html.tmpl
+++ b/skins/Seasons/celestial.html.tmpl
@@ -9,6 +9,9 @@
     <title>$station.location Celestial Details</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
     <style>
 #celestial_widget th {

--- a/skins/Seasons/index.html.tmpl
+++ b/skins/Seasons/index.html.tmpl
@@ -10,6 +10,9 @@
     <title>$station.location</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
   </head>
 

--- a/skins/Seasons/statistics.html.tmpl
+++ b/skins/Seasons/statistics.html.tmpl
@@ -9,6 +9,9 @@
     <title>$station.location Statistics</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
     <style>
 #statistics_widget th {

--- a/skins/Seasons/tabular.html.tmpl
+++ b/skins/Seasons/tabular.html.tmpl
@@ -10,6 +10,9 @@
     <title>$station.location</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript" src="seasons.js"></script>
     <style>
 .tabular {

--- a/skins/Seasons/telemetry.html.tmpl
+++ b/skins/Seasons/telemetry.html.tmpl
@@ -24,6 +24,9 @@
     <title>$station.location $gettext["telemetry"]["Telemetry"]</title>
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" href="seasons.css"/>
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script src="seasons.js"></script>
   </head>
 

--- a/skins/Smartphone/lang/de.conf
+++ b/skins/Smartphone/lang/de.conf
@@ -1,0 +1,33 @@
+###############################################################################
+# Localization File                                                           #
+#    Deutsch                                                                  #
+# Copyright (c) 2021 Tom Keffer <tkeffer@gmail.com>                           #
+# See the file LICENSE.txt for your rights.                                   #
+###############################################################################
+
+[Labels]
+    [[Generic]]
+        barometer = Luftdruck
+        dewpoint = Taupunkt
+        outHumidity = Außenluftfeuchte
+        outTemp = Außentemperatur
+        rain = Regen
+        rainRate = Regenrate
+        wind = Wind
+        windDir = Windrichtung
+        windGust = Windböen
+        windSpeed = Windstärke
+
+[Texts]
+    "7-day" = "7-Tage"
+    "24h" = "24h"
+    "at" = "um"     # Time context. E.g., 15.1C "at" 12:22
+    "in" = "in"     # Geographic context. E.g., Temperature "in" Boston.
+    "Last 7 days" = "7-Tage"
+    "Last 30 days" = "30-Tage"
+    "Last update" = "letzte Aktualisierung"
+    "max gust" = "max. Böen"
+    "Max rate" = "Max. Rate"
+    "max" = "max"
+    "min" = "min"
+    "Total" = "gesamt"

--- a/skins/Standard/index.html.tmpl
+++ b/skins/Standard/index.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Current Weather Conditions"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/month.html.tmpl
+++ b/skins/Standard/month.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Monthly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/week.html.tmpl
+++ b/skins/Standard/week.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Weekly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {

--- a/skins/Standard/year.html.tmpl
+++ b/skins/Standard/year.html.tmpl
@@ -11,6 +11,9 @@
     <title>$station.location $gettext["Yearly Weather Summary"]</title>
     <link rel="stylesheet" type="text/css" href="weewx.css"/>
     <link rel="icon" type="image/png" href="favicon.ico" />
+    #if $station.station_url
+    <link rel="canonical" href="$station.station_url/$filename" />
+    #end if
     <script type="text/javascript">
       function openURL(urlname)
       {


### PR DESCRIPTION
These are the german localization files for the Mobile and Smartphone skins.

If words are put together in german language there is always a hyphen between them or they are put together without space in between. So "Last 7-day Temperature" is "7-Tage-Temperatur" oder "Temperaturen der letzten 7 Tage" (the latter is better German). That is not possible with the current structure of the language files.