### PR TITLE
implement `weectl import --update` action

### DIFF
--- a/src/weectllib/import_cmd.py
+++ b/src/weectllib/import_cmd.py
@@ -14,6 +14,7 @@ import_usage = f"""{bcolors.BOLD}weectl import --help
        weectl import --import-config=IMPORT_CONFIG_FILE
                      [--config=CONFIG_FILE]
                      [[--date=YYYY-mm-dd] | [[--from=YYYY-mm-dd[THH:MM]] [--to=YYYY-mm-dd[THH:MM]]]]
+                     [--update]
                      [--dry-run][--verbose]
                      [--no-prompt][--suppress-warnings]{bcolors.ENDC}
 """
@@ -36,21 +37,20 @@ def add_subparser(subparsers):
                                           epilog=import_epilog,
                                           help="Import observation data.")
 
-    import_parser.add_argument('--config', 
+    import_parser.add_argument('--config',
                                metavar='FILENAME',
                                help=f'Path to configuration file. '
                                     f'Default is "{weecfg.default_config_path}".')
-    import_parser.add_argument('--import-config', 
+    import_parser.add_argument('--import-config',
                                metavar='IMPORT_CONFIG_FILE',
                                dest='import_config',
                                help=f'Path to import configuration file.')
-    import_parser.add_argument('--dry-run', 
+    import_parser.add_argument('--dry-run',
                                action='store_true',
                                dest='dry_run',
                                help=f'Print what would happen but do not do it.')
-    import_parser.add_argument('--date', 
+    import_parser.add_argument('--date',
                                metavar='YYYY-mm-dd',
-                               # dest='d_date',
                                help=f'Import data for this date. Format is YYYY-mm-dd.')
     import_parser.add_argument('--from',
                                metavar='YYYY-mm-dd[THH:MM]',
@@ -62,6 +62,9 @@ def add_subparser(subparsers):
                                dest='to_datetime',
                                help=f'Import data up until this date or date-time. Format '
                                     f'is YYYY-mm-dd[THH:MM].')
+    import_parser.add_argument('--update',
+                               action='store_true',
+                               help=f'Allow imported data to update existing database records.')
     import_parser.add_argument('--verbose',
                                action='store_true',
                                help=f'Print and log useful extra output.')
@@ -85,6 +88,7 @@ def import_func(config_dict, namespace):
                                         date=namespace.date,
                                         from_datetime=namespace.from_datetime,
                                         to_datetime=namespace.to_datetime,
+                                        update=namespace.update,
                                         verbose=namespace.verbose,
                                         no_prompt=namespace.no_prompt,
                                         suppress_warning=namespace.suppress_warnings)

--- a/src/weeimport/csvimport.py
+++ b/src/weeimport/csvimport.py
@@ -181,6 +181,12 @@ class CSVSource(weeimport.Source):
         print(_msg)
         log.info(_msg)
         self.print_map()
+        if self.update:
+            _msg = "Imported records will overwrite existing database records."
+        else:
+            _msg = "Imported records will not overwrite existing database records."
+        print(_msg)
+        log.info(_msg)
         if self.calc_missing:
             _msg = "Missing derived observations will be calculated."
             print(_msg)

--- a/src/weeimport/cumulusimport.py
+++ b/src/weeimport/cumulusimport.py
@@ -240,6 +240,12 @@ class CumulusSource(weeimport.Source):
         print(_msg)
         log.info(_msg)
         self.print_map()
+        if self.update:
+            _msg = "Imported records will overwrite existing database records."
+        else:
+            _msg = "Imported records will not overwrite existing database records."
+        print(_msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/src/weeimport/wdimport.py
+++ b/src/weeimport/wdimport.py
@@ -354,6 +354,12 @@ class WDSource(weeimport.Source):
         print(_msg)
         log.info(_msg)
         self.print_map()
+        if self.update:
+            _msg = "Imported records will overwrite existing database records."
+        else:
+            _msg = "Imported records will not overwrite existing database records."
+        print(_msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/src/weeimport/weathercatimport.py
+++ b/src/weeimport/weathercatimport.py
@@ -284,6 +284,12 @@ class WeatherCatSource(weeimport.Source):
         print(_msg)
         log.info(_msg)
         self.print_map()
+        if self.update:
+            _msg = "Imported records will overwrite existing database records."
+        else:
+            _msg = "Imported records will not overwrite existing database records."
+        print(_msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if not self.UV_sensor:

--- a/src/weeimport/weeimport.py
+++ b/src/weeimport/weeimport.py
@@ -179,6 +179,7 @@ class Source(object):
 
         # process our command line options
         self.dry_run = kwargs['dry_run']
+        self.update = kwargs['update']
         self.verbose = kwargs['verbose']
         self.no_prompt = kwargs['no_prompt']
         self.suppress_warning = kwargs['suppress_warning']
@@ -514,9 +515,15 @@ class Source(object):
                         _msg = "1 duplicate record was ignored."
                         print(_msg)
                         log.info(_msg)
-                    print("Those records with a timestamp already "
-                          "in the archive will not have been")
-                    print("imported. Confirm successful import in the WeeWX log file.")
+                    if self.update:
+                        print("Existing database records may have been updated "
+                              "with imported data.")
+                        print("Confirm successful import in the weectl log file.")
+                    else:
+                        print("Those records with a timestamp already in the "
+                              "archive will not have been")
+                        print("imported. Confirm successful import in the weectl "
+                              "log file.")
 
     def parse_map(self, map, field_map, field_map_extensions):
         """Update a field map with a field map and/or field map extension.
@@ -1057,11 +1064,18 @@ class Source(object):
                         print("Dry run import aborted by user. %d records were processed." % self.total_rec_proc)
                     else:
                         if self.total_rec_proc > 0:
-                            print("Those records with a timestamp already in the "
-                                  "archive will not have been")
-                            print("imported. As the import was aborted before completion "
-                                  "refer to the WeeWX log")
-                            print("file to confirm which records were imported.")
+                            if self.update:
+                                print("Some existing database records may have been updated "
+                                      "with imported data.")
+                                print("As the import was aborted before completion refer to "
+                                      "the weectl log file to")
+                                print("confirm which records were imported.")
+                            else:
+                                print("Those records with a timestamp already in the "
+                                      "archive will not have been")
+                                print("imported. As the import was aborted before completion "
+                                      "refer to the WeeWX log")
+                                print("file to confirm which records were imported.")
                             raise SystemExit('Exiting.')
                         else:
                             print("Import aborted by user. No records saved to archive.")
@@ -1266,7 +1280,7 @@ class Source(object):
                         # add the record only if it is not a dry run
                         if not self.dry_run:
                             # add the record only if it is not a dry run
-                            archive.addRecord(_tranche)
+                            archive.addRecord(_tranche, update=self.update)
                         # add our the dateTime for each record in our tranche
                         # to the dry run set
                         for _trec in _tranche:
@@ -1284,7 +1298,7 @@ class Source(object):
                     # we do so process them
                     if not self.dry_run:
                         # add the record only if it is not a dry run
-                        archive.addRecord(_tranche)
+                        archive.addRecord(_tranche, update=self.update)
                     # add our the dateTime for each record in our tranche to
                     # the dry run set
                     for _trec in _tranche:
@@ -1325,9 +1339,8 @@ class Source(object):
             elif self.ans == 'n':
                 # user does not want to import so display a message and then
                 # ask to exit
-                _msg = "User chose not to import records. Exiting. Nothing done."
-                print(_msg)
-                log.info(_msg)
+                print("User chose not to import records.")
+                log.info("User chose not to import records. Exiting. Nothing done.")
                 raise SystemExit('Exiting. Nothing done.')
         else:
             # we have no records to import, advise the user but what we say

--- a/src/weeimport/wuimport.py
+++ b/src/weeimport/wuimport.py
@@ -273,6 +273,12 @@ class WUSource(weeimport.Source):
         print(_msg)
         log.info(_msg)
         self.print_map()
+        if self.update:
+            _msg = "Imported records will overwrite existing database records."
+        else:
+            _msg = "Imported records will not overwrite existing database records."
+        print(_msg)
+        log.info(_msg)
         if self.calc_missing:
             print("Missing derived observations will be calculated.")
         if kwargs['date'] or kwargs['from_datetime']:

--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -360,10 +360,10 @@ class Manager(object):
 
     def addRecord(self, record_obj,
                   accumulator=None,
-                  update=False,
                   progress_fn=None,
                   log_success=True,
-                  log_failure=True):
+                  log_failure=True,
+                  update = False):
         """
         Commit a single record or a collection of records to the archive.
 
@@ -424,7 +424,7 @@ class Manager(object):
 
         return N
 
-    def _addSingleRecord(self, record, cursor, update=False, log_success=True, log_failure=True):
+    def _addSingleRecord(self, record, cursor, log_success=True, log_failure=True, update=False):
         """Internal function for adding a single record to the main archive table."""
 
         if record['dateTime'] is None:
@@ -1175,7 +1175,7 @@ class DaySummaryManager(Manager):
         for column_name in column_names:
             cursor.execute("DROP TABLE IF EXISTS %s_day_%s;" % (self.table_name, column_name))
 
-    def _addSingleRecord(self, record, cursor, update=False, log_success=True, log_failure=True):
+    def _addSingleRecord(self, record, cursor, log_success=True, log_failure=True, update=False):
         """Specialized version that updates the daily summaries, as well as the main archive
         table.
         """

--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -401,7 +401,7 @@ class Manager(object):
                         self._updateHiLo(accumulator, cursor)
 
                     # Then add the record to the archives:
-                    self._addSingleRecord(record, cursor, update, log_success, log_failure)
+                    self._addSingleRecord(record, cursor, log_success, log_failure, update)
 
                     N += 1
                     if progress_fn and N % 1000 == 0:
@@ -1181,7 +1181,7 @@ class DaySummaryManager(Manager):
         """
 
         # First let my superclass handle adding the record to the main archive table:
-        super()._addSingleRecord(record, cursor, update, log_success, log_failure)
+        super()._addSingleRecord(record, cursor, log_success, log_failure, update)
 
         # Get the start of day for the record:
         _sod_ts = weeutil.weeutil.startOfArchiveDay(record['dateTime'])

--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -360,6 +360,7 @@ class Manager(object):
 
     def addRecord(self, record_obj,
                   accumulator=None,
+                  update=False,
                   progress_fn=None,
                   log_success=True,
                   log_failure=True):
@@ -372,6 +373,7 @@ class Manager(object):
                 SQL types and the values are the values to be stored in the database.
             accumulator (weewx.accum.Accum): An optional accumulator. If given, the record
                 will be added to the accumulator.
+            update (bool): Update database if timestamp is already present
             progress_fn (function): This function will be called every 1000 insertions. It should
                 have the signature fn(time, N) where time is the unix epoch time, and N is the
                 insertion count.
@@ -399,7 +401,7 @@ class Manager(object):
                         self._updateHiLo(accumulator, cursor)
 
                     # Then add the record to the archives:
-                    self._addSingleRecord(record, cursor, log_success, log_failure)
+                    self._addSingleRecord(record, cursor, update, log_success, log_failure)
 
                     N += 1
                     if progress_fn and N % 1000 == 0:
@@ -422,7 +424,7 @@ class Manager(object):
 
         return N
 
-    def _addSingleRecord(self, record, cursor, log_success=True, log_failure=True):
+    def _addSingleRecord(self, record, cursor, update=False, log_success=True, log_failure=True):
         """Internal function for adding a single record to the main archive table."""
 
         if record['dateTime'] is None:
@@ -451,11 +453,29 @@ class Manager(object):
         q_str = ','.join('?' * len(key_list))
         # Form the SQL insert statement:
         sql_insert_stmt = "INSERT INTO %s (%s) VALUES (%s)" % (self.table_name, k_str, q_str)
-        cursor.execute(sql_insert_stmt, value_list)
-        if log_success:
-            log.info("Added record %s to database '%s'",
-                     timestamp_to_string(record['dateTime']),
-                     self.database_name)
+        try:
+            cursor.execute(sql_insert_stmt, value_list)
+            if log_success:
+                log.info("Added record %s to database '%s'",
+                         timestamp_to_string(record['dateTime']),
+                         self.database_name)
+
+        except weedb.IntegrityError:
+            if not update:
+                raise
+            set_stmt = ', '.join(["%s=?" % k for k in key_list])
+            where_stmt = ' AND '.join(["%s IS ?" % k for k in key_list])
+            sql_update_stmt = "UPDATE %s SET %s WHERE dateTime = ? AND NOT (%s)" % (self.table_name, set_stmt, where_stmt)
+            cursor.execute(sql_update_stmt, value_list + [record['dateTime'],] + value_list)
+            if log_success:
+                if cursor.rowcount > 0:
+                    log.info("Updated record %s to database '%s'",
+                             timestamp_to_string(record['dateTime']),
+                             self.database_name)
+                else:
+                    log.info("Unchanged record %s to database '%s'",
+                             timestamp_to_string(record['dateTime']),
+                             self.database_name)
 
     def _updateHiLo(self, accumulator, cursor):
         pass
@@ -1155,13 +1175,13 @@ class DaySummaryManager(Manager):
         for column_name in column_names:
             cursor.execute("DROP TABLE IF EXISTS %s_day_%s;" % (self.table_name, column_name))
 
-    def _addSingleRecord(self, record, cursor, log_success=True, log_failure=True):
+    def _addSingleRecord(self, record, cursor, update=False, log_success=True, log_failure=True):
         """Specialized version that updates the daily summaries, as well as the main archive
         table.
         """
 
         # First let my superclass handle adding the record to the main archive table:
-        super()._addSingleRecord(record, cursor, log_success, log_failure)
+        super()._addSingleRecord(record, cursor, update, log_success, log_failure)
 
         # Get the start of day for the record:
         _sod_ts = weeutil.weeutil.startOfArchiveDay(record['dateTime'])


### PR DESCRIPTION
refer [PR839](https://github.com/weewx/weewx/pull/839).

PR839 sought to add the ability for `wee_import` to update existing database records with imported records whose timestamp already exists in the WeeWX archive. Current `wee_import`/`weectl import` behaviour is to ignore imported records whose timestamp already exists in the WeeWX archive. PR839 was raised against the WeeWX v4 code base, WeeWX v5 has since been released with `wee_import` being replaced with `weectl import`. Given the significant changes to the WeeWX code base in developing v5, PR839 will be discarded and the changes sought at PR839 will be applied via a new PR or via separate direct commits to the v5 code base.

This PR has been raised to clearly identify the changes to the v5 code base required to implement the intent of PR839. This PR includes the PR839 changes (to `import_cmd.py`, `weeimport.py` and `manager.py`) as well as a number of other necessary changes (to `csvimport.py`,`cumulusimport.py `,`wdimport.py `,`weathercatimport.py ` and `wuimport.py `).

This PR does not include documentation changes, documentation will be updated once the code is finalised.