### PR TITLE
chore: Add additonal log info per executed template

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -25,6 +25,10 @@ Fix problem with Acurite usb failures in newer kernels. [PR #1080](https://githu
 
 Allow duration notation to be used with option `x_interval`.
 
+Enhance cheetah logging in debug mode, showing generation execution time per 
+report to identify bottlenecks. 
+[PR #1091](https://github.com/weewx/weewx/pull/1091)
+
 
 ### 5.3.1 03/03/2026
 

--- a/src/weewx/cheetahgenerator.py
+++ b/src/weewx/cheetahgenerator.py
@@ -313,6 +313,7 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                                                _filename))
 
             # First, compile the template
+            t1 = time.time()
             try:
                 # TODO: Look into caching the compiled template.
                 compiled_template = Cheetah.Template.Template(
@@ -378,6 +379,9 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                     os.unlink(tmpname)
                 except OSError:
                     pass
+
+            if weewx.debug >= 2:
+                log.debug("%s took %.2f s" % (template, time.time()-t1))
 
         return ngen
 


### PR DESCRIPTION
I would like to add enhance logging for cheetah template generator to explicit show execution time per template
to be able to identify how much time individual template needs to be generated

e.g. here you see that year template took much more than other

```
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/index.html.tmpl took 2.22 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/yesterday.html.tmpl took 5.86 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/week.html.tmpl took 1.24 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/month.html.tmpl took 3.33 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/year.html.tmpl took 120.12 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/neowx-material/almanac.html.tmpl took 1.25 s
weewxd[1]: INFO weewx.cheetahgenerator: Generated 12 files for report NeowxMaterial in 158.74 seconds
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/NOAA/NOAA-%Y-%m.txt.tmpl took 0.22 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/NOAA/NOAA-%Y.txt.tmpl took 0.50 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/index.html.tmpl took 0.65 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/statistics.html.tmpl took 0.29 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/telemetry.html.tmpl took 0.05 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/tabular.html.tmpl took 0.01 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/celestial.html.tmpl took 0.87 s
weewxd[1]: INFO weewx.cheetahgenerator: /root/weewx-data/skins/Seasons/rss.xml.tmpl took 0.12 s
weewxd[1]: INFO weewx.cheetahgenerator: Generated 8 files for report SeasonsReport in 2.74 seconds
```
 