### PR TITLE
Implement `Cumulative` Xtype

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -122,6 +122,8 @@ this long before doing a restart.
 Change from old Google analytics UA code to the GA4 tag system in the Standard
 and Seasons skins. Fixes issue #892.
 
+`cumulative` aggregate type now supports a user specified reset date-time meaning cumulative plots can now reset to zero at a user specified time. Partially mitigates issue #91. 
+
 
 ### 4.10.2 02/22/2023
 


### PR DESCRIPTION
This PR implements the `Cumulative` Xtype to allow the `cumulative` aggregate to allow resetting the cumulative total at time(s) specified by the `reset` option. This in turn allows users to specify a 'reset' time for cumulative plots at which time the cumulative plot value will be reset to zero.

The `reset` option is a date-time specification for times within the overall `cumulative` aggregate time span at which time the cumulative value will be reset to zero. The `reset` option is an optional string in the format `[mm-][dd][T]HH:MM`. A number of keyword values are also supported:
- `midnight` - reset at midnight each day
- `midday` - reset at midday each day
- `day` - reset at midnight each day
- `month` - reset at midnight at the end of each month (aka midnight at the start of the 1st of each month)
- `year` - reset at midnight at the end of each year (aka midnight at the start of 1 January each year)

The default is no reset.

The `Cumulative` Xtype is fully backwards compatible with the existing `cumulative` aggregate. Whilst the initial version of this PR includes a fully functioning replacement for the `cumulative` aggregate, there are one or two additional features still to be added. The purpose of submitting this PR now is for review of the `Cumulative` Xtype implementation/structure.
