### PR TITLE
v5 weectl extension list ordering

### DIFF
--- a/bin/weecfg/extension.py
+++ b/bin/weecfg/extension.py
@@ -75,7 +75,7 @@ class ExtensionEngine(object):
         """Print info about all installed extensions to the logger."""
         ext_dir = self.root_dict['EXT_DIR']
         try:
-            exts = os.listdir(ext_dir)
+            exts = sorted(os.listdir(ext_dir))
             if exts:
                 self.logger.log("%-18s%-10s%s" % ("Extension Name", "Version", "Description"),
                                 level=0)


### PR DESCRIPTION
This sorts the extension list in alphabetical order for easier perusal.