### PR TITLE
Remove unnecessary `UNIQUE` index on `INTEGER PRIMARY KEY`

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,10 @@ WeeWX change history
 
 ### 5.2.1 MM/DD/YYYY
 
+Remove unnecessary `UNIQUE` index on `PRIMARY KEY` columns in SQLite, achieving
+size reduction of ~10%.  Existing database schemas are not modified.  Users
+desiring size reduction are advised to consider manually migrating.
+
 Fix problem that prevented `weectl database reconfigure` from working in cases
 where a schema was specified.
 

--- a/src/weedb/sqlite.py
+++ b/src/weedb/sqlite.py
@@ -268,7 +268,7 @@ class Cursor(sqlite3.Cursor, weedb.Cursor):
             if obs_name in column_names:
                 continue
             no_null_str = " NOT NULL" if no_null else ""
-            pk_str = " UNIQUE PRIMARY KEY" if pk else ""
+            pk_str = " PRIMARY KEY" if pk else ""
             default_str = " DEFAULT %s" % default if default is not None else ""
             create_list.append("`%s` %s%s%s%s" % (obs_name, obs_type, no_null_str,
                                                   pk_str, default_str))

--- a/src/weedb/tests/check_mysql.py
+++ b/src/weedb/tests/check_mysql.py
@@ -150,7 +150,7 @@ class TestMySQL(unittest.TestCase):
         with Cursor(user='weewx1', password='weewx1') as cursor:
             cursor.execute("CREATE DATABASE test_weewx1")
             cursor.execute("CREATE TABLE test_weewx1.test1 "
-                           "( dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY, col1 int, col2 int)")
+                           "( dateTime INTEGER NOT NULL PRIMARY KEY, col1 int, col2 int)")
             cursor.execute("INSERT INTO test_weewx1.test1 "
                            "(dateTime, col1, col2) VALUES (1, 10, 20)")
             with self.assertRaises(IntegrityError) as e:

--- a/src/weedb/tests/check_sqlite.py
+++ b/src/weedb/tests/check_sqlite.py
@@ -100,7 +100,7 @@ class TestSqlite3(unittest.TestCase):
 
     def test_duplicate_key(self):
         with Cursor(sqdb1) as cursor:
-            cursor.execute("CREATE TABLE test1 ( dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY, col1 int, col2 int)")
+            cursor.execute("CREATE TABLE test1 ( dateTime INTEGER NOT NULL PRIMARY KEY, col1 int, col2 int)")
             cursor.execute("INSERT INTO test1 (dateTime, col1, col2) VALUES (1, 10, 20)")
             with self.assertRaises(IntegrityError) as e:
                 cursor.execute("INSERT INTO test1 (dateTime, col1, col2) VALUES (1, 30, 40)")

--- a/src/weedb/tests/test_errors.py
+++ b/src/weedb/tests/test_errors.py
@@ -180,7 +180,7 @@ class Common(unittest.TestCase):
             weedb.create(db_dict)
             connect = weedb.connect(db_dict)
             cursor = connect.cursor()
-            cursor.execute("CREATE TABLE test1 ( dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY, col1 int, col2 int)")
+            cursor.execute("CREATE TABLE test1 ( dateTime INTEGER NOT NULL PRIMARY KEY, col1 int, col2 int)")
             cursor.execute("INSERT INTO test1 (dateTime, col1, col2) VALUES (1, 10, 20)")
             with self.assertRaises(weedb.IntegrityError) as e:
                 cursor.execute("INSERT INTO test1 (dateTime, col1, col2) VALUES (1, 30, 40)")

--- a/src/weedb/tests/test_weedb.py
+++ b/src/weedb/tests/test_weedb.py
@@ -48,10 +48,10 @@ class Common(unittest.TestCase):
             weedb.create(self.db_dict)
         with weedb.connect(self.db_dict) as _connect:
             with weedb.Transaction(_connect) as _cursor:
