### PR TITLE
Udev rules fix for acurite stations on newer kernels

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -18,6 +18,7 @@ Use better measure of system uptime.
 Fix problem that prevented table headers from appearing in the Seasons's 
 statistics page.
 
+Fix problem with Acurite usb failures in newer kernels. [PR #1080](https://github.com/weewx/weewx/pull/1080)
 
 ### 5.3.1 03/03/2026
 

--- a/pkg/etc/udev/rules.d/weewx.rules
+++ b/pkg/etc/udev/rules.d/weewx.rules
@@ -2,6 +2,8 @@
 
 # acurite
 SUBSYSTEM=="usb",ATTRS{idVendor}=="24c0",ATTRS{idProduct}=="0003",MODE="0664",GROUP="weewx"
+# Workaround to unbind the hid-generic driver so it doesn't "lock" the station on newer kernels
+SUBSYSTEM=="usb",ATTRS{idVendor}=="24c0",ATTRS{idProduct}=="0003",ACTION=="add",RUN+="/bin/sh -c 'sleep 1; echo $kernel > /sys/bus/usb/drivers/usbhid/unbind || true'"
 
 # fine offset usb
 SUBSYSTEM=="usb",ATTRS{idVendor}=="1941",ATTRS{idProduct}=="8021",MODE="0664",GROUP="weewx"


### PR DESCRIPTION
Added a workaround to unbind the hid-generic driver for Acurite devices on newer kernels, due to buggy Acurite hid implementation. I believe this should be backwards compatible with all modern kernels (i.e. 5+)

Issue widely reported with newer kernels on weewx-user list, e.g. https://groups.google.com/g/weewx-user/c/0Jiye8CmtLE/m/Bob4QRxzAgAJ

Submitting PR to master, as this is a fix.