### PR TITLE
Log user and groups (PR for issue #933)

### DIFF
--- a/src/weewxd.py
+++ b/src/weewxd.py
@@ -121,14 +121,14 @@ def main():
     try:
       import pwd
       euid  = pwd.getpwuid(os.geteuid())[0]
-      log.info("User: : %s", euid)
+      log.info("User:   %s", euid)
     except Exception as ex:
       log.info("User unavailable: %s",ex)
 
     try:
       import grp
       egid = grp.getgrgid(os.getegid())[0]
-      log.info("Group:: %s", egid)
+      log.info("Group:  %s", egid)
     except Exception as ex:
       log.info("Group unavailable: %s",ex)
 
@@ -140,7 +140,7 @@ def main():
       mygrouplist = ' '.join(mygroups)
       log.info("Groups: %s", mygrouplist)
     except Exception as ex:
-      log.info("Grouplist unavailable: %s",ex)
+      log.info("Groups unavailable: %s",ex)
 
     # If no command line --loop-on-init was specified, look in the config file.
     if namespace.loop_on_init is None:

--- a/src/weewxd.py
+++ b/src/weewxd.py
@@ -117,6 +117,31 @@ def main():
     log.info("User module: %s", user_module)
     log.info("Debug: %s", weewx.debug)
 
+    # these try/except are because not every os will succeed here
+    try:
+      import pwd
+      euid  = pwd.getpwuid(os.geteuid())[0]
+      log.info("User: : %s", euid)
+    except Exception as ex:
+      log.info("User unavailable: %s",ex)
+
+    try:
+      import grp
+      egid = grp.getgrgid(os.getegid())[0]
+      log.info("Group:: %s", egid)
+    except Exception as ex:
+      log.info("Group unavailable: %s",ex)
+
+    try:
+      groupList = os.getgroups()
+      mygroups=[ ]
+      for group in groupList:
+        mygroups.append(grp.getgrgid(group)[0])
+      mygrouplist = ' '.join(mygroups)
+      log.info("Groups: %s", mygrouplist)
+    except Exception as ex:
+      log.info("Grouplist unavailable: %s",ex)
+
     # If no command line --loop-on-init was specified, look in the config file.
     if namespace.loop_on_init is None:
         loop_on_init = to_bool(config_dict.get('loop_on_init', False))


### PR DESCRIPTION
Here's the PR for https://github.com/weewx/weewx/issues/933

This tests ok on mac and pi and vagrant vm.  Typical output for pi looks like the following.  Added the three lines under Debug to the output on system startup.

````
Feb 15 19:57:09 pi4 weewxd-ecowitt[688]: INFO __main__: Terminating weewx version 5.0.0
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Initializing weewxd version 5.0.0
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Command line: /home/pi/weewx-venv/lib/python3.9/site-packages/weewxd.py --log-label weewxd-ecowitt /home/pi/weewx-data/ecowitt.conf
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Using Python 3.9.2 (default, Mar 12 2021, 04:06:34) #012[GCC 10.2.1 20210110]
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Located at /home/pi/weewx-venv/bin/python3
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Platform Linux-6.1.21-v8+-aarch64-with-glibc2.31
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Locale: 'en_US.UTF-8'
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Entry path: /home/pi/weewx-venv/lib/python3.9/site-packages/weewxd.py
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: WEEWX_ROOT: /home/pi/weewx-data
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Configuration file: /home/pi/weewx-data/ecowitt.conf
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: User module: /home/pi/weewx-data/bin/user
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Debug: 1
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: User:   pi
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Group:  pi
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO __main__: Groups: adm dialout cdrom sudo audio video plugdev games users input render netdev gpio i2c spi pi
Feb 15 20:00:01 pi4 weewxd-ecowitt[2872]: INFO weewx.engine: Loading station type GW1000 (user.gw1000)
````