### PR TITLE
pip uninstall docs for RH

### DIFF
--- a/docs/quickstarts/pip.md
+++ b/docs/quickstarts/pip.md
@@ -229,7 +229,20 @@ Stop WeeWX
     sudo systemctl disable weewx
     ```
 
-=== "Redhat, SuSE,<br/>and very old Debian:"
+=== "Very old Debian"
+
+    ```shell
+    sudo /etc/rc.d/init.d/weewx stop
+    ```
+
+=== "Redhat"
+
+    ```shell
+    sudo systemctl stop weewx
+    sudo systemctl disable weewx
+    ```
+
+=== "SuSE"
 
     ```shell
     sudo /etc/rc.d/init.d/weewx stop
@@ -249,7 +262,19 @@ Uninstall any daemon files:
     sudo rm /etc/systemd/system/weewx.service
     ```
 
-=== "Redhat, SuSE,<br/>and very old Debian:"
+=== "Very old Debian"
+
+    ```shell
+    sudo rm /etc/init.d/weewx
+    ```
+
+=== "Redhat"
+
+    ```shell
+    sudo rm /etc/systemd/system/weewx.service
+    ```
+
+=== "SuSE"
 
     ```shell
     sudo rm /etc/init.d/weewx


### PR DESCRIPTION
We previously missed updating the RH uninstalling instructions to refer to systemd.  I also updated the tabs for uninstalling to match 'installing'.