### PR TITLE
Catch the CannotCalculate exception, giving other xtypes a chance to perform the calculation

### DIFF
--- a/src/weewx/xtypes.py
+++ b/src/weewx/xtypes.py
@@ -157,7 +157,7 @@ def has_data(obs_type, timespan, db_manager):
             # Check to see if we found a non-null value. Otherwise, keep going.
             if vt[0]:
                 return True
-        except (weewx.UnknownType, weewx.UnknownAggregation):
+        except (weewx.UnknownType, weewx.UnknownAggregation, weewx.CannotCalculate):
             pass
     # Tried all the  get_aggregates() and didn't find a non-null value. Either it doesn't exist,
     # or doesn't have any data


### PR DESCRIPTION
As noted in this [pull request](https://github.com/weewx/weewx/pull/924#issuecomment-1925893127), this is the appropriate place. Now the `CannotCalculate` raised by `XtypeTable` is ‘ignored’ and my xtype gets a chance.
The reason I thought it was not working; because more of the `Seasons` can be processed, another `CannotCalculate` is now raised. Since they were both raised from the same line of code, I overlooked in the stack trace how that code was reached.
