### PR TITLE
catch the CannotCalculate and 'say' the observation does not have an data

### DIFF
--- a/src/weewx/tags.py
+++ b/src/weewx/tags.py
@@ -386,7 +386,10 @@ class ObservationBinder(object):
                                                   'not_null', db_manager)[0])
         else:
             # Nope. Try the xtypes system.
-            val = weewx.xtypes.has_data(self.obs_type, self.timespan, db_manager)
+            try:
+                val = weewx.xtypes.has_data(self.obs_type, self.timespan, db_manager)
+            except weewx.CannotCalculate:
+                return False
         return val
 
     def series(self, aggregate_type=None,

--- a/src/weewx/xtypes.py
+++ b/src/weewx/xtypes.py
@@ -159,8 +159,6 @@ def has_data(obs_type, timespan, db_manager):
                 return True
         except (weewx.UnknownType, weewx.UnknownAggregation):
             pass
-        except weewx.CannotCalculate:
-            return False
     # Tried all the  get_aggregates() and didn't find a non-null value. Either it doesn't exist,
     # or doesn't have any data
     return False

--- a/src/weewx/xtypes.py
+++ b/src/weewx/xtypes.py
@@ -159,6 +159,8 @@ def has_data(obs_type, timespan, db_manager):
                 return True
         except (weewx.UnknownType, weewx.UnknownAggregation):
             pass
+        except weewx.CannotCalculate:
+            return False
     # Tried all the  get_aggregates() and didn't find a non-null value. Either it doesn't exist,
     # or doesn't have any data
     return False


### PR DESCRIPTION
I added an xtype to the Seasons observations_stats variable. The xtype raised a weewx.CannotCalculate exception. It was not caught, causing the template generation to fail.

I ‘fixed’ it with this code. Not sure if there is a better way…