### PR TITLE
Support For Gill MetConnect

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -18,6 +18,10 @@ Fix problem that prevented cached values of first and last timestamp from
 being set. [PR #999](https://github.com/weewx/weewx/pull/999). Thanks to user
 Rich Bell!
 
+Fix problem in `Standard` skin if `Select Month` was literally selected in drop
+down list. [PR #1002](https://github.com/weewx/weewx/pull/1002). Thanks to user
+Ben Cotton!
+
 
 ### 5.1.0 07/04/2024
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -14,6 +14,11 @@ Adjust exclusion of top-level files in wheel creation to meet poetry
 norms and to be consistent across poetry-core versions.  Fixes issue
 [#993](https://github.com/weewx/weewx/issues/993), in part.
 
+Fix problem that prevented cached values of first and last timestamp from
+being set. [PR #999](https://github.com/weewx/weewx/pull/999). Thanks to user
+Rich Bell!
+
+
 ### 5.1.0 07/04/2024
 
 If option `lang` is a valid locale, then it will be used to change locale as

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -28,6 +28,9 @@ The utility and documentation have been changed to use `cur_in_temp` (one
 '`r`'), making all types consistent. Fixes [Issue
 #1006](https://github.com/weewx/weewx/issues/1006).
 
+Fix a problem caused by an assumption that delta times are always in seconds.
+Fixes issue [Issue #1009](https://github.com/weewx/weewx/issues/1009).
+
 
 ### 5.1.0 07/04/2024
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -22,6 +22,12 @@ Fix problem in `Standard` skin if `Select Month` was literally selected in drop
 down list. [PR #1002](https://github.com/weewx/weewx/pull/1002). Thanks to user
 Ben Cotton!
 
+In the Cumulus import code, the prefix `cur_` is used to signify a current value
+for most observation types. However, there was one exception: `curr_in_temp`.
+The utility and documentation have been changed to use `cur_in_temp` (one
+'`r`'), making all types consistent. Fixes [Issue
+#1006](https://github.com/weewx/weewx/issues/1006).
+
 
 ### 5.1.0 07/04/2024
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -31,6 +31,10 @@ The utility and documentation have been changed to use `cur_in_temp` (one
 Fix a problem caused by an assumption that delta times are always in seconds.
 Fixes issue [Issue #1009](https://github.com/weewx/weewx/issues/1009).
 
+Fix bug that prevented arbitrary types from being used with `weectl database
+add-column`. Fixes issue [Issue
+#1007](https://github.com/weewx/weewx/issues/1007).
+
 
 ### 5.1.0 07/04/2024
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -35,6 +35,9 @@ Fix bug that prevented arbitrary types from being used with `weectl database
 add-column`. Fixes issue [Issue
 #1007](https://github.com/weewx/weewx/issues/1007).
 
+Fix bug that prevented MySQL and MariaDB versions greater than 10.0 from
+working. Fixes issue [Issue #1010](https://github.com/weewx/weewx/issues/1010).
+
 
 ### 5.1.0 07/04/2024
 

--- a/docs_src/hardware/gill.md
+++ b/docs_src/hardware/gill.md
@@ -1,0 +1,146 @@
+# Ultimeter {id=ultimeter_notes}
+
+The Gill driver listens for data transmitted via a gill weatherstation over serial approximatley every second. 
+
+The driver ignores gps corrected values but takes compass corrections into account. 
+
+In order to interface with the driver, you need to set up the station with Gill MetSet and get your .mcf config file.
+
+## Configuring with `weectl device` {id=ultimeter_configuration}
+
+The Gill stations cannot be configured with the utility
+[`weectl device`](../utilities/weectl-device.md).
+
+## Station data {id=gill_data}
+
+The following table shows which data are provided by the station hardware and which are calculated
+by WeeWX.
+
+Only the values you have enabled in gill metset are relevant.
+
+<table class='station_data'>
+    <caption>Gill station data</caption>
+    <tbody class='code'>
+    <tr class="first_row">
+        <td style='width:200px'>Database Field</td>
+        <td>Observation</td>
+        <td>Loop</td>
+        <td>Archive</td>
+    </tr>
+    <tr>
+        <td class='first_col'>barometer<sup></sup></td>
+        <td>barometer</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>pressure<sup></sup></td>
+        <td>pressure</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>altimeter<sup></sup></td>
+        <td>altimeter</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>gustdir<sup></sup></td>
+        <td>gust_direction</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>windDir<sup></sup></td>
+        <td>wind_direction</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>outHumidity<sup></sup></td>
+        <td>humiditiy_out</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+        <tr>
+        <td class='first_col'>cloudbase<sup></sup></td>
+        <td>cloud_base</td>
+        <td>S</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>rain<sup>1</sup></td>
+        <td>rain</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>rainRate<sup>1</sup></td>
+        <td>rain_rate</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>windSpeed<sup></sup></td>
+        <td>wind_speed</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>wind_gust<sup></sup></td>
+        <td>wind_gust</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>outTemp<sup></sup></td>
+        <td>temperature_out</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+        <tr>
+        <td class='first_col'>appTemp<sup></sup></td>
+        <td>apparent_temperature</td>
+        <td>S</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>heatindex<sup></sup></td>
+        <td>heat_index</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>windchill<sup></sup></td>
+        <td>wind_chill</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+        <tr>
+        <td class='first_col'>dewpoint<sup></sup></td>
+        <td>dew_point</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class='first_col'>supplyVoltage<sup></sup></td>
+        <td>supply_voltage</td>
+        <td>H</td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>
+<p class='station_data_key'>
+    <sup>1</sup> The <span class='code'>rain</span> and
+    <span class='code'>rainRate</span> are
+    available only on stations with the optional rain sensor.
+</p>
+
+
+<p class='station_data_key'>
+    <b>H</b> indicates data provided by <b>H</b>ardware<br/>
+    <b>D</b> indicates data calculated by the <b>D</b>river<br/>
+    <b>S</b> indicates data calculated by the StdWXCalculate <b>S</b>ervice<br/>
+</p>
+

--- a/docs_src/hardware/vantage.md
+++ b/docs_src/hardware/vantage.md
@@ -324,6 +324,11 @@ look at [Installing Repeater Networks for Vantage
 Pro2](https://support.davisinstruments.com/article/t9nvrc8c1u-app-notes-installing-repeater-networks-for-vantage-pro-2)
 for how to set them up.
 
+!!! Note
+    There is a possible bug in the Davis firmware that can prevent changing the
+    channel of the ISS. See the Wiki section [_Changing the ISS
+    channel_](https://github.com/weewx/weewx/wiki/Troubleshooting-the-Davis-Vantage-station#iss-channel-workaround).
+
 ### `--set-retransmit` {id=vantage_retransmit}
 
 Use this command to tell your console whether to act as a retransmitter of ISS

--- a/docs_src/quickstarts/pip.md
+++ b/docs_src/quickstarts/pip.md
@@ -392,3 +392,29 @@ remove the data directory:
 ```{ .shell .copy }
 rm -r ~/weewx-data
 ```
+
+## After a major OS upgrade
+
+After a major OS upgrade, the version of Python that comes with the OS may
+change. For example, after upgrading from Debian 12 to Debian 13, the Python
+version changes from Python 3.11 to 3.13.
+
+This means that the WeeWX virtual environment will be expecting Python 3.11, but
+it and its libraries will no longer exist.
+
+The solution is to rebuild your virtual environment and reinstall the WeeWX
+executables.
+
+```shell
+# Move the old virtual environment out of the way
+mv ~/weewx-venv ~/weewx-venv.old
+# Create a new virtual environment
+python3 -m venv ~/weewx-venv
+# Activate the new WeeWX virtual environment
+source ~/weewx-venv/bin/activate
+# Install WeeWX into the new virtual environment
+python3 -m pip install weewx
+```
+
+The station data under `~/weewx-data`, and any WeeWX extensions contained
+within, are left alone.

--- a/docs_src/reference/weewx-options/stdarchive.md
+++ b/docs_src/reference/weewx-options/stdarchive.md
@@ -35,6 +35,13 @@ When performing hardware record generation, this option will attempt to
 augment the record with any additional observation types that it can extract
 out of the LOOP packets. Default is `true`.
 
+#### no_catchup
+
+Many weather stations have internal memory that can continue to record weather
+data even when WeeWX is not running. Normally, when WeeWX starts up, it will
+download this data and archive it. However, if you set this option to `true`,
+then WeeWX will not attempt to catch up. Default is `false`.
+
 #### loop_hilo
 
 Set to `true` to have LOOP data and archive data to be used for high / low

--- a/docs_src/utilities/weectl-import-config-opt.md
+++ b/docs_src/utilities/weectl-import-config-opt.md
@@ -910,7 +910,7 @@ every Cumulus field need to be included in a mapping.
         <td>Current inside humidity</td>
     </tr>
     <tr>
-        <td class="first_col code">curr_in_temp</td>
+        <td class="first_col code">cur_in_temp</td>
         <td>Current inside temperature</td>
     </tr>
     <tr>

--- a/src/weectllib/database_cmd.py
+++ b/src/weectllib/database_cmd.py
@@ -156,7 +156,6 @@ def add_subparser(subparsers):
                                    metavar='NAME',
                                    help="Add new column NAME to database.")
     add_column_parser.add_argument('--type',
-                                   choices=['REAL', 'INTEGER', 'real', 'integer', 'int'],
                                    default='REAL',
                                    metavar='COLUMN-DEF',
                                    dest='column_type',

--- a/src/weedb/mysql.py
+++ b/src/weedb/mysql.py
@@ -19,7 +19,7 @@ else:
     except ImportError:
         from _mysql_exceptions import DatabaseError as MySQLDatabaseError
 
-from weeutil.weeutil import to_bool
+from weeutil.weeutil import to_bool, natural_compare
 import weedb
 
 DEFAULT_ENGINE = 'INNODB'
@@ -310,7 +310,7 @@ def set_engine(connect, engine):
     # Try to normalize:
     if isinstance(server_version, (tuple, list)):
         server_version = '%s.%s' % server_version[:2]
-    if server_version >= '5.5':
+    if natural_compare(server_version, '5.5') >= 0:
         connect.query("SET default_storage_engine=%s" % engine)
     else:
         connect.query("SET storage_engine=%s;" % engine)

--- a/src/weeimport/cumulusimport.py
+++ b/src/weeimport/cumulusimport.py
@@ -56,13 +56,13 @@ class CumulusSource(weeimport.Source):
     _field_list = ['datetime', 'cur_out_temp', 'cur_out_hum',
                    'cur_dewpoint', 'avg_wind_speed', 'gust_wind_speed',
                    'avg_wind_bearing', 'cur_rain_rate', 'day_rain', 'cur_slp',
-                   'rain_counter', 'curr_in_temp', 'cur_in_hum',
+                   'rain_counter', 'cur_in_temp', 'cur_in_hum',
                    'latest_wind_gust', 'cur_windchill', 'cur_heatindex',
                    'cur_uv', 'cur_solar', 'cur_et', 'annual_et',
                    'cur_app_temp', 'cur_tmax_solar', 'day_sunshine_hours',
                    'cur_wind_bearing', 'day_rain_rg11', 'midnight_rain']
     # tuple of fields using 'temperature' units
-    _temperature_fields = ('cur_out_temp', 'cur_dewpoint', 'curr_in_temp',
+    _temperature_fields = ('cur_out_temp', 'cur_dewpoint', 'cur_in_temp',
                            'cur_windchill', 'cur_heatindex','cur_app_temp')
     # tuple of fields using 'pressure' units
     _pressure_fields = ('cur_slp', )

--- a/src/weeimport/weeimport.py
+++ b/src/weeimport/weeimport.py
@@ -900,8 +900,8 @@ class Source:
                                 # or secondary inter-cardinal direction that we
                                 # can convert to degrees
 
-                                if _value is None and hasattr(self, 'wind_dir_map') and \
-                                        self.map[_field]['unit'] == 'degree_compass':
+                                if (_value is None and hasattr(self, 'wind_dir_map') and
+                                        self.map[_field].get('unit') == 'degree_compass'):
                                     # we have a csv import and we are mapping
                                     # to a direction field, so try a cardinal
                                     # conversion

--- a/src/weeutil/tests/test_weeutil.py
+++ b/src/weeutil/tests/test_weeutil.py
@@ -1072,7 +1072,24 @@ class WeeutilTest(unittest.TestCase):
         self.assertEqual(version_compare('1.2.2', '1.2.3'), -1)
         self.assertEqual(version_compare('1.3', '1.2.2'), 1)
         self.assertEqual(version_compare('1.3.0a1', '1.3.0a2'), -1)
+        self.assertEqual(version_compare('10.3.0', '2.3.0'), 1)
+        self.assertEqual(version_compare('10.3.0', '10.10.0'), -1)
+        self.assertEqual(version_compare('2.3.0', '10.3.0'), -1)
+        self.assertEqual(version_compare('12.0.2-MariaDB-ubu2404', '5.5'), 1)
 
+
+    def test_natural_sort_keys(self):
+        from weeutil.weeutil import natural_sort_keys
+        a = {'5foo':'a', '6foo': 'b', '10foo': 'c', '1foo': 'd', '01foo':'e'}
+        self.assertEqual(natural_sort_keys(a), ['1foo', '01foo', '5foo', '6foo', '10foo'])
+
+    def test_natural_compare(self):
+        from weeutil.weeutil import natural_compare
+        self.assertEqual(natural_compare('5foo', '10foo'), -1)
+        self.assertEqual(natural_compare('10foo', '5foo'), 1)
+        self.assertEqual(natural_compare('10foo', '1foo'), 1)
+        self.assertEqual(natural_compare('10foo', '10foo'), 0)
+        self.assertEqual(natural_compare('10foo', '11foo'), -1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -1744,6 +1744,17 @@ def natural_sort_keys(source_dict):
     return keys_list
 
 
+def natural_compare(a, b):
+    """Return -1 if a<b, 0 if a==b, 1 if a>b using natural sort."""
+
+    def natural_key(s):
+        return [int(text) if text.isdigit() else text.lower()
+                for text in re.split(r'(\d+)', s)]
+
+    ak, bk = natural_key(a), natural_key(b)
+    return (ak > bk) - (ak < bk)
+
+
 def to_sorted_string(rec, simple_sort=False):
     """Return a string representation of a dict sorted by key.
 
@@ -1832,7 +1843,7 @@ class bcolors:
 
 
 def version_compare(v1, v2):
-    """Compare two version numbers
+    """Compare two version numbers, using a natural compare
 
     Args:
         v1(str): The first version number as a string. Can be something like '4.5.1a1'
@@ -1847,10 +1858,9 @@ def version_compare(v1, v2):
     mash = itertools.zip_longest(v1.split('.'), v2.split('.'), fillvalue='0')
 
     for x1, x2 in mash:
-        if x1 > x2:
-            return 1
-        if x1 < x2:
-            return -1
+        cmp = natural_compare(x1, x2)
+        if cmp:
+            return cmp
     return 0
 
 

--- a/src/weewx/almanac.py
+++ b/src/weewx/almanac.py
@@ -415,17 +415,17 @@ class AlmanacBinder:
 
     def visible_change(self, days_ago=1):
         """Change in visibility of the heavenly body compared to 'days_ago'."""
-        # Visibility for today:
+        # Visibility for today, as a ValueTuple
         today_visible = self.visible
         # The time to compare to
         then_time = self.almanac.time_ts - days_ago * 86400
         # Get a new almanac, set up for the time back then
         then_almanac = self.almanac(almanac_time=then_time)
-        # Find the visibility back then
+        # Find the visibility back then as a ValueTuple
         then_visible = getattr(then_almanac, self.heavenly_body).visible
-        # Take the difference
-        diff = today_visible.raw - then_visible.raw
-        return weewx.units.ValueHelper(ValueTuple(diff, "second", "group_deltatime"),
+        # Take the difference, which will also be a ValueTuple
+        diff_vt = today_visible.value_t - then_visible.value_t
+        return weewx.units.ValueHelper(diff_vt,
                                        context="hour",
                                        formatter=self.almanac.formatter,
                                        converter=self.almanac.converter)

--- a/src/weewx/drivers/gill.py
+++ b/src/weewx/drivers/gill.py
@@ -23,16 +23,17 @@ import weewx.drivers
 from weewx.units import ValueTuple,convert
 
 DRIVER_NAME = 'Gill'
+DRIVER_VERSION = '1.3'
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
-if not logger.hasHandlers():
+if not log.hasHandlers():
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
-    logger.addHandler(ch)
+    log.addHandler(ch)
 
 #This dictionary controls the format wwewx extracts data from the
 #config file.
@@ -56,10 +57,6 @@ weewx_gill_mapping = {
             'gustdir':[
                 'CGDIR',
                 'GDIR',
-            ],
-            'vecdir':[
-                'AVGCDIR',
-                'AVGDIR'
             ],
             'windDir':[
                 'DIR',

--- a/src/weewx/drivers/gill.py
+++ b/src/weewx/drivers/gill.py
@@ -1,0 +1,364 @@
+'''
+Driver for the Gill MetConnect Series of weatherstations (i.e MX500)
+
+This driver has been tested with the stations MX400, MX500 and MX600
+however more models may be compatible.
+
+You are required to configure your reciever to send data over serial
+with gill metset - https://gillinstruments.com/downloads/metset-download-form/
+and then download your .mcf config file to get data packet structure,
+
+V 1.3
+https://github.com/Cosmospacedog
+https://siriusinsight.ai
+'''
+import socket
+import logging
+import time
+
+import xml.etree.ElementTree as ET
+
+
+import weewx.drivers
+from weewx.units import ValueTuple,convert
+
+DRIVER_NAME = 'Gill'
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+if not logger.hasHandlers():
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+#This dictionary controls the format wwewx extracts data from the
+#config file.
+#
+#Structured as:
+# weewx_gill_mapping
+# ├── group
+# │   ├── vals
+# │   │   ├── value type 1   : [preferred source, secondary source...]
+# │   │   └── value type 2   : [preferred source, secondary source...]
+# │   ├── units
+# │   │   ├── default : (standard unit, conversion rate)
+# │   │   ├── TBD     : (None, -1)
+# │   │   ├── Unit1   : (weewx unit 1, conversion rate)
+# │   │   └── Unit2   : (weewx unit 2, conversion rate)
+# │   └── config      : Path to unit variable in config or None if there is only one unit avaliable
+
+weewx_gill_mapping = {
+    'group_direction':{
+        'vals':{
+            'gustdir':[
+                'CGDIR',
+                'GDIR',
+            ],
+            'vecdir':[
+                'AVGCDIR',
+                'AVGDIR'
+            ],
+            'windDir':[
+                'DIR',
+                'CDIR'
+            ]
+        },
+        'units':{
+            'default':('degree_compass',1)
+        },
+        'config':None
+    },
+    'group_percent':{
+        'vals':{
+            'outHumidity':[
+                'RH'
+            ]
+        },
+        'units':{
+            'default':('percent',1)
+        },
+        'config':None
+    },
+    'group_pressure':{
+        'vals':{
+            'barometer':[
+                'PSTN'
+            ],
+            'altimeter':[
+                'PASL'
+            ],
+            'pressure':[
+                'PRESS'
+            ]
+        },
+        'units':{
+            'default':('mbar',1),
+            'TBD':(None,-1),
+            'HPA':('hPa',1),
+            'MB':('mbar',1),
+            'MMHG':('inHg',25.4),
+            'INHG':('inHg',1)
+        },
+        'config':".//category[@name='Pressure']/param[@name='Pressure Units']/valuestring"
+    },
+    'group_rain':{
+        'vals':{
+            'rain':[
+                'PRECIPT'
+            ]
+        },
+        'units':{
+            'default':('mm',1),
+            'TBD':(None,-1),
+            'MM':('mm',1),
+            'IN':('inch',1)
+        },
+        'config':".//category[@name='Precipitation']/param[@name='Precipitation Units']/valuestring"
+    },
+    'group_rainrate':{
+        'vals':{
+            'rainRate':[
+                'PRECIPI'
+            ]
+        },
+        'units':{
+            'default':('mm_per_hour',1),
+            'TBD':(None,-1),
+            'MM':('mm_per_hour',1),
+            'IN':('inch_per_hour ',1)
+        },
+        'config':".//category[@name='Precipitation']/param[@name='Precipitation Units']/valuestring"
+    },
+    'group_speed':{
+        'vals':{
+            'windSpeed':[
+                'CSPEED',
+                'AVGCSPEED',
+                'SPEED',
+                'AVGSPEED'
+            ],
+            'windGust':[
+                'CGSPEED',
+                'GSPEED'
+            ]
+        },
+        'units':{
+            'default':('meter_per_second ',1),
+            'TBD':(None,-1),
+            'MS':('meter_per_second ',1),
+            'KTS':('knot',1),
+            'MPH':('mile_per_hour',1),
+            'KPH':('km_per_hour',1),
+            'FPM':('mile_per_hour',1/88)
+        },
+        'config':".//category[@name='Wind']/param[@name='Wind speed Units']/valuestring"
+    },
+    'group_temperature':{
+        'vals':{
+            'outTemp':[
+                'TEMP'
+            ],
+            'heatindex':[
+                'HEATIDX'
+            ],
+            'windchill':[
+                'WCHILL'
+            ],
+            'dewpoint':[
+                'DEWPOINT'
+            ]
+        },
+        'units':{
+            'default':('degree_C',1),
+            'TBD':(None,-1),
+            'C':('degree_C',1),
+            'F':('degree_F',1),
+            'K':('degree_K',1)
+        },
+        'config':".//category[@name='Temperature']/param[@name='Temperature Units']/valuestring"
+
+    },
+    'group_volt':{
+        'vals':{
+            'supplyVoltage':[
+                'VOLT'
+            ]
+        },
+        'units':{
+            'default':('volt',1)
+        },
+        'config':None
+    }
+}
+
+
+class Gill(weewx.drivers.AbstractDevice):
+    '''
+    Driver to communicate between weewx and Gill Metconnect Devices
+    '''
+    def __init__(self,ip_addr:str,port:int,sample_rate:int,config_path:str) -> None:
+        #Private value initialisation
+        self.__ip_addr = ip_addr
+        self.__port = port
+        self.__sample_rate = sample_rate
+
+        self.network_stream = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+        self.network_stream.connect((self.__ip_addr,self.__port))
+
+        #Build output framework
+        self._output_map = {}
+        self._value_string = None
+        self._weewx_map = None
+        self._config = ET.parse(config_path)
+        self._config_root = self._config.getroot()
+
+        #Pull config information
+        self._hardware_name = self._config_root.find(
+            ".//device"
+        ).get('name')
+
+        self._initalise_packet_map()
+
+    @property
+    def hardware_name(self):
+        '''
+        Get Gill Model
+        '''
+        return self._hardware_name
+
+
+    def _initalise_packet_map(self) -> None:
+        '''
+        Generate our weewx output format to match weatherstation configuration
+        '''
+
+        #Pull Config String - Like
+        value_string = self._config_root.find(
+            ".//category[@name='Reporting']/param[@name='Report Format']/reportvalue"
+        )
+
+        #Split up config string
+        self._value_string = value_string.text.split(' ')
+
+        #Iterate through each weewx field and find if the station is transmitting
+        #it. If it is - build a tuple ->
+        #weewx unit:(GILL unit,gill unit group,(weewx unit,conversion rate))
+
+        for group,group_data in weewx_gill_mapping.items():
+            for value_map,value in group_data['vals'].items():
+                for key in value:
+                    if key not in self._value_string:
+                        continue
+                    config = group_data['config']
+
+                    if config is None:
+                        unit =group_data['units']['default']
+                    else:
+                        unit = group_data['units'][
+                            self._config_root.find(
+                                config
+                            ).text
+                        ]
+
+                    self._output_map[value_map] = (key,group,unit)
+
+    def proccess_packet(self, data_out) -> dict:
+        '''
+        Proccess an array packet to match the provided gill encoding
+        '''
+        packet = {
+                'dateTime': int(time.time() + 0.5),
+                'usUnits': weewx.METRICWX
+            }
+        for field,value in self._output_map.items():
+            index = self._value_string.index(value[0])
+            tuple_temp = ValueTuple(float(data_out[index])*value[2][1],value[2][0],value[1])
+            normalised_data = convert(
+                tuple_temp,weewx_gill_mapping[value[1]]['units']['default'][0]
+                )
+            packet[field] = normalised_data[0]
+        logging.info(packet)
+        return packet
+
+    def genLoopPackets(self):
+        while True:
+            time.sleep(self.__sample_rate)
+
+            data =  self.network_stream.recv(
+                1024).decode(errors="ignore").strip()  # read up to 1024 bytes at a time
+
+            #Bad sync -> go to generate new packet
+            if not data.lstrip('\x02').split(',')[0].isalpha():
+                continue
+
+            packet_size = len(self._value_string) + 1 #one more for checksum
+
+            #Missed packet end -> cache current data and request the rest
+            if len(data.strip().split(',')) < packet_size:
+                logging.info("Failed Sync")
+
+                while len(data.strip().split(',')) != packet_size:
+                    logging.info("Data Apeended")
+                    buffer = str(data)
+                    data =  self.network_stream.recv(1024).decode(errors="ignore").strip()
+                    data = buffer + data
+                    print (data)
+
+            current_values = data.strip().split(',')
+
+            # Final check if packet is legit
+            if len(current_values) != packet_size:
+                logging.info("Failed Size")
+                continue
+
+            #load values into packet
+            yield self.proccess_packet(current_values)
+
+def loader(config_dict, engine):
+    gill_config = config_dict['Gill']
+    return Gill(
+        gill_config['eth_address'],
+        int(gill_config['eth_port']),
+        int(gill_config['sample_rate']),
+        gill_config['gill_config'],
+    )
+
+class GillConfEditor(weewx.drivers.AbstractConfEditor):
+    '''
+    Generate default config
+    '''
+    @property
+    def default_stanza(self):
+        '''
+        Returns defaults
+        '''
+        return """
+[Gill]
+    # This section is for the Gill MetConnect series of weather stations
+
+    # Connection type: serial or ethernet
+    # serial (via a com port or tty USB device)
+    # ethernet (via a TCP connection i.e a MOXA or DIGI device port)
+    type = ethernet
+
+    # Internal IPV4 adress of the weather station
+    eth_address = x.x.x.x
+
+    # port your Gill device operates on - typically 4001 for a tcp connection
+    eth_port = 4001
+
+    serial_port = /dev/ttyUSB0
+
+    gps = 0
+
+    gill_config = /x/x/config.mcf
+    ###############################################################
+    #  Advanced Config
+
+    sample_rate = 1
+
+    driver = user.gill
+"""

--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -417,10 +417,8 @@ class Manager:
 
         # Update the cached timestamps. This has to sit outside the transaction context,
         # in case an exception occurs.
-        if self.first_timestamp is not None:
-            self.first_timestamp = min(min_ts, self.first_timestamp)
-        if self.last_timestamp is not None:
-            self.last_timestamp = max(max_ts, self.last_timestamp)
+        self.first_timestamp = min_ts if self.first_timestamp is None else min(min_ts, self.first_timestamp)
+        self.last_timestamp = max_ts if self.last_timestamp is None else max(max_ts, self.last_timestamp)
 
         return N
 


### PR DESCRIPTION
<img width="800" height="418" alt="MetConnect-Social_-272591656" src="https://github.com/user-attachments/assets/07bcf094-18fa-40ee-8d24-e4e5573b54e9" />

I recently set up this custom driver for receiving and processing data from [Gill Metconnect](https://gillinstruments.com/compare-weather-stations/metconnect-weather-station/) systems and thought it was worth contributing back to weewx.

Gill instruments provide weather stations capable of providing diverse weather and gps data, this driver covers their MetConnect line - having been tested with the MX400,MX500,MX550 and MX600 models.

These devices are set up ahead of transmit via the [Gill MetSet](https://gillinstruments.com/downloads/metset-download-form/) software and cannot have their configs changed on the fly. Thus, the driver makes use of the .mcf config files provided on setup to infer the correct packet data format.

No additional dependencies are required to implement the driver as metConnect systems transmit standard UTF-8 serial data.