### PR TITLE
Add option to set decimal character for csv import

### DIFF
--- a/util/import/csv-example.conf
+++ b/util/import/csv-example.conf
@@ -27,6 +27,14 @@ source = CSV
     #   delimiter = <single character>
     # Default is , (comma).
     delimiter = ,
+    
+    # Specify the character used as the decimal point. The character
+    # must be enclosed in quotes.
+    # Format is:
+    #   decimal = '.' (dot)
+    #   or
+    #   decimal = ',' (comma)
+    decimal = '.'
 
     # If there is no mapped interval field how will the interval field be
     # determined for the imported records. Available options are:


### PR DESCRIPTION
Add option to set decimal character for csv import. Adopting the option from [wd-example.conf](https://github.com/weewx/weewx/blob/master/util/import/wd-example.conf)

https://groups.google.com/g/weewx-user/c/QV4UKRnR9v0