### PR TITLE
Fixes pgettext example in docs

### DIFF
--- a/docs/customizing.htm
+++ b/docs/customizing.htm
@@ -3325,8 +3325,8 @@ $month.outTemp.series(aggregate_type='max', aggregate_interval='day', time_serie
         </p>
 
         <pre>
-            &lt;p&gt;$gettext("Geographical","Altitude"): $station.altitude&lt;/p&gt;
-            &lt;p&gt;$gettext("Astronomical","Altitude"): $almanac.moon.alt&lt;/p&gt;
+            &lt;p&gt;$pgettext("Geographical","Altitude"): $station.altitude&lt;/p&gt;
+            &lt;p&gt;$pgettext("Astronomical","Altitude"): $almanac.moon.alt&lt;/p&gt;
         </pre>
 
         <p>


### PR DESCRIPTION
The `pgettext` code example actually uses `gettext` not `pgettext`.