### PR TITLE
Data Manager caching of first and last timestamps

### DIFF
--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -417,10 +417,8 @@ class Manager:
 
         # Update the cached timestamps. This has to sit outside the transaction context,
         # in case an exception occurs.
-        if self.first_timestamp is not None:
-            self.first_timestamp = min(min_ts, self.first_timestamp)
-        if self.last_timestamp is not None:
-            self.last_timestamp = max(max_ts, self.last_timestamp)
+        self.first_timestamp = min_ts if self.first_timestamp is None else min(min_ts, self.first_timestamp)
+        self.last_timestamp = max_ts if self.last_timestamp is None else max(max_ts, self.last_timestamp)
 
         return N
 


### PR DESCRIPTION
Background:
I am creating and initializing a database to be used when testing an XType extension, so this use case may not be valid.
While doing this, I noticed that the attributes first_timestamp and last_stamp of the manager where not being updated. They were set to still set to `None` after 'importing' the data into the newly created database.

A small test program can be found [here](https://github.com/bellrichm/experiments/tree/main/dbmanager)

Here is the output prior to the changes in this pull request
```
min value in timestamps being imported: 1740114300
db_manager.first_timestamp is: None
db_manager.firstGoodStamp() is: 1740114300
max value in timestamps being imported: 1740200400
db_manager.last_timestamp is: None
db_manager.lastGoodStamp() is: 1740200400
End of testing db_manager caching of timestamps (first and last)
```

Here is the output after the changes.
```
min value in timestamps being imported: 1740114300
db_manager.first_timestamp is: 1740114300
db_manager.firstGoodStamp() is: 1740114300
max value in timestamps being imported: 1740200400
db_manager.last_timestamp is: 1740200400
db_manager.lastGoodStamp() is: 1740200400
End of testing db_manager caching of timestamps (first and last)
```