### PR TITLE
handling UnknownType in property `raw`

### DIFF
--- a/bin/weewx/units.py
+++ b/bin/weewx/units.py
@@ -1091,7 +1091,10 @@ class ValueHelper(object):
     @property
     def raw(self):
         """Returns just the data part, without any formatting."""
-        return self.value_t[0]
+        try:
+            return self.value_t[0]
+        except (TypeError,LookupError):
+            return None
 
     def convert(self, target_unit):
         """Return a ValueHelper in a new target unit.


### PR DESCRIPTION
Sometimes webpage creation fails with the following messages:
```
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: Evaluation of template ... failed with exception '<class 'TypeError'>'
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: **** Ignoring template ...
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: **** Reason: 'UnknownType' object is not subscriptable
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****  Traceback (most recent call last):
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****    File "/usr/share/weewx/weewx/cheetahgenerator.py", line 348, in generate
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****      unicode_string = compiled_template.respond()
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****    File "...", line 753, in respond
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****    File "/usr/share/weewx/weewx/units.py", line 1094, in raw
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****      return self.value_t[0]
Oct 28 13:01:05 XXX weewx[382617] ERROR weewx.cheetahgenerator: ****  TypeError: 'UnknownType' object is not subscriptable
```

I thought it would be an idea to return `None` in such cases. 