### PR TITLE
MySQLdb has 2 sets of Exceptions

### DIFF
--- a/src/weedb/mysql.py
+++ b/src/weedb/mysql.py
@@ -18,7 +18,7 @@ except ImportError:
                          InterfaceError as MySQLInterfaceError)
 else:
     try:
-        from MySQLdb import DatabaseError as MySQLDatabaseError
+        from MySQLdb._exceptions import DatabaseError as MySQLDatabaseError
     except ImportError:
         from _mysql_exceptions import (DatabaseError as MySQLDatabaseError,
                                        InterfaceError as MySQLInterfaceError)
@@ -66,6 +66,8 @@ def guard(fn):
             raise klass(e)
         except MySQLInterfaceError as e:
             raise weedb.DisconnectError(e)
+        except MySQLOperationalError as e:
+            raise weedb.DatabaseError("test")
 
     return guarded_fn
 

--- a/src/weedb/mysql.py
+++ b/src/weedb/mysql.py
@@ -66,8 +66,6 @@ def guard(fn):
             raise klass(e)
         except MySQLInterfaceError as e:
             raise weedb.DisconnectError(e)
-        except MySQLOperationalError as e:
-            raise weedb.DatabaseError("test")
 
     return guarded_fn
 


### PR DESCRIPTION
importing from MySQLdb doesn't import the same base exception classes as those defined in MySQLdb._exceptions, something to do with C verse python exceptions