### PR TITLE
implement a 'natural' sort of field names in `to_sorted_string()`

### DIFF
--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -16,6 +16,7 @@ import cmath
 import datetime
 import math
 import os
+import re
 import shutil
 import time
 
@@ -1543,9 +1544,48 @@ class KeyDict(dict):
         return key
 
 
-def to_sorted_string(rec):
-    import locale
-    return ", ".join(["%s: %s" % (k, rec.get(k)) for k in sorted(rec, key=locale.strxfrm)])
+def natural_sort_keys(source_dict):
+    """Return a naturally sorted list of keys for a dict."""
+
+    def atoi(text):
+        return int(text) if text.isdigit() else text
+
+    def natural_keys(text):
+        """Natural key sort.
+
+        Allows use of key=natural_keys to sort a list in human order, eg:
+            alist.sort(key=natural_keys)
+
+        http://nedbatchelder.com/blog/200712/human_sorting.html
+        """
+
+        return [atoi(c) for c in re.split(r'(\d+)', text.lower())]
+
+    # create a list of keys in the dict
+    keys_list = list(source_dict.keys())
+    # naturally sort the list of keys such that, for example, xxxxx16 appears
+    # after xxxxx1
+    keys_list.sort(key=natural_keys)
+    # return the sorted list
+    return keys_list
+
+
+def to_sorted_string(rec, simple_sort=False):
+    """Return a string representation of a dict sorted by key.
+
+    Default action is to perform a 'natural' sort by key, ie 'xxx1' appears
+    before 'xxx16'. If called with simple_sort=True a simple alphanumeric sort
+    is performed instead which will result in 'xxx16' appearing before 'xxx1'.
+    """
+
+    if simple_sort:
+        import locale
+        return ", ".join(["%s: %s" % (k, rec.get(k)) for k in sorted(rec, key=locale.strxfrm)])
+    else:
+        # first obtain a list of key:value pairs sorted naturally by key
+        sorted_dict = ["'%s': '%s'" % (k, rec[k]) for k in natural_sort_keys(rec)]
+        # return as a string of comma separated key:value pairs in braces
+        return ", ".join(sorted_dict)
 
 
 def y_or_n(msg, noprompt=False):

--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -1557,10 +1557,10 @@ def natural_keys(text):
     http://nedbatchelder.com/blog/200712/human_sorting.html
     """
 
-    return [atoi(c) for c in natural_keys.compiled_re(text.lower())]
+    return [atoi(c) for c in re.split(natural_keys.compiled_re, text.lower())]
 
 
-natural_keys.compiled_re = re.split(r'(\d+)')
+natural_keys.compiled_re = re.compile(r'(\d+)')
 
 
 def natural_sort_keys(source_dict):

--- a/bin/weeutil/weeutil.py
+++ b/bin/weeutil/weeutil.py
@@ -1544,22 +1544,27 @@ class KeyDict(dict):
         return key
 
 
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+
+def natural_keys(text):
+    """Natural key sort.
+
+    Allows use of key=natural_keys to sort a list in human order, eg:
+        alist.sort(key=natural_keys)
+
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    """
+
+    return [atoi(c) for c in natural_keys.compiled_re(text.lower())]
+
+
+natural_keys.compiled_re = re.split(r'(\d+)')
+
+
 def natural_sort_keys(source_dict):
     """Return a naturally sorted list of keys for a dict."""
-
-    def atoi(text):
-        return int(text) if text.isdigit() else text
-
-    def natural_keys(text):
-        """Natural key sort.
-
-        Allows use of key=natural_keys to sort a list in human order, eg:
-            alist.sort(key=natural_keys)
-
-        http://nedbatchelder.com/blog/200712/human_sorting.html
-        """
-
-        return [atoi(c) for c in re.split(r'(\d+)', text.lower())]
 
     # create a list of keys in the dict
     keys_list = list(source_dict.keys())

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -80,6 +80,9 @@ when running weewx as non-root user.
 Fixed bug that prevented the ssh port from being specified when using rsync.
 Fixes issue #725.
 
+Improved alphanumeric sorting of loop packet/archive record fields displayed
+when WeeWX is run directly.
+
 
 4.5.1 04/02/2021
 Reverted the wview schema back to the V3 style.


### PR DESCRIPTION
Default action is to sort 'naturally' where `extraTemp1` will appear before `extraTemp10`. The previous simple sort using `sorted()` is still available if `to_sorted_string()` is called with the `simple_sort` parameter set to True.