### PR TITLE
fix(debian): add weewx user to dialout group for serial port access

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -299,6 +299,13 @@ create_user() {
                 --disabled-password weewx || true
         echo "done"
     fi
+    # add the weewx user to the dialout group for serial port access
+    if getent group dialout > /dev/null 2>&1; then
+        if ! id -nG "$WEEWX_USER" | grep -qw dialout; then
+            echo "Adding user $WEEWX_USER to group dialout"
+            usermod -aG dialout "$WEEWX_USER"
+        fi
+    fi
 }
 
 # add the user who is installing into the weewx group, if appropriate


### PR DESCRIPTION
## Problem

On Debian Trixie (and other systems where serial ports are owned by the `dialout` group), the weewx service fails to start after installation:

```
SerialException: [Errno 13] could not open port /dev/ttyUSB0: [Errno 13] Permission denied
```

The systemd service runs as `weewx:weewx`, but the user is never added to the `dialout` group, so it cannot access serial ports. The udev rules only cover specific known USB devices — generic USB-serial adapters are not matched.

## Fix

Add the `weewx` user to the `dialout` group in `postinst` `create_user()`. The group is checked for existence first (it is standard on Debian/Ubuntu but may not exist on all systems), and membership is checked to avoid duplicate additions on upgrades.

Fixes #1084