### PR TITLE
Add option --update to wee_import

### DIFF
--- a/bin/wee_import
+++ b/bin/wee_import
@@ -778,6 +778,8 @@ def main():
     parser.add_option("--to", dest="date_to", type=str, metavar="YYYY-mm-dd[THH:MM]",
                       help="Import data up until this date or date-time. Format "
                            "is YYYY-mm-dd[THH:MM].")
+    parser.add_option("--update", dest="update", action="store_true",
+                      help="Update data in database.")
     parser.add_option("--verbose", action="store_true", dest="verbose",
                       help="Print and log useful extra output.")
     parser.add_option("--no-prompt", action="store_true", dest="no_prompt",

--- a/bin/weeimport/weeimport.py
+++ b/bin/weeimport/weeimport.py
@@ -192,6 +192,7 @@ class Source(object):
 
         # Process our command line options
         self.dry_run = options.dry_run
+        self.update = options.update
         self.verbose = options.verbose
         self.no_prompt = options.no_prompt
         self.suppress = options.suppress
@@ -1273,7 +1274,7 @@ class Source(object):
                         # add the record only if it is not a dry run
                         if not self.dry_run:
                             # add the record only if it is not a dry run
-                            archive.addRecord(_tranche)
+                            archive.addRecord(_tranche, update=self.update)
                         # add our the dateTime for each record in our tranche
                         # to the dry run set
                         for _trec in _tranche:
@@ -1291,7 +1292,7 @@ class Source(object):
                     # we do so process them
                     if not self.dry_run:
                         # add the record only if it is not a dry run
-                        archive.addRecord(_tranche)
+                        archive.addRecord(_tranche, update=self.update)
                     # add our the dateTime for each record in our tranche to
                     # the dry run set
                     for _trec in _tranche:


### PR DESCRIPTION
When specified, data in database with the same dateTime is updated with new values from import. Option can also be used when importing a different column of database from a different csv file.

Linked to #733.