### PR TITLE
Minor quoting and exec improvements to util/scripts

### DIFF
--- a/util/scripts/wee_config
+++ b/util/scripts/wee_config
@@ -6,4 +6,4 @@ app=wee_config
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_database
+++ b/util/scripts/wee_database
@@ -6,4 +6,4 @@ app=wee_database
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_debug
+++ b/util/scripts/wee_debug
@@ -6,4 +6,4 @@ app=wee_debug
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_device
+++ b/util/scripts/wee_device
@@ -6,4 +6,4 @@ app=wee_device
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_extension
+++ b/util/scripts/wee_extension
@@ -6,4 +6,4 @@ app=wee_extension
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_import
+++ b/util/scripts/wee_import
@@ -6,4 +6,4 @@ app=wee_import
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_reports
+++ b/util/scripts/wee_reports
@@ -6,4 +6,4 @@ app=wee_reports
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/weewxd
+++ b/util/scripts/weewxd
@@ -6,4 +6,4 @@ app=weewxd
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wunderfixer
+++ b/util/scripts/wunderfixer
@@ -6,4 +6,4 @@ app=wunderfixer
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-"$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"


### PR DESCRIPTION
I noticed a couple of minor issues with the `/usr/bin/weewxd` sh script which are applicable to all scripts in `util/scripts`:

1. Arguments are not quoted, so calling `weewxd "/path/with spaces/weewx.conf"` fails with `/path/with is not a file`.  Similarly with `WEEWX_PYTHON=/path/with spaces/python` fails with `sh: 1: /path/with: not found`.
2. The scripts don't use `exec` to invoke `python`, so the sh process sticks around and complicates control from the invoking program (e.g. sending `SIGHUP`) which only has the PID of sh, unless it does extra work to explore the process tree.

This PR fixes both issues.  One caveat which might be worth considering is that quoting `$WEEWX_PYTHON` precludes passing arguments in that variable (e.g. `WEEWX_PYTHON="python3 -Werror"`) in exchange for supporting a python interpreter path with spaces (e.g. `WEEWX_PYTHON="/home/user/custom python/bin/python"`).  If that's unacceptable, I can unquote it or add `$WEEWX_PYTHON_ARGS` or similar for passing args.

Thanks for considering,
Kevin