### PR TITLE
Update csv-example.conf / delimiter fix

### DIFF
--- a/util/import/csv-example.conf
+++ b/util/import/csv-example.conf
@@ -26,7 +26,7 @@ source = CSV
     # The character used to separate fields. Format is:
     #   delimiter = <single character>
     # Default is , (comma).
-    delimiter = ,
+    delimiter =  ','
     
     # Specify the character used as the decimal point. The character
     # must be enclosed in quotes.


### PR DESCRIPTION
delimiter must also be provided with ' ', otherwise there will be an error message.

TypeError: "delimiter" must be a 1-character string