### PR TITLE
Modified ReportTiming to check if files don't exist but would have been created otherwise

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -32,7 +32,7 @@ report to identify bottlenecks.
 Added @createIfMissing option for report_timing handling so that report
 generation will be allowed if there are missing report files or if the
 modified times of templates are newer than generated files.
-Added in [PR #XXXX](https://github.com/weewx/weewx/pull/XXXX). Thanks
+Added in [PR #1097](https://github.com/weewx/weewx/pull/1097). Thanks
 to user evilbunny2008.
 
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -12,7 +12,6 @@ Example `xstats.py` had nonsensical time context values. Fixed in
 [PR #1072](https://github.com/weewx/weewx/pull/1072). Thanks to user 
 evilbunny2008. 
 
-<<<<<<< HEAD
 Prevent `AttributeError` when the `weectl` command is run without a subcommand.
 
 Guard against an empty string being passed to the copy generator.
@@ -35,10 +34,6 @@ generation will be allowed if there are missing report files or if the
 modified times of templates are newer than generated files.
 Added in [PR #XXXX](https://github.com/weewx/weewx/pull/XXXX). Thanks
 to user evilbunny2008.
-
-The getFileName function in the CheetahGenerator class was needed for
-[PR #1076](https://github.com/weewx/weewx/pull/1076) to convert template
-file names with date formatting to filenames, shifted to weeutil.py
 
 
 ### 5.3.1 03/03/2026

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -36,6 +36,10 @@ modified times of templates are newer than generated files.
 Added in [PR #XXXX](https://github.com/weewx/weewx/pull/XXXX). Thanks
 to user evilbunny2008.
 
+The getFileName function in the CheetahGenerator class was needed for
+[PR #1076](https://github.com/weewx/weewx/pull/1076) to convert template
+file names with date formatting to filenames, shifted to weeutil.py
+
 
 ### 5.3.1 03/03/2026
 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -12,6 +12,7 @@ Example `xstats.py` had nonsensical time context values. Fixed in
 [PR #1072](https://github.com/weewx/weewx/pull/1072). Thanks to user 
 evilbunny2008. 
 
+<<<<<<< HEAD
 Prevent `AttributeError` when the `weectl` command is run without a subcommand.
 
 Guard against an empty string being passed to the copy generator.
@@ -28,6 +29,12 @@ Allow duration notation to be used with option `x_interval`.
 Enhance cheetah logging in debug mode, showing generation execution time per 
 report to identify bottlenecks. 
 [PR #1091](https://github.com/weewx/weewx/pull/1091)
+
+Added @createIfMissing option for report_timing handling so that report
+generation will be allowed if there are missing report files or if the
+modified times of templates are newer than generated files.
+Added in [PR #XXXX](https://github.com/weewx/weewx/pull/XXXX). Thanks
+to user evilbunny2008.
 
 
 ### 5.3.1 03/03/2026

--- a/docs_src/custom/report-scheduling.md
+++ b/docs_src/custom/report-scheduling.md
@@ -276,6 +276,31 @@ parameters in the report_timing option. The nicknames supported are:
 </tr>
 </table>
 
+### @createIfMissing option
+
+report_timing supports the @createIfMissing option that allows reports
+to run if files that would have been created during report generation
+are missing or if the modified times on report files are older than
+template files in the skin directory.
+
+<table>
+<tr>
+<td>report_timing</td>
+<td>When the report will be run</td>
+</tr>
+<tr>
+<td>0 * 1 * 0,3</td>
+<td>On the hour on the first of the month and on the hour every Sunday and Wednesday unless the report files are missing or the template files are newer.</td>
+</tr>
+<tr>
+<td>@monthly, @createIfMissing</td>
+<td>On the first day of every month unless the report files are missing or the template files are newer.</td>
+</tr>
+<tr>
+<td>@yearly, @createIfMissing</td>
+<td>On the first day of the year unless the report files are missing or the template files are newer.</td>
+</tr>
+</table>
 
 ### Examples of report_timing
 

--- a/src/weeutil/tests/test_weeutil.py
+++ b/src/weeutil/tests/test_weeutil.py
@@ -973,6 +973,11 @@ def test_max_with_none():
     assert max_with_none([1, 2, None, 4]) == 4
     assert max_with_none([-1, -2, None, -4]) == -1
 
+def test_dict_search():
+    # build a dict with dicts to test recursive searches
+    test_dict = {"CheetahGenerator": {"encoding": "utf8", "search_list_extensions": "user.xstats.ExtendedStatistics", "Data": {"template": "filename.html.tmpl"}}, "Generators": {"generator_list": "weewx.cheetahgenerator.CheetahGenerator"}}
+    assert dict_search(test_dict, "templates") == []
+    assert dict_search(test_dict, "template") == ["filename.html.tmpl"]
 
 def test_ListOfDicts():
     # Try an empty dictionary:

--- a/src/weeutil/tests/test_weeutil.py
+++ b/src/weeutil/tests/test_weeutil.py
@@ -979,6 +979,12 @@ def test_dict_search():
     assert dict_search(test_dict, "templates") == []
     assert dict_search(test_dict, "template") == ["filename.html.tmpl"]
 
+def test_getFileName():
+    # build a dict with dicts to test recursive searches
+    assert getFileName("test.txt.tmpl", 1775267792) == "test.txt"
+    assert getFileName("test-%Y-%m.html.tmpl", 1775267792) == "test-2026-04.html"
+    assert getFileName("test-YYYY-MM.html.tmpl", 1775267792) == "test-2026-04.html"
+
 def test_ListOfDicts():
     # Try an empty dictionary:
     lod = ListOfDicts()

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -155,6 +155,7 @@ def _ord_to_ts(ord_date):
     t = int(time.mktime(d.timetuple()))
     return t
 
+
 # ===============================================================================
 # What follows is a bunch of "time span" routines. Generally, time spans
 # are used when start and stop times fall on calendar boundaries

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -30,6 +30,7 @@ except:
 # For backwards compatibility:
 from weeutil.config import accumulateLeaves, search_up
 
+
 def convertToFloat(seq):
     """Convert a sequence with strings to floats, honoring 'Nones'
 

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -14,6 +14,7 @@ import calendar
 import cmath
 import datetime
 import importlib
+import logging
 import math
 import os
 import re
@@ -30,6 +31,7 @@ except:
 # For backwards compatibility:
 from weeutil.config import accumulateLeaves, search_up
 
+log = logging.getLogger(__name__)
 
 def convertToFloat(seq):
     """Convert a sequence with strings to floats, honoring 'Nones'
@@ -1621,6 +1623,38 @@ def dict_search(d, key_search):
         elif isinstance(value, dict):
             results.extend(dict_search(value, key_search))
     return results
+
+def getFileName(template, timestamp):
+    """Calculate a destination filename given a template filename.
+
+    For backwards compatibility replace 'YYYY' with the year, 'MM' with the
+    month, 'DD' with the day. Also observe any strftime format strings in
+    the filename. Finally, strip off any trailing .tmpl."""
+
+    log.info(f"timestamp: {timestamp}")
+
+    report_time = datetime.datetime.fromtimestamp(timestamp)
+    filename = os.path.basename(template).replace('.tmpl', '')
+
+    # If the filename contains YYYY, MM, DD or WW, then do the replacement
+    if 'YYYY' in filename or 'MM' in filename or 'DD' in filename or 'WW' in filename:
+        # Get strings representing year, month, and day
+        yr_str = "%4d" % report_time.year
+        mo_str = "%02d" % report_time.month
+        day_str = "%02d" % report_time.day
+        week_str = "%02d" % report_time.isocalendar()[1];
+        # Replace any instances of 'YYYY' with the year string
+        filename = filename.replace('YYYY', yr_str)
+        # Do the same thing with the month...
+        filename = filename.replace('MM', mo_str)
+        # ... the week ...
+        filename = filename.replace('WW', week_str)
+        # ... and the day
+        filename = filename.replace('DD', day_str)
+    # then apply any strftime formatting
+    filename = report_time.strftime(filename)
+
+    return filename
 
 class Polar:
     """Polar notation, except the direction is a compass heading."""

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -155,7 +155,6 @@ def _ord_to_ts(ord_date):
     t = int(time.mktime(d.timetuple()))
     return t
 
-
 # ===============================================================================
 # What follows is a bunch of "time span" routines. Generally, time spans
 # are used when start and stop times fall on calendar boundaries
@@ -1610,6 +1609,17 @@ def dirN(c):
         value = (450 - math.degrees(cmath.phase(c))) % 360.0
     return value
 
+def dict_search(d, key_search):
+    """ Recursively searches for a key in a dict and builds a list of the results """
+    results = []
+    if d is None or key_search is None or key_search.strip() == "":
+        return results
+    for key, value in d.items():
+        if key == key_search:
+            results.append(value)
+        elif isinstance(value, dict):
+            results.extend(dict_search(value, key_search))
+    return results
 
 class Polar:
     """Polar notation, except the direction is a compass heading."""

--- a/src/weeutil/weeutil.py
+++ b/src/weeutil/weeutil.py
@@ -14,7 +14,6 @@ import calendar
 import cmath
 import datetime
 import importlib
-import logging
 import math
 import os
 import re
@@ -30,8 +29,6 @@ except:
 
 # For backwards compatibility:
 from weeutil.config import accumulateLeaves, search_up
-
-log = logging.getLogger(__name__)
 
 def convertToFloat(seq):
     """Convert a sequence with strings to floats, honoring 'Nones'
@@ -1630,8 +1627,6 @@ def getFileName(template, timestamp):
     For backwards compatibility replace 'YYYY' with the year, 'MM' with the
     month, 'DD' with the day. Also observe any strftime format strings in
     the filename. Finally, strip off any trailing .tmpl."""
-
-    log.info(f"timestamp: {timestamp}")
 
     report_time = datetime.datetime.fromtimestamp(timestamp)
     filename = os.path.basename(template).replace('.tmpl', '')

--- a/src/weewx/cheetahgenerator.py
+++ b/src/weewx/cheetahgenerator.py
@@ -76,7 +76,7 @@ import weewx.station
 import weewx.tags
 import weewx.units
 from weeutil.config import search_up, accumulateLeaves, deep_copy
-from weeutil.weeutil import to_bool, to_int, timestamp_to_string
+from weeutil.weeutil import getFileName, to_bool, to_int, timestamp_to_string
 
 log = logging.getLogger(__name__)
 
@@ -278,11 +278,11 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
                 if date_str not in self.outputted_dict[summarize_by]:
                     self.outputted_dict[summarize_by].append(date_str)
                 # For these "SummaryBy" generations, the file name comes from the start of the timespan:
-                _filename = self._getFileName(template, start_tt)
+                _filename = getFileName(template, time.mktime(start_tt))
             else:
                 # This is a "ToDate" generation. File name comes 
                 # from the stop (i.e., present) time:
-                _filename = self._getFileName(template, stop_tt)
+                _filename = getFileName(template, time.mktime(stop_tt))
 
             # Get the absolute path for the target of this template
             _fullname = os.path.join(dest_dir, _filename)
@@ -405,38 +405,6 @@ class CheetahGenerator(weewx.reportengine.ReportGenerator):
             search_list += obj.get_extension_list(timespan, db_lookup)
 
         return search_list
-
-    def _getFileName(self, template, ref_tt):
-        """Calculate a destination filename given a template filename.
-
-        For backwards compatibility replace 'YYYY' with the year, 'MM' with the
-        month, 'DD' with the day. Also observe any strftime format strings in
-        the filename. Finally, strip off any trailing .tmpl."""
-
-        _filename = os.path.basename(template).replace('.tmpl', '')
-
-        # If the filename contains YYYY, MM, DD or WW, then do the replacement
-        if 'YYYY' in _filename or 'MM' in _filename or 'DD' in _filename or 'WW' in _filename:
-            # Get strings representing year, month, and day
-            _yr_str = "%4d" % ref_tt[0]
-            _mo_str = "%02d" % ref_tt[1]
-            _day_str = "%02d" % ref_tt[2]
-            _week_str = "%02d" % datetime.date(ref_tt[0], ref_tt[1], ref_tt[2]).isocalendar()[1];
-            # Replace any instances of 'YYYY' with the year string
-            _filename = _filename.replace('YYYY', _yr_str)
-            # Do the same thing with the month...
-            _filename = _filename.replace('MM', _mo_str)
-            # ... the week ...
-            _filename = _filename.replace('WW', _week_str)
-            # ... and the day
-            _filename = _filename.replace('DD', _day_str)
-        # observe any strftime format strings in the base file name
-        # first obtain a datetime object from our timetuple
-        ref_dt = datetime.datetime.fromtimestamp(time.mktime(ref_tt))
-        # then apply any strftime formatting
-        _filename = ref_dt.strftime(_filename)
-
-        return _filename
 
     def _prepGen(self, report_dict):
         """Get the template, destination directory, encoding, and default

--- a/src/weewx/reportengine.py
+++ b/src/weewx/reportengine.py
@@ -27,7 +27,7 @@ import weeutil.weeutil
 import weewx.defaults
 import weewx.manager
 import weewx.units
-from weeutil.weeutil import to_bool, to_int
+from weeutil.weeutil import to_bool, to_int, dict_search
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ NICKNAME_MAP = {
     "@monthly": "0 0 1 * *",
     "@weekly": "0 0 * * 0",
     "@daily": "0 0 * * *",
-    "@hourly": "0 * * * *",
+    "@hourly": "0 * * * *"
 }
 # list of valid spans for CRON like fields
 SPANS = (MINUTES, HOURS, DOM, MONTHS, DOW)
@@ -100,23 +100,6 @@ def set_locale(name):
             yield loc
         finally:
             locale.setlocale(locale.LC_ALL, saved_locale)
-
-def dict_search(d, key_search):
-
-    results = []
-
-    if d is None or key_search is None or key_search.strip() == "":
-        return results
-
-    for key, value in d.items():
-
-        if key == key_search:
-            results.append(value)
-
-        elif isinstance(value, dict):
-            results.extend(dict_search(value, key_search))
-
-    return results
 
 # =============================================================================
 #                    Class StdReportEngine
@@ -679,9 +662,10 @@ class ReportTiming:
         @weekly   : Run once a week,  ie "0 0 * * 0"
         @daily    : Run once a day,   ie "0 0 * * *"
         @hourly   : Run once an hour, ie "0 * * * *"
-    - if the timing is given with CreateIfMissing appended eg @yearlyCreateIfMissing
-      the report generation is allowed to occur if files that the report would
-      generate doesn't exist even if the report_timing would normally fail
+    - if the timing is given with @createIfMissing the report generation is
+      allowed to occur if files that the report would generate doesn't exist
+      or if the extension has been updated and the modified file times in the
+      skin directory are newer even if the report_timing would normally fail
 
     Useful ReportTiming class attributes:
 
@@ -725,9 +709,9 @@ class ReportTiming:
                                                                                  self.raw_line)
                 return
 
-        if line_str.endswith("CreateIfMissing"):
+        if "@createIfMissing" in line_str:
             self.create_if_missing = True
-            self.raw_line = line_str = line_str[:-15]
+            self.raw_line = line_str = line_str.replace(",@createIfMissing", "")
 
         # Six special time definition 'nicknames' are supported which replace
         # the line elements with pre-determined values. These nicknames start
@@ -900,16 +884,33 @@ class ReportTiming:
         if self.is_valid and self.create_if_missing:
             # check for missing files
 
+            skin_dir = self.skin_dict["SKIN_ROOT"]
+            skin_dir = os.path.join(skin_dir, self.skin_dict["skin"])
             html_dest_dir = self.skin_dict["HTML_ROOT"]
 
-            templates = dict_search(self.skin_dict.get("CheetahGenerator", None), "template")
-            for template in templates:
-                if not template.endswith(".tmpl"):
-                    continue
+            if os.path.exists(skin_dir):
+                if os.path.exists(html_dest_dir):
+                    templates = dict_search(self.skin_dict.get("CheetahGenerator", None), "template")
+                    for template in templates:
+                        if not template.endswith(".tmpl"):
+                            continue
 
-                filename = os.path.join(html_dest_dir, template[:-5])
-                if not os.path.exists(filename):
-                    log.debug(f"{filename} should exist but doesn't, allowing report generation")
+                        template_filename = os.path.join(skin_dir, template)
+                        if os.path.exists(template_filename):
+                            output_filename = os.path.join(html_dest_dir, template[:-5])
+                            if not os.path.exists(output_filename):
+                                log.debug(f"{output_filename} should exist but doesn't, allowing report generation")
+                                return True
+
+                            template_mtime = os.path.getmtime(template_filename)
+                            output_mtime = os.path.getmtime(output_filename)
+
+                            if template_mtime > output_mtime:
+                                log.debug(f"{output_filename} exists but is older than {template_filename}, allowing report generation")
+                                return True
+
+                else:
+                    log.debug(f"{html_dest_dir} should exist but doesn't, allowing report generation")
                     return True
 
         if self.is_valid and ts_hi is not None:
@@ -974,3 +975,4 @@ class ReportTiming:
             # Our line is not valid, or we do not have a timestamp to use,
             # return None
             return None
+

--- a/src/weewx/reportengine.py
+++ b/src/weewx/reportengine.py
@@ -58,7 +58,7 @@ NICKNAME_MAP = {
     "@monthly": "0 0 1 * *",
     "@weekly": "0 0 * * 0",
     "@daily": "0 0 * * *",
-    "@hourly": "0 * * * *"
+    "@hourly": "0 * * * *",
 }
 # list of valid spans for CRON like fields
 SPANS = (MINUTES, HOURS, DOM, MONTHS, DOW)
@@ -101,6 +101,22 @@ def set_locale(name):
         finally:
             locale.setlocale(locale.LC_ALL, saved_locale)
 
+def dict_search(d, key_search):
+
+    results = []
+
+    if d is None or key_search is None or key_search.strip() == "":
+        return results
+
+    for key, value in d.items():
+
+        if key == key_search:
+            results.append(value)
+
+        elif isinstance(value, dict):
+            results.extend(dict_search(value, key_search))
+
+    return results
 
 # =============================================================================
 #                    Class StdReportEngine
@@ -194,7 +210,7 @@ class StdReportEngine(threading.Thread):
                 timing_line = skin_dict.get('report_timing')
                 if timing_line:
                     # Get a ReportTiming object.
-                    timing = ReportTiming(timing_line)
+                    timing = ReportTiming(timing_line, skin_dict)
                     if timing.is_valid:
                         # Get timestamp and interval, so we can check if the
                         # report timing is triggered.
@@ -663,6 +679,9 @@ class ReportTiming:
         @weekly   : Run once a week,  ie "0 0 * * 0"
         @daily    : Run once a day,   ie "0 0 * * *"
         @hourly   : Run once an hour, ie "0 * * * *"
+    - if the timing is given with CreateIfMissing appended eg @yearlyCreateIfMissing
+      the report generation is allowed to occur if files that the report would
+      generate doesn't exist even if the report_timing would normally fail
 
     Useful ReportTiming class attributes:
 
@@ -674,7 +693,7 @@ class ReportTiming:
                       replaced with numeric equivalents.
     """
 
-    def __init__(self, raw_line):
+    def __init__(self, raw_line, skin_dict):
         """Initialises a ReportTiming object.
 
         Processes raw line to produce 5 field line suitable for further
@@ -686,6 +705,9 @@ class ReportTiming:
         # initialise some properties
         self.is_valid = None
         self.validation_error = None
+        self.create_if_missing = False
+        self.skin_dict = skin_dict
+
         # To simplify error reporting keep a copy of the raw line passed to us
         # as a string. The raw line could be a list if it included any commas.
         # Assume a string but catch the error if it is a list and join the list
@@ -702,6 +724,11 @@ class ReportTiming:
                 self.validation_error = "Unsupported character '%s' in '%s'." % (unsupported_char,
                                                                                  self.raw_line)
                 return
+
+        if line_str.endswith("CreateIfMissing"):
+            self.create_if_missing = True
+            self.raw_line = line_str = line_str[:-15]
+
         # Six special time definition 'nicknames' are supported which replace
         # the line elements with pre-determined values. These nicknames start
         # with the @ character. Check for any of these nicknames and substitute
@@ -869,6 +896,21 @@ class ReportTiming:
                 checked for triggering. May be omitted in which case only
                 ts_hi is checked.
         """
+
+        if self.is_valid and self.create_if_missing:
+            # check for missing files
+
+            html_dest_dir = self.skin_dict["HTML_ROOT"]
+
+            templates = dict_search(self.skin_dict.get("CheetahGenerator", None), "template")
+            for template in templates:
+                if not template.endswith(".tmpl"):
+                    continue
+
+                filename = os.path.join(html_dest_dir, template[:-5])
+                if not os.path.exists(filename):
+                    log.debug(f"{filename} should exist but doesn't, allowing report generation")
+                    return True
 
         if self.is_valid and ts_hi is not None:
             # setup ts range to iterate over

--- a/src/weewx/reportengine.py
+++ b/src/weewx/reportengine.py
@@ -27,7 +27,7 @@ import weeutil.weeutil
 import weewx.defaults
 import weewx.manager
 import weewx.units
-from weeutil.weeutil import to_bool, to_int, dict_search
+from weeutil.weeutil import getFileName, to_bool, to_int, dict_search
 
 log = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ class StdReportEngine(threading.Thread):
                 timing_line = skin_dict.get('report_timing')
                 if timing_line:
                     # Get a ReportTiming object.
-                    timing = ReportTiming(timing_line, skin_dict)
+                    timing = ReportTiming(timing_line, skin_dict, self.record['dateTime'])
                     if timing.is_valid:
                         # Get timestamp and interval, so we can check if the
                         # report timing is triggered.
@@ -678,7 +678,7 @@ class ReportTiming:
                       replaced with numeric equivalents.
     """
 
-    def __init__(self, raw_line, skin_dict):
+    def __init__(self, raw_line, skin_dict, dateTime):
         """Initialises a ReportTiming object.
 
         Processes raw line to produce 5 field line suitable for further
@@ -692,6 +692,7 @@ class ReportTiming:
         self.validation_error = None
         self.create_if_missing = False
         self.skin_dict = skin_dict
+        self.dateTime = dateTime
 
         # To simplify error reporting keep a copy of the raw line passed to us
         # as a string. The raw line could be a list if it included any commas.
@@ -898,7 +899,7 @@ class ReportTiming:
 
                         template_filename = os.path.join(skin_dir, template)
                         if os.path.exists(template_filename):
-                            output_filename = os.path.join(html_dest_dir, template[:-5])
+                            output_filename = os.path.join(html_dest_dir, getFileName(template, self.dateTime))
                             if not os.path.exists(output_filename):
                                 log.debug(f"{output_filename} should exist but doesn't, allowing report generation")
                                 return True

--- a/src/weewx/reportengine.py
+++ b/src/weewx/reportengine.py
@@ -101,6 +101,7 @@ def set_locale(name):
         finally:
             locale.setlocale(locale.LC_ALL, saved_locale)
 
+
 # =============================================================================
 #                    Class StdReportEngine
 # =============================================================================
@@ -975,4 +976,3 @@ class ReportTiming:
             # Our line is not valid, or we do not have a timestamp to use,
             # return None
             return None
-


### PR DESCRIPTION
I need to periodically generate reports but because the report_timing setting didn't match report generation was skipped even though data exists for the period in the database but files that would be generated don't exist.

A solution was to make minimal changes to the ReportTiming class to check if files the report would create exist and if the files don't exist allow report generation regardless of the report_timing setting.

Existing behaviour won't be altered by this PR, instead the proposed code checks for 'CreateIfMissing' appended to the report_timing string, eg @yearlyCreateIfMissing to enable the new functionality.

Distributing an extension just to extend the ReportTiming class doesn't seem like the best idea, and I thought this change would benefit others with the same need.

I still need this functionality but #1076 was closed when I shifted my changes to a different branch so I could submit another PR without having changes from this PR