### PR TITLE
Make almanac extensible

### DIFF
--- a/docs_src/custom/cheetah-generator.md
+++ b/docs_src/custom/cheetah-generator.md
@@ -1629,7 +1629,8 @@ for each context. For example, the Thai language file would include:
 
 ## Almanac
 
-If module [`ephem`](https://rhodesmill.org/pyephem) has been installed, then
+If module [`ephem`](https://rhodesmill.org/pyephem) or an appropriate
+almanac extension has been installed, then
 WeeWX can generate extensive almanac information for the Sun, Moon, Venus,
 Mars, Jupiter, and other heavenly bodies, including their rise, transit and
 set times, as well as their azimuth and altitude. Other information is also
@@ -1651,7 +1652,7 @@ Current time is $current.dateTime
 #end if
 ```
 
-If `ephem` is installed this would result in:
+If an almanac module like `ephem` is installed this would result in:
 
 <div class="example_output">
 Current time is 03-Sep-2010 11:00
@@ -1983,7 +1984,12 @@ The separation between Venus and Mars is 55:55:31.8
 ### Adding new bodies
 
 It is possible to extend the WeeWX almanac, adding new bodies that it was not
-previously aware of. For example, say we wanted to add
+previously aware of. The following description explains how to do it for 
+PyEphem, which is supported by core WeeWX. If you use an alternative almanac 
+extension, refer to the documentation of that extension for how to add new 
+bodies.
+
+For example, say we wanted to add
 [*433 Eros*](https://en.wikipedia.org/wiki/433_Eros), the first asteroid
 visited by a spacecraft. Here is the process:
 
@@ -2005,6 +2011,44 @@ visited by a spacecraft. Here is the process:
     ``` tty
     $almanac.eros.rise
     ```
+
+### Almanac extensions
+
+You can install almanac extensions that add new events and/or attributes to 
+the almanac or replace PyEphem by another astronomic computation module. 
+See the [utilities guide](../utilities/weectl-extension.md) 
+for how to install extensions.
+
+WeeWX provides one such installable almanac extension. It uses Skyfield for 
+the almanac computations instead of PyEphem.
+
+* Why should I use another almanac module than PyEphem?
+
+  PyEphem is supported by core WeeWX. There is no need to use something
+  different unless you encounter problems.
+
+  But PyEphem is deprecated. Its database is outdated and will not be
+  updated any more. It ends in 2018. Dates after that year are calculated by
+  extrapolation. The differences are small by now, but if you look for more
+  precision or your Linux distribution does not include PyEphem any
+  more you may want to move to another almanac module.
+
+* What are the advantages of Skyfield?
+
+  Skyfield uses more modern and more precise formulae, actual ephemeris
+  provided by NASA's JPL, and can use actual timescale data provided
+  by IERS. It is the successor of PyEphem, and it is devoloped by the
+  same author, Brandon Rhodes.
+
+  You can update ephemeris and timescales yourself. There is no need to
+  wait for the next release to get actual data.
+
+  There are additional observation types available like hour angle
+  and distance to the heavenly body, which PyEphem does not provide.
+
+* What are the disadvantages of Skyfield?
+
+  Skyfield depends on NumPy while PyEphem does not.
 
 ## Wind
 

--- a/src/weewx/almanac.py
+++ b/src/weewx/almanac.py
@@ -268,9 +268,6 @@ class Almanac:
                 almanac.time_ts = kwargs['almanac_time']
             else:
                 setattr(almanac, key, kwargs[key])
-        # Check to see whether there is a module that provides more than
-        # just sunrise, sunset and moon phase
-        self.hasExtras = any(almanac.hasExtras for almanac in almanacs)
 
         return almanac
 
@@ -446,7 +443,7 @@ class WeeutilAlmanacType(AlmanacType):
                 context="ephem_day",
                 formatter=almanac_obj.formatter,
                 converter=almanac_obj.converter)
-        elif attr in ('moon_fullness','moon_index','moon_phase'):
+        elif attr.startswith('moon_'):
             moon_index, moon_fullness = weeutil.Moon.moon_phase_ts(almanac_obj.time_ts)
             if attr=='moon_phase':
                 return almanac_obj.moon_phases[moon_index]

--- a/src/weewx/tests/test_almanac.py
+++ b/src/weewx/tests/test_almanac.py
@@ -44,6 +44,7 @@ class AlmanacTest(unittest.TestCase):
         # Test back conversion
         self.assertAlmostEqual(djd_to_timestamp(t_djd), self.ts_ue, 5)
 
+    @unittest.skipIf(pyephem_installed, "Skipping test_moon: using extended test instead")
     def test_moon(self):
         # Test backwards compatiblity with the attribute _moon_fullness
         self.assertAlmostEqual(self.almanac.moon_fullness, 3, 2)


### PR DESCRIPTION
See issue "[Pyephem is deprecated](https://github.com/weewx/weewx/issues/981)" for background.

The approach is very similar to the XType extensions. There is a list of almanacs that are tried in order until one of them provides a result for the given attribute. An almanac is a subclass of `weewx.almanac.AlmanacType`. 

Built-in almanacs of core WeeWX are the weeutil formulae and the PyEphem wrapper. PyEphem is used automatically if it is available. Otherwise the weeutil formulae are used. This behavior is as before. Calls to PyEphem or weeutil formulae in `__getattr__` I moved to separate classes that seamlessly fit into the new concept of an extensible almanacs list. So no special condition statements were needed.

If a developer wants to provide an almanac extension they have to define a WeeWX service that instantiates a subclass of `weewx.almanac.AlmanacType` and inserts it into the almanacs list `weewx.almanac.almanacs`, just like they would do with XType extensions.

I ran `test_almanac.py`. The result was OK. I checked the output of the Seasons skin, both with and without PyEphem, and the results were reasonable to me. Additionally I checked to output of `$almanac.sunrise`, `$almanac.sunset`, `$almanac.moon_fullness`, and `$almanac.separation()` again with and without PyEphem.

Whether `AlmanacType` should include a precalculation method, could be discussed. It would make a difference if the user  re-uses `$almanac` (for example by `#set $alm = $almanac` and then `$alm.sun.rise`, `$alm.sun.set` etc.).

I added documentation to the file in the hope it will make it easier to read.