### PR TITLE
systemctl stop sends 2 SIGKILL signals

### DIFF
--- a/util/systemd/weewx.service
+++ b/util/systemd/weewx.service
@@ -7,10 +7,9 @@ After=time-sync.target
 RequiresMountsFor=/home
 
 [Service]
-ExecStart=/home/weewx/bin/weewxd --daemon --pidfile=/var/run/weewx.pid /home/weewx/weewx.conf
+ExecStart=/home/weewx/bin/weewxd /home/weewx/weewx.conf
 ExecReload=/bin/kill -HUP $MAINPID
-Type=forking
-PIDFile=/var/run/weewx.pid
+StandardOutput=null
 #User=weewx
 #Group=weewx
 


### PR DESCRIPTION
See, https://groups.google.com/g/weewx-user/c/Yg8OJ7uot7U/m/-QxTQr1VCwAJ

Here is some reference material I used
From, https://wiki.debian.org/systemd/Services
“Most services should use the simple type, which means a program that runs in the foreground. If your service normally runs itself in the background, search the documentation to see if it has an option to disable that. Running in the foreground is preferred.”

From, https://www.freedesktop.org/software/systemd/man/systemd.service.html
For StandardOutput
[This setting defaults to the value set with DefaultStandardOutput= in systemd-system.conf(5), which defaults to journal.](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=)
For StandardError
[The available options are identical to those of StandardOutput=, with some exceptions: if set to inherit the file descriptor used for standard output is duplicated for standard error, while fd:name will use a default file descriptor name of "stderr".](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardError=)
For StandardInput
[This setting defaults to null, unless StandardInputText=/StandardInputData= are set, in which case it defaults to data.](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardInput=)

weewxd file
```
daemon.daemonize(pidfile=options.pidfile)
```
daemon.py file
```
def daemonize(stdout='/dev/null', stderr=None, stdin='/dev/null',
              pidfile=None, startmsg = 'started with pid %s' ):
```
```
if not stderr: stderr = stdout
```
I read this as currently stdout goes to /dev/null, stderr goes to stdout, and stdin goes to /dev/null. So I only overide the default for StandardOutput.