### PR TITLE
When reports  done, shutdown engine and services

### DIFF
--- a/bin/wee_reports
+++ b/bin/wee_reports
@@ -98,6 +98,8 @@ def main():
     # Although the report engine inherits from Thread, we can just run it in the main thread:
     t.run()
 
+    # Shut down any running services, 
+    engine.shutDown()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I have a service that creates a thread. Because its shutDown method is not called, it is not terminating cleanly.