### PR TITLE
fix(pkg): read HTML_ROOT from config for chown/chmod during upgrade

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -433,11 +433,24 @@ setup_database_dir() {
     chown -R $WEEWX_USER:$WEEWX_GROUP $WEEWX_HOME
 }
 
+# get HTML_ROOT from the configuration file
+get_html_root() {
+    if [ -f $cfgfile ]; then
+        hr=$(sed -n 's/^HTML_ROOT[[:space:]]*=[[:space:]]*//p' $cfgfile | head -1)
+        if [ -n "$hr" ]; then
+            echo "$hr"
+            return
+        fi
+    fi
+    echo "$WEEWX_HTMLDIR"
+}
+
 # create the reporting directory
 setup_reporting_dir() {
-    echo "Configuring reporting directory $WEEWX_HTMLDIR"
-    mkdir -p $WEEWX_HTMLDIR
-    set_permissions $WEEWX_USER $WEEWX_GROUP $WEEWX_HTMLDIR
+    html_root=$(get_html_root)
+    echo "Configuring reporting directory $html_root"
+    mkdir -p "$html_root"
+    set_permissions $WEEWX_USER $WEEWX_GROUP "$html_root"
 }
 
 # set the permissions on the configuration, skins, and extensions

--- a/pkg/weewx.spec.in
+++ b/pkg/weewx.spec.in
@@ -345,11 +345,24 @@ setup_database_dir() {
     chown -R $WEEWX_USER:$WEEWX_GROUP %{sqlite_root}
 }
 
+# get the HTML_ROOT from the configuration file
+get_html_root() {
+    if [ -f %{cfg_file} ]; then
+        html_root=$(sed -n 's/^HTML_ROOT[[:space:]]*=[[:space:]]*//p' %{cfg_file} | head -1)
+        if [ -n "$html_root" ]; then
+            echo "$html_root"
+            return
+        fi
+    fi
+    echo '%{html_root}'
+}
+
 # create the reports directory
 setup_reporting_dir() {
-    echo "Configuring reporting directory %{html_root}"
-    mkdir -p %{html_root}
-    set_permissions $WEEWX_USER $WEEWX_GROUP %{html_root}
+    html_root=$(get_html_root)
+    echo "Configuring reporting directory $html_root"
+    mkdir -p "$html_root"
+    set_permissions $WEEWX_USER $WEEWX_GROUP "$html_root"
 }
 
 # set the permissions on the configuration, skins, and extensions


### PR DESCRIPTION
During upgrade, \`setup_reporting_dir\` hardcoded the HTML_ROOT path instead of reading it from the configuration file. If a user had customized HTML_ROOT in weewx.conf, permissions would be applied to the default location, leaving the actual reporting directory with wrong ownership.

Add \`get_html_root()\` helper to both RPM spec and Debian postinst that reads HTML_ROOT from weewx.conf, falling back to the default when the config file does not exist (fresh install).

Fixes #1046