### PR TITLE
update apt-key command to debian10 and future syntax

### DIFF
--- a/docs/debian.htm
+++ b/docs/debian.htm
@@ -25,7 +25,8 @@
 <p>Tell <span class="code">apt</span> where to find the WeeWX releases.  This only has to be done once - the first time you install WeeWX.</p>
 
 Tell your system to trust weewx.com:
-<pre class='tty cmd'>wget -qO - https://weewx.com/keys.html | sudo apt-key add -</pre>
+<pre class='tty cmd'>wget -qO - https://weewx.com/keys.html | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/weewx.gpg</pre>
+<!-- <pre class='tty cmd'>wget -qO - https://weewx.com/keys.html | sudo apt-key add -</pre> -->
 
 For Debian10 and later, use python3:
 <pre class='tty cmd'>wget -qO - https://weewx.com/apt/weewx-python3.list | sudo tee /etc/apt/sources.list.d/weewx.list</pre>


### PR DESCRIPTION
This updates the debian apt-key instructions to future-proof it.  We've seen multiple people run into confusion with the new debian deprecation warnings and even some failures of the key to import.  This seems to be the new way.