### PR TITLE
remove systemd reload implementation

### DIFF
--- a/util/systemd/weewx.service
+++ b/util/systemd/weewx.service
@@ -8,7 +8,6 @@ RequiresMountsFor=/home
 
 [Service]
 ExecStart=/home/weewx/bin/weewxd --daemon --pidfile=/var/run/weewx.pid /home/weewx/weewx.conf
-ExecReload=/bin/kill -HUP $MAINPID
 Type=forking
 PIDFile=/var/run/weewx.pid
 #User=weewx


### PR DESCRIPTION
I am not a systemd expert, but the current implementation just kills weewxd which seems wrong and misleading.

Hopefully the following commands illustrate the concern.
**Before pull request**
```
9]pi@raspberrypi:/home/weewx $ sudo systemctl status weewx
* weewx.service - weewx weather system
   Loaded: loaded (/etc/systemd/system/weewx.service; disabled; vendor preset: enabled)
   Active: active (running) since Mon 2022-04-11 10:17:04 EDT; 15s ago
  Process: 19037 ExecStart=/home/weewx/bin/weewxd --daemon --pidfile=/home/weewx/run/weewx.pid /home/weewx/weewx.conf (code=exited, status=0/SUCCESS)
 Main PID: 19041 (weewxd)
    Tasks: 2 (limit: 1995)
   Memory: 14.6M
   CGroup: /system.slice/weewx.service
           `-19041 /usr/bin/python3 /home/weewx/bin/weewxd --daemon --pidfile=/home/weewx/run/weewx.pid /home/weewx/weewx.conf

Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:17 EDT ([1649686517](tel:1649686517)) to database 'mem.sdb'
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:17 EDT ([1649686517](tel:1649686517)) to daily summary in 'mem.sdb'
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.restx: StationRegistry: Registration not requested.
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO __main__: Starting up weewx version 4.6.0b3
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.engine: Using binding 'wx_binding' to database 'weewx.sdb'
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Starting backfill of daily summaries
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Daily summaries up to date
Apr 11 10:17:08 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:00 EDT ([1649686500](tel:1649686500)) to database 'weewx.sdb'
Apr 11 10:17:08 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:00 EDT ([1649686500](tel:1649686500)) to daily summary in 'weewx.sdb'
Apr 11 10:17:11 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.engine: Starting main packet loop.
```
```pi@raspberrypi:/home/weewx $ sudo systemctl reload weewx```

```
pi@raspberrypi:/home/weewx $ sudo systemctl reload weewx
weewx.service is not active, cannot reload.
```

```
pi@raspberrypi:/home/weewx $ ps -ef | grep weewx
pi       19081  1186  0 10:17 pts/0    00:00:00 grep --color=auto weewx
```

```
pi@raspberrypi:/home/weewx $ sudo systemctl status weewx
* weewx.service - weewx weather system
   Loaded: loaded (/etc/systemd/system/weewx.service; disabled; vendor preset: enabled)
   Active: inactive (dead)

Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Starting backfill of daily summaries
Apr 11 10:17:07 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Daily summaries up to date
Apr 11 10:17:08 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:00 EDT ([1649686500](tel:1649686500)) to database 'weewx.sdb'
Apr 11 10:17:08 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.manager: Added record 2022-04-11 10:15:00 EDT ([1649686500](tel:1649686500)) to daily summary in 'weewx.sdb'
Apr 11 10:17:11 raspberrypi weewxd[19041]: weewx[19041] INFO weewx.engine: Starting main packet loop.
Apr 11 10:17:27 raspberrypi systemd[1]: Reloading weewx weather system.
Apr 11 10:17:27 raspberrypi systemd[1]: Reloaded weewx weather system.
Apr 11 10:17:27 raspberrypi systemd[1]: weewx.service: Main process exited, code=killed, status=1/HUP
Apr 11 10:17:27 raspberrypi systemd[1]: weewx.service: Succeeded.
Apr 11 10:17:29 raspberrypi systemd[1]: weewx.service: Unit cannot be reloaded because it is inactive.
```

**After pull request**
```
pi@raspberrypi:/home/weewx $ sudo systemctl status weewx
* weewx.service - weewx weather system
   Loaded: loaded (/etc/systemd/system/weewx.service; disabled; vendor preset: enabled)
   Active: active (running) since Mon 2022-04-11 10:23:42 EDT; 8s ago
  Process: 19186 ExecStart=/home/weewx/bin/weewxd --daemon --pidfile=/home/weewx/run/weewx.pid /home/weewx/weewx.conf (code=exited, status=0/SUCCESS)
 Main PID: 19190 (weewxd)
    Tasks: 2 (limit: 1995)
   Memory: 14.6M
   CGroup: /system.slice/weewx.service
           `-19190 /usr/bin/python3 /home/weewx/bin/weewxd --daemon --pidfile=/home/weewx/run/weewx.pid /home/weewx/weewx.conf

Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Added record 2022-04-11 10:20:17 EDT ([1649686817](tel:1649686817)) to database 'mem.sdb'
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Added record 2022-04-11 10:20:17 EDT ([1649686817](tel:1649686817)) to daily summary in 'mem.sdb'
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.restx: StationRegistry: Registration not requested.
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO __main__: Starting up weewx version 4.6.0b3
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.engine: Using binding 'wx_binding' to database 'weewx.sdb'
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Starting backfill of daily summaries
Apr 11 10:23:44 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Daily summaries up to date
Apr 11 10:23:45 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Added record 2022-04-11 10:20:00 EDT ([1649686800](tel:1649686800)) to database 'weewx.sdb'
Apr 11 10:23:45 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.manager: Added record 2022-04-11 10:20:00 EDT ([1649686800](tel:1649686800)) to daily summary in 'weewx.sdb'
Apr 11 10:23:45 raspberrypi weewxd[19190]: weewx[19190] INFO weewx.engine: Starting main packet loop.
```

```
pi@raspberrypi:/home/weewx $ sudo systemctl reload weewx
Failed to reload weewx.service: Job type reload is not applicable for unit weewx.service.
```