### PR TITLE
add weewxd entrypoint to station registration url

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1392,7 +1392,7 @@ class StdStationRegistry(StdRESTful):
         weewx_info       weewx version
         python_info
         platform_info
-        installer
+        entrypoint
 
     The station_url is the unique key by which a station is identified.
     """
@@ -1424,7 +1424,7 @@ class StdStationRegistry(StdRESTful):
         _registry_dict.setdefault('latitude', self.engine.stn_info.latitude_f)
         _registry_dict.setdefault('longitude', self.engine.stn_info.longitude_f)
         _registry_dict.setdefault('station_model', self.engine.stn_info.hardware)
-        _registry_dict.setdefault('installer', config_dict['installer'])
+        _registry_dict.setdefault('entrypoint', config_dict['entrypoint'])
 
         self.archive_queue = queue.Queue()
         self.archive_thread = StationRegistryThread(self.archive_queue,
@@ -1444,7 +1444,7 @@ class StationRegistryThread(RESTThread):
                  server_url=StdStationRegistry.archive_url,
                  description="Unknown",
                  station_type="Unknown", station_model="Unknown",
-                 installer="Unknown",
+                 entrypoint="Unknown",
                  post_interval=604800, max_backlog=0, stale=None,
                  log_success=True, log_failure=True,
                  timeout=60, max_tries=3, retry_wait=5):
@@ -1473,7 +1473,9 @@ class StationRegistryThread(RESTThread):
           property provided by the driver.
           Default is 'Unknown'.
 
-          installer: how was weewx installed, based on location of config_path
+          entrypoint: location of the invoked weewxd, used in system
+          registration to determine how weewx might have been installed.
+          Default is 'Unknown'.
 
         Parameters customized for this class:
           
@@ -1499,7 +1501,7 @@ class StationRegistryThread(RESTThread):
         self.description = weeutil.weeutil.list_as_string(description)
         self.station_type = station_type
         self.station_model = station_model
-        self.installer = installer
+        self.entrypoint = entrypoint
 
     def get_record(self, dummy_record, dummy_archive):
         _record = {
@@ -1512,7 +1514,7 @@ class StationRegistryThread(RESTThread):
             'python_info'   : platform.python_version(),
             'platform_info' :  platform.platform(),
             'weewx_info'    : weewx.__version__,
-            'installer'     : self.installer,
+            'entrypoint'     : self.entrypoint,
             'usUnits'       : weewx.US,
         }
         return _record
@@ -1525,7 +1527,7 @@ class StationRegistryThread(RESTThread):
                 'station_model': 'station_model=%s',
                 'python_info'  : 'python_info=%s',
                 'platform_info': 'platform_info=%s',
-                'installer'    : 'installer=%s',
+                'entrypoint'    : 'entrypoint=%s',
                 'weewx_info'   : 'weewx_info=%s'}
 
     def format_url(self, record):

--- a/bin/weewxd
+++ b/bin/weewxd
@@ -105,6 +105,10 @@ def main():
     log.info("Using configuration file %s", config_path)
     log.info("Debug is %s", weewx.debug)
 
+    # save the full path to the invoked weewxd for station registration
+    config_dict['entrypoint'] = os.path.realpath(__file__)
+    log.info("Entrypoint is %s", config_dict['entrypoint'])
+
     # If no command line --loop-on-init was specified, look in the config file.
     if options.loop_on_init is None:
         loop_on_init = to_bool(config_dict.get('loop_on_init', False))
@@ -142,14 +146,6 @@ def main():
 
         try:
             log.debug("Initializing engine")
-
-            # determine how weewx was installed for station registration
-            if config_path == '/etc/weewx/weewx.conf':
-                config_dict['installer'] = 'packaged'
-            elif config_path == '/home/weewx/weewx.conf':
-                config_dict['installer'] = 'setup'
-            else:
-                config_dict['installer'] = 'other'
 
             # Create and initialize the engine
             engine = weewx.engine.StdEngine(config_dict)

--- a/bin/weewxd
+++ b/bin/weewxd
@@ -143,6 +143,14 @@ def main():
         try:
             log.debug("Initializing engine")
 
+            # determine how weewx was installed for station registration
+            if config_path == '/etc/weewx/weewx.conf':
+                config_dict['installer'] = 'packaged'
+            elif config_path == '/home/weewx/weewx.conf':
+                config_dict['installer'] = 'setup'
+            else:
+                config_dict['installer'] = 'other'
+
             # Create and initialize the engine
             engine = weewx.engine.StdEngine(config_dict)
 


### PR DESCRIPTION
This adds a 'installer' element to the station registry to provide breakdowns of how registered stations chose to install weewx, based on the location of weewx.conf for the running instance.  

The updated registration url would have the 'installer=<value>' just before weewx_info ala:

http://weewx.com/register/register.cgi?station_url=http%3A%2F%2Fwww.example.com&description=My+Little+Town%2C+Oregon&latitude=0.0000&longitude=0.0000&station_type=Simulator&station_model=Simulator&python_info=3.7.3&platform_info=Linux-4.19.0-16-amd64-x86_64-with-debian-10.11&installer=setup&weewx_info=4.5.1
