### PR TITLE
Make barometer algorithms available to the user

### DIFF
--- a/bin/weewx/tests/test_wxxtypes.py
+++ b/bin/weewx/tests/test_wxxtypes.py
@@ -155,6 +155,7 @@ class TestPressureCooker(unittest.TestCase):
             mock_mgr.assert_called_once_with(self.record['dateTime'] - 12 * 3600, max_delta=1800)
             self.assertEqual(t, (80.3, 'degree_F', 'group_temperature'))
 
+        pc = weewx.wxxtypes.PressureCooker(altitude_vt)
         # Mock a database in METRICWX units
         with mock.patch.object(db_manager, 'getRecord',
                                return_value={'usUnits': weewx.METRICWX,
@@ -163,6 +164,7 @@ class TestPressureCooker(unittest.TestCase):
             mock_mgr.assert_called_once_with(self.record['dateTime'] - 12 * 3600, max_delta=1800)
             self.assertEqual(t, (30.0, 'degree_C', 'group_temperature'))
 
+        pc = weewx.wxxtypes.PressureCooker(altitude_vt)
         # Mock a database missing a record from 12h ago
         with mock.patch.object(db_manager, 'getRecord',
                                return_value=None) as mock_mgr:
@@ -170,6 +172,7 @@ class TestPressureCooker(unittest.TestCase):
             mock_mgr.assert_called_once_with(self.record['dateTime'] - 12 * 3600, max_delta=1800)
             self.assertEqual(t, None)
 
+        pc = weewx.wxxtypes.PressureCooker(altitude_vt)
         # Mock a database that has a record from 12h ago, but it's missing outTemp
         with mock.patch.object(db_manager, 'getRecord',
                                return_value={'usUnits': weewx.METRICWX}) as mock_mgr:

--- a/bin/weewx/units.py
+++ b/bin/weewx/units.py
@@ -109,6 +109,10 @@ obs_group_dict = ListOfDicts({
     "appTemp"                   : "group_temperature",
     "appTemp1"                  : "group_temperature",
     "barometer"                 : "group_pressure",
+    "barometerDWD"              : "group_pressure",
+    "barometerManBar"           : "group_pressure",
+    "barometerDavisVp"          : "group_pressure",
+    "barometerUnivie"           : "group_pressure",
     "barometerRate"             : "group_pressurerate",
     "beaufort"                  : "group_count",           # DEPRECATED
     "cloudbase"                 : "group_altitude",

--- a/bin/weewx/uwxutils.py
+++ b/bin/weewx/uwxutils.py
@@ -253,6 +253,12 @@ class TWxUtils(object):
             geopElevationM = TWxUtils.GeopotentialAltitude(elevationM)
             Result = Exp(geopElevationM * 6.1454E-2 / (CToF(meanTempC) + 459.7 + (geopElevationM * TWxUtils.manBarLapseRate / 2) + hCorr))
 
+        elif algorithm == 'paDWD':
+            # German Weather Service DWD
+            # https://www.dwd.de/DE/leistungen/pbfb_verlag_vub/pdf_einzelbaende/vub_2_binaer_barrierefrei.pdf?__blob=publicationFile&v=4
+            vp = TWxUtils.ActualVaporPressure(currentTempC,humidity,'vaDWD')
+            Result = math.exp(TWxUtils.gravity/TWxUtils.gasConstantAir*elevationM/(CToK(currentTempC)+vp*0.12+TWxUtils.standardLapseRate*elevationM/2))
+
         else:
             raise ValueError("Unknown PressureReductionRatio algorithm '%s'" %
                              algorithm)
@@ -291,6 +297,10 @@ class TWxUtils(object):
             # Magnus Teten
             # www.vivoscuola.it/US/RSIGPP3202/umidita/attivita/relhumONA.htm
             Result = 6.1078 * Power(10, (7.5 * tempC / (tempC + 237.3)))
+        elif algorithm == 'vaDWD':
+            # German Weather Service DWD
+            # https://www.dwd.de/DE/leistungen/pbfb_verlag_vub/pdf_einzelbaende/vub_2_binaer_barrierefrei.pdf?__blob=publicationFile&v=4
+            Result = 6.11213*math.exp(17.5043*tempC/(241.2+tempC))
         else:
             raise ValueError("Unknown SaturationVaporPressure algorithm '%s'" %
                              algorithm)

--- a/bin/weewx/wxxtypes.py
+++ b/bin/weewx/wxxtypes.py
@@ -385,7 +385,7 @@ class PressureCooker(weewx.xtypes.XType):
         # or we don't have a usable temperature, or the old temperature is too stale.
         if self.ts_12h is None \
                 or self.temp_12h_vt is None \
-                or abs(self.ts_12h - ts_12h) < self.max_delta_12h:
+                or abs(self.ts_12h - ts_12h) > self.max_delta_12h:
             # Hit the database to get a newer temperature.
             record = dbmanager.getRecord(ts_12h, max_delta=self.max_delta_12h)
             if record and 'outTemp' in record:


### PR DESCRIPTION
This refers to https://groups.google.com/g/weewx-user/c/ViQusNGKCIA

WeeWX includes various sealevel pressure calculation algorithms in `wxforumulas.py` and `uwxutils.py`, but the user cannot choose between them. IMHO it would be interesting to see the different results and compare them. 

`get_scalar` knows the parameter `option_dict`, but it is not used. So no thing like `$current.barometer(algorithm='vaManBar')` exists. Therefore separate observation types for all the algorithms are used:

* `barometer`: sent by the hardware or calculated using the formula in `wxformulas.py` as before (no change)
* `barometerUnivie`: from `uwxutils.py` University of Vienna algorithm
* `barometerDavisVp`: from `uwxutils.py` Davis Vantage Pro algorithm
* `barometerManBar`: from `uwxutils.py` WMO algorithm
* `barometerDWD`: from `uwxutils.py` German Weater Service DWD algorithm