### PR TITLE
Don't open "Select" option for NOAA reports

### DIFF
--- a/src/weewx_data/skins/Standard/index.html.tmpl
+++ b/src/weewx_data/skins/Standard/index.html.tmpl
@@ -21,10 +21,12 @@
       }
       function openNoaaFile(date)
       {
-        var url = "NOAA/NOAA-";
-        url = url + date;
-        url = url + ".txt";
-        window.location=url;
+        if ( date != "none" ) {
+          var url = "NOAA/NOAA-";
+          url = url + date;
+          url = url + ".txt";
+          window.location=url;
+        }
       }
     </script>
     ## If a Google Analytics GA4 code has been specified, include it.
@@ -504,7 +506,7 @@
         #for $monthYear in $SummaryByMonth
             <option value="$monthYear">$monthYear</option>
         #end for
-        <option selected>-$gettext("Select month")-</option>
+        <option value="none" selected>-$gettext("Select month")-</option>
         </select>
         <br/>
         $gettext("Yearly summary"):&nbsp;
@@ -512,7 +514,7 @@
         #for $yr in $SummaryByYear
             <option value="$yr">$yr</option>
         #end for
-        <option selected>-$gettext("Select year")-</option>
+        <option value="none" selected>-$gettext("Select year")-</option>
         </select>
         </p>
       </div>


### PR DESCRIPTION
If you select a NOAA report and then choose "Select Month" or "Select Year" from the dropdown, it will try to open `NOAA--Select Month-.txt` which does not exist.

Is this a thing that reasonable users do? Possibly not. But it's definitely a thing that I do regularly. 😄 