### PR TITLE
pyproject.toml: Clarify exclusion of top-level files in wheel

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -10,6 +10,9 @@ Fix bug that prevented relative paths to the config file from working.
 
 Allow simple Python objects to be used as an argument to `$jsonize()`.
 
+Adjust exclusion of top-level files in wheel creation to meet poetry
+norms and to be consistent across poetry-core versions.  Fixes issue
+[#993](https://github.com/weewx/weewx/issues/993), in part.
 
 ### 5.1.0 07/04/2024
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ packages = [
 ]
 
 include = [
-    { path = "LICENSE.txt" },
-    { path = "README.md"},
+    { path = "LICENSE.txt", format = "sdist" },
+    { path = "README.md", format = "sdist" },
 ]
 
 exclude = [


### PR DESCRIPTION
Mark README.md and LICENSE.txt as for sdist only, so that they are not included in a wheel.  This follows the poetry documentation's guidance not to include such files:

  https://python-poetry.org/docs/pyproject/#exclude-and-include

specifically

  "When a wheel is installed, its includes are unpacked straight into
  the site-packages directory.  Pay attention to include top level
  files and directories with common names like CHANGELOG.md, LICENSE,
  tests or docs only in sdists and not in wheels."

Resolves installation of these files in wheels and thus in $prefix/lib/python3.xy/site-packages with poetry-core 1.9.1.  (With poetry-core 2, the default for include is sdist, so this change has no effect.)

It seems fine to not include them in wheels, as wheels are essentially binaries (even if they have foo.py).  But, adding them (someplace) is separable, as this commit's purpose is to align behavior with older poetry-core to that of current poetry-core.