-                _cursor.execute("CREATE TABLE test1 (dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY,"
+                _cursor.execute("CREATE TABLE test1 (dateTime INTEGER NOT NULL PRIMARY KEY,"
                                 " min REAL, mintime INTEGER, max REAL, maxtime INTEGER, sum REAL,"
                                 " count INTEGER, descript CHAR(20));")
-                _cursor.execute("CREATE TABLE test2 (dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY,"
+                _cursor.execute("CREATE TABLE test2 (dateTime INTEGER NOT NULL PRIMARY KEY,"
                                 " min REAL, mintime INTEGER, max REAL, maxtime INTEGER, sum REAL, "
                                 "count INTEGER, descript CHAR(20));")
                 for irec in range(20):
@@ -151,7 +151,7 @@ class Common(unittest.TestCase):
         with weedb.connect(self.db_dict) as _connect:
             with _connect.cursor() as _cursor:
                 _cursor.execute(
-                    "CREATE TABLE test1 (dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY, x REAL )")
+                    "CREATE TABLE test1 (dateTime INTEGER NOT NULL PRIMARY KEY, x REAL )")
 
                 # Now start the transaction
                 _connect.begin()
@@ -176,7 +176,7 @@ class Common(unittest.TestCase):
             # create the table outside the transaction. We're not as concerned about a
             # transaction failing when creating a table, because it only happens the first time
             # weewx starts up.
-            _connect.execute("CREATE TABLE test1 (dateTime INTEGER NOT NULL UNIQUE PRIMARY KEY, "
+            _connect.execute("CREATE TABLE test1 (dateTime INTEGER NOT NULL PRIMARY KEY, "
                              "x REAL );")
 
             # We're going to trigger the rollback by raising a bogus exception.

--- a/src/weewx/manager.py
+++ b/src/weewx/manager.py
@@ -1016,7 +1016,7 @@ class DaySummaryManager(Manager):
     # Schemas used by the daily summaries:
     day_schemas = {
         'scalar': [
-            ('dateTime', 'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+            ('dateTime', 'INTEGER NOT NULL PRIMARY KEY'),
             ('min', 'REAL'),
             ('mintime', 'INTEGER'),
             ('max', 'REAL'),
@@ -1027,7 +1027,7 @@ class DaySummaryManager(Manager):
             ('sumtime', 'INTEGER')
         ],
         'vector': [
-            ('dateTime', 'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+            ('dateTime', 'INTEGER NOT NULL PRIMARY KEY'),
             ('min', 'REAL'),
             ('mintime', 'INTEGER'),
             ('max', 'REAL'),
@@ -1047,7 +1047,7 @@ class DaySummaryManager(Manager):
 
     # SQL statements used by the metadata in the daily summaries.
     meta_create_str = "CREATE TABLE %s_day__metadata (name CHAR(20) NOT NULL " \
-                      "UNIQUE PRIMARY KEY, value TEXT);"
+                      "PRIMARY KEY, value TEXT);"
     meta_replace_str = "REPLACE INTO %s_day__metadata VALUES(?, ?)"
     meta_select_str = "SELECT value FROM %s_day__metadata WHERE name=?"
 

--- a/src/weewx/schemas/wview.py
+++ b/src/weewx/schemas/wview.py
@@ -21,7 +21,7 @@
 # with V4, a new style was added, which allows schema for the daily summaries
 # to be expressed explicitly.
 # =============================================================================
-schema = [('dateTime',             'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+schema = [('dateTime',             'INTEGER NOT NULL PRIMARY KEY'),
           ('usUnits',              'INTEGER NOT NULL'),
           ('interval',             'INTEGER NOT NULL'),
           ('barometer',            'REAL'),

--- a/src/weewx/schemas/wview_extended.py
+++ b/src/weewx/schemas/wview_extended.py
@@ -13,7 +13,7 @@
 # =============================================================================
 # NB: This schema is specified using the WeeWX V4 "new-style" schema.
 # =============================================================================
-table = [('dateTime',             'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+table = [('dateTime',             'INTEGER NOT NULL PRIMARY KEY'),
          ('usUnits',              'INTEGER NOT NULL'),
          ('interval',             'INTEGER NOT NULL'),
          ('altimeter',            'REAL'),

--- a/src/weewx/schemas/wview_small.py
+++ b/src/weewx/schemas/wview_small.py
@@ -14,7 +14,7 @@
 # =============================================================================
 # NB: This schema is specified using the WeeWX V4 "new-style" schema.
 # =============================================================================
-table = [('dateTime',             'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+table = [('dateTime',             'INTEGER NOT NULL PRIMARY KEY'),
          ('usUnits',              'INTEGER NOT NULL'),
          ('interval',             'INTEGER NOT NULL'),
          ('altimeter',            'REAL'),

--- a/src/weewx/tests/test_database.py
+++ b/src/weewx/tests/test_database.py
@@ -22,7 +22,7 @@ weeutil.logger.setup('weetest_database')
 archive_sqlite = {'database_name': '/var/tmp/weewx_test/weedb.sdb', 'driver':'weedb.sqlite'}
 archive_mysql  = {'database_name': 'test_weedb', 'user':'weewx1', 'password':'weewx1', 'driver':'weedb.mysql'}
 
-archive_schema = [('dateTime',             'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+archive_schema = [('dateTime',             'INTEGER NOT NULL PRIMARY KEY'),
                   ('usUnits',              'INTEGER NOT NULL'),
                   ('interval',             'INTEGER NOT NULL'),
                   ('barometer',            'REAL'),

--- a/src/weewx/tests/tst_schema.py
+++ b/src/weewx/tests/tst_schema.py
@@ -3,7 +3,7 @@
 #
 #      See the file LICENSE.txt for your full rights.
 #
-table = [('dateTime',             'INTEGER NOT NULL UNIQUE PRIMARY KEY'),
+table = [('dateTime',             'INTEGER NOT NULL PRIMARY KEY'),
          ('usUnits',              'INTEGER NOT NULL'),
          ('interval',             'INTEGER NOT NULL'),
          ('altimeter',            'REAL'),


### PR DESCRIPTION
SQLite creates a unique index in addition to the clustered index for `INTEGER NOT NULL UNIQUE PRIMARY KEY` columns.  The index is not necessary to enforce uniqueness and is not used for existing queries. Removing these unnecessary indexes reduced my database from 444MB to 395MB (11%).

Remove the `UNIQUE` constraint from `INTEGER PRIMARY KEY` columns to avoid the unnecessary overhead.

Note: Testing with MariaDB 11.8.3 indicates that the `UNIQUE` constraint is ignored (`SHOW CREATE TABLE` does not include `UNIQUE` and `SHOW INDEX` only shows a `PRIMARY` index.)  Removing it will have no effect that I am aware of for MariaDB.

Fixes: #1031

#### Discussion

I added a note to `docs_src/changes.md`, but I have two thoughts/questions:

1. Will this have enough visibility for users?  For Debian, I'd consider adding `debian/NEWS` so that programs like apt-listchanges will surface it to users.
2. Should we describe how to manually migrate (or link to a source that does)?  Unfortunately, I'm not aware of an easy process.  The user would need to either recreate the database or tables, copy the data, remove the old, rename new to old.

Thanks for considering (and maintaining WeeWX!),
Kevin