### PR TITLE
fix(reportengine): default HTML_ROOT to public_html when not configured

### DIFF
--- a/src/weewx/reportengine.py
+++ b/src/weewx/reportengine.py
@@ -508,7 +508,7 @@ class FtpGenerator(ReportGenerator):
         try:
             local_root = Path(self.config_dict['WEEWX_ROOT'],
                               self.skin_dict.get('HTML_ROOT',
-                                                 self.config_dict['StdReport']['HTML_ROOT']))
+                                                 self.config_dict['StdReport'].get('HTML_ROOT', 'public_html')))
             ftp_data = weeutil.ftpupload.FtpUpload(
                 server=self.skin_dict['server'],
                 user=self.skin_dict['user'],
@@ -566,7 +566,7 @@ class RsyncGenerator(ReportGenerator):
         try:
             local_root = Path(self.config_dict['WEEWX_ROOT'],
                               self.skin_dict.get('HTML_ROOT',
-                                                 self.config_dict['StdReport']['HTML_ROOT']))
+                                                 self.config_dict['StdReport'].get('HTML_ROOT', 'public_html')))
             rsync_data = weeutil.rsyncupload.RsyncUpload(
                 local_root=local_root,
                 remote_root=self.skin_dict['path'],
@@ -616,7 +616,7 @@ class CopyGenerator(ReportGenerator):
         copy_list += weeutil.weeutil.option_as_list(copy_dict.get('copy_always', []))
 
         # Figure out the destination of the files
-        html_dest_dir = Path(self.config_dict['WEEWX_ROOT'], self.skin_dict['HTML_ROOT'])
+        html_dest_dir = Path(self.config_dict['WEEWX_ROOT'], self.skin_dict.get('HTML_ROOT', 'public_html'))
 
         # The copy list can contain wildcard characters. Go through the
         # list globbing any character expansions


### PR DESCRIPTION
## Bug

When `HTML_ROOT` is set only inside an `[[FTP]]` report section (not at the `[[StdReport]]` level), the FTP and rsync generators raise a `KeyError` accessing `config_dict['StdReport']['HTML_ROOT']`. The bare `except KeyError` catches it and logs the misleading message "FTP upload not requested. Skipped."

## Fix

Use `.get('HTML_ROOT', 'public_html')` for both the skin_dict and StdReport fallback lookups. This matches the weewx convention where `public_html` is the default HTML_ROOT.

Affected:
- `ftpgenerator` local_root (line ~510)
- `rsyncgenerator` local_root (line ~568)
- `copygenerator` html_dest_dir (line ~619)

Closes #1082