### PR TITLE
fix github banner truncation

### DIFF
--- a/docs/css/weewx_ui.css
+++ b/docs/css/weewx_ui.css
@@ -699,3 +699,7 @@ a.toc-link:hover {
 .md-typeset code {
     font-weight:bold;
 }
+
+.md-source__facts li {
+    margin-right: 7%;   /* over 7% breaks the github banner */
+}


### PR DESCRIPTION
Add this to the .css to fix the truncated values in the github banner.