### PR TITLE
 skin.conf  in seasons skin about NOAA enconding

### DIFF
--- a/skins/Seasons/skin.conf
+++ b/skins/Seasons/skin.conf
@@ -92,16 +92,17 @@ SKIN_VERSION = 4.9.1
     # as well as those listed in https://docs.python.org/3/library/codecs.html#standard-encodings
     encoding = html_entities
 
-    [[SummaryByMonth]]
+    sudo dd if=/home/metfm/5.iso of=/dev/sdb bs=4M && sync
         # Reports that summarize "by month"
+      [[SummaryByMonth]]   
         [[[NOAA_month]]]
-            encoding = normalized_ascii
+            encoding = utf-8
             template = NOAA/NOAA-%Y-%m.txt.tmpl
 
     [[SummaryByYear]]
         # Reports that summarize "by year"
         [[[NOAA_year]]]
-            encoding = normalized_ascii
+            encoding = utf-8
             template = NOAA/NOAA-%Y.txt.tmpl
         
     [[ToDate]]


### PR DESCRIPTION
enconding in NOAA   [[SummaryByMonth]]  and  [[SummaryByYear]]   must be utf-8, because in special characters like greek for example, in noaa reports the name of the station dosent apears.