### PR TITLE
ci: Install Pillow with pip as python3-pil is too old

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,6 @@ jobs:
           python3-ephem \
           python3-mock \
           python3-mysqldb \
-          python3-pil \
-          python3-pillow \
           python3-serial \
           python3-usb \
           python3-pip \
@@ -27,6 +25,10 @@ jobs:
           sqlite
 
     - uses: actions/checkout@v3
+
+    - name: pip install
+      run: |
+        python3 -m pip install --user "Pillow>=9.2"
 
     - name: Setup tests
       run: |


### PR DESCRIPTION
Note that a test is still failing, but this doesn't look linked to Pillow:
```
======================================================================
ERROR: testElapsedTime (__main__.ValueHelperTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/weewx/weewx/bin/weewx/tests/test_units.py", line 203, in testElapsedTime
    self.assertEqual(vh.long_form(None_string="Nothing"), "Nothing")
  File "/home/runner/work/weewx/weewx/bin/weewx/units.py", line 1061, in long_form
    return self.formatter.long_form(self.value_t,
  File "/home/runner/work/weewx/weewx/bin/weewx/units.py", line 802, in long_form
    val_str = self.delta_time_to_string(val_t, format_string, None_string)
  File "/home/runner/work/weewx/weewx/bin/weewx/units.py", line 820, in delta_time_to_string
    if isinstance(None_string, six.string_types):
NameError: name 'six' is not defined
```