### PR TITLE
Fix `loop_on_init` bug in `weewxd.py`

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -12,6 +12,8 @@ Related to PR #929.
 Fix bug in tag `$tag.obstype` where `obstype` is an XType that cannot be
 calculated. Related to PR #929
 
+Fix bug that caused the `weewx.conf` `loop_on_init` setting to be ignored.
+
 
 ### 5.0.2 02/10/2024
 

--- a/src/weewxd.py
+++ b/src/weewxd.py
@@ -118,10 +118,10 @@ def main():
     log.info("Debug: %s", weewx.debug)
 
     # If no command line --loop-on-init was specified, look in the config file.
-    if namespace.loop_on_init is None:
+    if not namespace.loop_on_init:
         loop_on_init = to_bool(config_dict.get('loop_on_init', False))
     else:
-        loop_on_init = namespace.loop_on_init
+        loop_on_init = True
 
     # Save the current working directory. A service might
     # change it. In case of a restart, we need to change it back.


### PR DESCRIPTION
The `argparse` and deprecated `optparse` libraries handle `store_true` and `store_false` actions slightly differently. `optparse` will store the value `None` for `store_true` or `store_false` actions if the option is omitted from the command line. On the other hand, `argparse` stores the value `False` or `True` for `store_true` or `store_false` actions if the option is omitted from the command line. This can be seen in the following, for `optparse`:

```
>>> import optparse
>>> parser=optparse.OptionParser()
>>> parser.add_option("--foo", action="store_true")
<Option at 0x106345070: --foo>
>>> parser.add_option("--bar", action="store_false")
<Option at 0x106345700: --bar>
>>> parser.parse_args('--foo --bar'.split())
(<Values at 0x10635cd60: {'foo': True, 'bar': False}>, [])
>>> parser.parse_args('--bar'.split())
(<Values at 0x106359520: {'foo': None, 'bar': False}>, [])
```

and for `argparse`:
```
>>> import argparse
>>> parser = argparse.ArgumentParser()
>>> parser.add_argument('--foo', action='store_true')
_StoreTrueAction(option_strings=['--foo'], dest='foo', nargs=0, const=True, default=False, type=None, choices=None, help=None, metavar=None)
>>> parser.add_argument('--bar', action='store_false')
_StoreFalseAction(option_strings=['--bar'], dest='bar', nargs=0, const=False, default=True, type=None, choices=None, help=None, metavar=None)
>>> parser.parse_args('--foo --bar'.split())
Namespace(foo=True, bar=False)
>>> parser.parse_args('--bar'.split())
Namespace(foo=False, bar=False)
```

This difference means that `weewxd.py` always uses the value `False` for `loop_on_init` meaning the `weewx.conf` `loop_on_init` setting is never honoured.

This PR seeks to fix this bug.