### PR TITLE
Add $WEEWX_PYTHON_ARGS for python arguments

### DIFF
--- a/util/default/weewx
+++ b/util/default/weewx
@@ -1,4 +1,5 @@
 WEEWX_PYTHON=python3
+WEEWX_PYTHON_ARGS=
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_BIN=/home/weewx/bin/weewxd
 WEEWX_CFG=/home/weewx/weewx.conf

--- a/util/scripts/wee_config
+++ b/util/scripts/wee_config
@@ -6,4 +6,4 @@ app=wee_config
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_database
+++ b/util/scripts/wee_database
@@ -6,4 +6,4 @@ app=wee_database
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_debug
+++ b/util/scripts/wee_debug
@@ -6,4 +6,4 @@ app=wee_debug
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_device
+++ b/util/scripts/wee_device
@@ -6,4 +6,4 @@ app=wee_device
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_extension
+++ b/util/scripts/wee_extension
@@ -6,4 +6,4 @@ app=wee_extension
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_import
+++ b/util/scripts/wee_import
@@ -6,4 +6,4 @@ app=wee_import
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wee_reports
+++ b/util/scripts/wee_reports
@@ -6,4 +6,4 @@ app=wee_reports
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/weewxd
+++ b/util/scripts/weewxd
@@ -6,4 +6,4 @@ app=weewxd
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"

--- a/util/scripts/wunderfixer
+++ b/util/scripts/wunderfixer
@@ -6,4 +6,4 @@ app=wunderfixer
 WEEWX_BINDIR=/home/weewx/bin
 WEEWX_PYTHON=python3
 [ -r /etc/default/weewx ] && . /etc/default/weewx
-exec "$WEEWX_PYTHON" "$WEEWX_BINDIR/$app" "$@"
+exec "$WEEWX_PYTHON" $WEEWX_PYTHON_ARGS "$WEEWX_BINDIR/$app" "$@"


### PR DESCRIPTION
Now that arguments can no longer be passed to python in `$WEEWX_PYTHON` as a result of #706, add `$WEEWX_PYTHON_ARGS` for passing [python options], as requested in https://github.com/weewx/weewx/pull/706#issuecomment-947481005

Cheers,
Kevin

[python options]: https://docs.python.org/3/using/cmdline.html#miscellaneous-options