### PR TITLE
Update control since python3-ephem is no longer updated

### DIFF
--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -18,7 +18,6 @@ Depends:
  python3-pil,
  python3-serial,
  python3-usb,
- python3-ephem
 Suggests:
  sqlite,
  rsync,


### PR DESCRIPTION
Since the python module python3-ephem has had no updates since 2018 and is no longer maintained it makes no sense to have the weeWX Debian package depend on it.