### PR TITLE
Add new APRS-IS Weewx TOCALL allocation, rather than use generic "APRS" tocall

### DIFF
--- a/bin/weewx/restx.py
+++ b/bin/weewx/restx.py
@@ -1227,7 +1227,7 @@ class CWOPThread(RESTThread):
         """Form the TNC2 packet used by CWOP."""
 
         # Preamble to the TNC packet:
-        _prefix = "%s>APRS,TCPIP*:" % self.station
+        _prefix = "%s>APWEE4,TCPIP*:" % self.station
 
         # Time:
         _time_tt = time.gmtime(record['dateTime'])


### PR DESCRIPTION
There is a new TOCALL allocation in APRS-IS/APRS.fi for Weewx software[^1] (`"APWEE?"`): https://github.com/aprsorg/aprs-deviceid/blob/c180800126f2ceae2464a20b2e51e444dd4ce1d3/tocalls.yaml#LL1158C12-L1158C17

This change uses the new TOCALL allocation in the APRS packet to correctly ID the device. The last character in APWEE? I made version-specific. I.e.:
`APWEE4` (v4.x)
`APWEE5` (v.5x)

I've made the change locally and you can see the results in APRS.fi:

![Screenshot 2023-06-07 7 45 44 AM](https://github.com/weewx/weewx/assets/226376/c098ad69-96b1-4338-857a-743bb9d0810f)

[^1]: I requested the new allocation
