### PR TITLE
proof of concept for checking if an xtype exists

### DIFF
--- a/bin/weewx/manager.py
+++ b/bin/weewx/manager.py
@@ -344,7 +344,7 @@ class Manager(object):
         """
 
         # Check to see if this is a valid observation type:
-        return obs_type in self.obskeys
+        return obs_type in self.obskeys or weewx.xtypes.exists(obs_type)
 
     def has_data(self, obs_type, timespan):
         """Checks whether the observation type exists in the database and whether it has any

--- a/bin/weewx/xtypes.py
+++ b/bin/weewx/xtypes.py
@@ -64,6 +64,26 @@ class XType(object):
 
 # ##################### Retrieval functions ###########################
 
+def exists(obs_type):
+    """Checks whether the observation type is known to the xtype system.
+
+        Args:
+            obs_type(str): The observation type to check for existence.
+
+        Returns:
+            bool: True if the observation type is known to the xtyoe system. False otherwise.
+        """
+
+    # Search the list, looking for a exists() method that does not raise an AttributeError or
+    # UnknownType exception
+    for xtype in xtypes:
+        try:
+            return xtype.exists(obs_type)
+        except (AttributeError, weewx.UnknownType):
+            pass
+
+    return False
+
 def get_scalar(obs_type, record, db_manager=None, **option_dict):
     """Return a scalar value"""
 


### PR DESCRIPTION
This is just a proof of concept to brainstorm from

Each xtype should implement an `exists()` method. Xtypes should be doing this check in the methods that it has implemented. It would look something like this.
 
```
    def exists(self, obs_type):
        if obs_type not in self.aqi_fields:
            raise weewx.UnknownType(obs_type)

        return True
```
