### PR TITLE
Urlencode authentication key

### DIFF
--- a/src/weewx/restx.py
+++ b/src/weewx/restx.py
@@ -1038,7 +1038,7 @@ class WOWThread(AmbientThread):
 
         _liststr = ["action=updateraw",
                     "siteid=%s" % self.station,
-                    "siteAuthenticationKey=%s" % self.password,
+                    "siteAuthenticationKey=%s" % urllib.parse.quote(self.password),
                     "softwaretype=weewx-%s" % weewx.__version__]
 
         # Go through each of the supported types, formatting it, then adding


### PR DESCRIPTION
The WOW-BE service (see #1013 ) also allows full passwords as site authentication keys. If this password contains any special characters like `&` or `=`, this can mess up the query-string sent to the service.

This shouldn't cause any regressions for the WOW-service also, because the PIN codes used there aren't altered by URL-encoding them.