### PR TITLE
update to permit building rpms on centos8 host

### DIFF
--- a/pkg/weewx.spec.in
+++ b/pkg/weewx.spec.in
@@ -46,6 +46,10 @@
 %define deps python, python-setuptools, python-configobj, python-cheetah, python-imaging
 %define python python2
 %define html_root /var/www/html/weewx
+# Disable Fedora's shebang mangling script,
+# which errors out on any file with versionless `python` in its shebang
+# See: https://github.com/atom/atom/issues/21937
+%undefine __brp_mangle_shebangs
 %endif
 
 # rh8: python3 on redhat, fedora, centos
@@ -57,7 +61,12 @@
 %define deps python3, python3-setuptools, python3-configobj, python3-pillow, python3-pyserial, python3-pyusb
 %define python python3
 %define html_root /var/www/html/weewx
+# Disable Fedora's shebang mangling script,
+# which errors out on any file with versionless `python` in its shebang
+# See: https://github.com/atom/atom/issues/21937
+%undefine __brp_mangle_shebangs
 %endif
+
 
 %global relnum RPMREVISION
 %global release %{relnum}%{?relos:%{relos}}


### PR DESCRIPTION
This PR adds a couple one-liners to fix the problem where you can't build rpms using a centos8 host because that os complains about the shebang line in drivers that uses env python.   Adding the settings to weewx.spec.in turns this off and permits the rpms to build successfully on a centos8 build host.

(update - oops the blasted GitHub GUI reset the base branch on me again, so this will try to merge to master (sorry).  It looked like PR #694 the other day was also merged to master but not back to development, so this+that would need to be pulled to development too to keep development clean.  Ugh.)
