### PR TITLE
feat: Introducing weectl rest -command

### DIFF
--- a/docs_src/utilities/weectl-rest.md
+++ b/docs_src/utilities/weectl-rest.md
@@ -1,0 +1,75 @@
+# weectl rest
+
+Use the `weectl` subcommand `rest` to list the configured RESTful upload
+services, and to force an upload on demand.
+
+RESTful services are the uploaders that publish your data to online weather
+networks, such as the Weather Underground, CWOP, PWSWeather, WOW, AWEKAS, and
+the WeeWX station registry. They are configured in the `[StdRESTful]` section of
+`weewx.conf`.
+
+Specify `--help` to see the actions and options.
+
+## List RESTful services
+
+    weectl rest list
+        [--config=FILENAME]
+
+The `list` action lists all the RESTful services configured in
+`restful_services` (under `[Engine] / [[Services]]`), along with whether each
+one is enabled. A service counts as _enabled_ if it has been configured with
+everything it needs to run (for example, the Weather Underground requires a
+`station` and `password`). For example:
+
+```
+$ weectl rest list
+Using configuration file /home/ted_user/weewx-data/weewx.conf
+
+Service              Enabled   Class
+StationRegistry         N      weewx.restx.StdStationRegistry
+Wunderground            Y      weewx.restx.StdWunderground
+PWSweather              N      weewx.restx.StdPWSweather
+CWOP                    N      weewx.restx.StdCWOP
+WOW                     N      weewx.restx.StdWOW
+AWEKAS                  N      weewx.restx.StdAWEKAS
+```
+
+## Force an upload on demand
+
+    weectl rest run [NAME ...]
+        [--config=FILENAME]
+
+In normal operation, WeeWX uploads to a RESTful service only when a new archive
+record arrives, and only as often as the service's posting schedule allows. The
+action `weectl rest run` forces an immediate upload of the most recent archive
+record in the database, irrespective of the normal posting schedule (the
+`stale` and `post_interval` limits are ignored). It uses the same configuration
+file that `weewxd` uses.
+
+The names of the services to upload to can be given on the command line,
+separated by spaces. Names are _case insensitive_, and can be given either as
+the short name shown by `weectl rest list` (for example, `Wunderground`) or as
+the class name (for example, `StdWunderground`). Use `weectl rest list` to
+determine the names.
+
+For example, to force an upload to the Weather Underground and CWOP:
+
+    weectl rest run Wunderground CWOP
+
+If no names are given, then all _enabled_ services will be run:
+
+    # Upload to all enabled services:
+    weectl rest run
+
+Only enabled services are uploaded to. If you name a service that is not
+enabled, it will be skipped with a notice.
+
+## Options
+
+### --config
+
+Path to the configuration file. Default is `~/weewx-data/weewx.conf`.
+
+### --help
+
+Show the help message, then exit.

--- a/src/weectl.py
+++ b/src/weectl.py
@@ -27,7 +27,7 @@ description = """%(prog)s is the master utility used by WeeWX. It can invoke sev
 subcommands, listed below. You can explore what each subcommand does by using the --help option.
 For example, to find out what the 'database' subcommand can do, use '%(prog)s database --help'."""
 
-SUBCOMMANDS = ['database', 'debug', 'device', 'extension', 'import', 'report', 'station', ]
+SUBCOMMANDS = ['database', 'debug', 'device', 'extension', 'import', 'report', 'rest', 'station', ]
 
 
 # ===============================================================================

--- a/src/weectllib/rest_actions.py
+++ b/src/weectllib/rest_actions.py
@@ -1,0 +1,197 @@
+#
+#    Copyright (c) 2009-2024 Tom Keffer <tkeffer@gmail.com> and Matthew Wall
+#
+#    See the file LICENSE.txt for your rights.
+#
+"""Actions related to listing and running RESTful upload services.
+
+Normally, RESTful uploads (Weather Underground, CWOP, PWSWeather, etc.) happen
+only when the WeeWX engine receives a new archive record. These actions allow a
+RESTful upload to be forced manually, outside of the engine's scheduler.
+"""
+
+import logging
+import socket
+import sys
+
+import weewx.engine
+import weewx.manager
+import weewx.restx
+import weeutil.weeutil
+from weeutil.weeutil import bcolors, timestamp_to_string
+
+log = logging.getLogger('weectl-rest')
+
+
+def list_rest(config_dict):
+    """List all configured RESTful services, along with whether they are enabled."""
+
+    # Instantiate a dummy engine. This loads (and starts) all the configured services,
+    # including the RESTful ones.
+    engine = weewx.engine.DummyEngine(config_dict)
+    try:
+        service_map = _build_service_map(engine, config_dict)
+
+        if not service_map:
+            print("No RESTful services are configured.")
+            return
+
+        # Print a header
+        print(f"\n{bcolors.BOLD}{'Service':<20} {'Enabled':^8}  {'Class'}{bcolors.ENDC}")
+
+        for svc_path, name, inst in service_map:
+            enabled = _is_enabled(inst)
+            print(f"{name:<20} {'Y' if enabled else 'N':^8}  {svc_path}")
+    finally:
+        engine.shutDown()
+
+
+def run_rest(config_dict, services=None):
+    """Force an upload to one or more RESTful services.
+
+    Args:
+        config_dict (dict): The configuration dictionary.
+        services (list[str]|None): The names of the services to upload to. If None or
+            empty, all enabled RESTful services will be uploaded to.
+    """
+
+    # Use a sane default socket timeout, the same as 'weectl report run' does.
+    socket.setdefaulttimeout(10)
+
+    # Instantiate a dummy engine. This loads (and starts) all the configured services,
+    # including the RESTful ones.
+    engine = weewx.engine.DummyEngine(config_dict)
+    try:
+        service_map = _build_service_map(engine, config_dict)
+
+        # Figure out which services the user asked for.
+        if services:
+            # Build a set of all the names a service can be matched by (case-insensitive).
+            known = set()
+            for svc_path, name, _inst in service_map:
+                known.add(name.lower())
+                known.add(svc_path.split('.')[-1].lower())
+            # Warn about any names that don't match a configured service.
+            for requested in services:
+                if requested.lower() not in known:
+                    print(f"Unknown RESTful service: '{requested}'. "
+                          f"Use 'weectl rest list' to see configured services.",
+                          file=sys.stderr)
+            wanted = {s.lower() for s in services}
+            selected = [t for t in service_map
+                        if t[1].lower() in wanted
+                        or t[0].split('.')[-1].lower() in wanted]
+        else:
+            selected = service_map
+
+        if not selected:
+            print("No matching RESTful services to run.")
+            return
+
+        # Retrieve the most recent archive record from the database. This is the record
+        # that will be uploaded.
+        try:
+            binding = config_dict['StdArchive']['data_binding']
+        except KeyError:
+            binding = 'wx_binding'
+
+        with weewx.manager.DBBinder(config_dict) as db_binder:
+            db_manager = db_binder.get_manager(binding)
+            ts = db_manager.lastGoodStamp()
+            record = db_manager.getRecord(ts) if ts else None
+
+        if record is None:
+            print("No archive record is available to upload.", file=sys.stderr)
+            return
+
+        print(f"Uploading record for {timestamp_to_string(record['dateTime'])}")
+
+        for svc_path, name, inst in selected:
+            if not _is_enabled(inst):
+                print(f"{name}: not enabled; skipping.")
+                continue
+            _force_post(name, inst, record)
+    finally:
+        engine.shutDown()
+
+    print("Done.")
+
+
+def _build_service_map(engine, config_dict):
+    """Build a list describing the configured RESTful services.
+
+    Returns:
+        list[tuple]: A list of 3-way tuples (svc_path, name, instance), where
+            'svc_path' is the fully-qualified class path from the configuration file,
+            'name' is a short, user-friendly name, and 'instance' is the loaded service
+            object (or None if it could not be loaded).
+    """
+    # Retrieve the list of configured RESTful services. ConfigObj parses a single entry
+    # (no trailing comma) as a string, so coerce to a list.
+    services = config_dict['Engine']['Services'].get('restful_services', [])
+    if not isinstance(services, list):
+        services = [services]
+
+    service_map = []
+    for svc_path in services:
+        if not svc_path:
+            continue
+        # Find the loaded instance whose class matches this configuration entry.
+        inst = None
+        try:
+            klass = weeutil.weeutil.get_object(svc_path)
+        except Exception:
+            klass = None
+        if klass is not None:
+            for obj in engine.service_obj:
+                if type(obj) is klass:
+                    inst = obj
+                    break
+        service_map.append((svc_path, _short_name(svc_path), inst))
+
+    return service_map
+
+
+def _short_name(svc_path):
+    """Derive a short, user-friendly name from a service class path.
+
+    For example, 'weewx.restx.StdWunderground' becomes 'Wunderground'.
+    """
+    cls = svc_path.split('.')[-1]
+    if cls.startswith('Std'):
+        cls = cls[3:]
+    return cls
+
+
+def _is_enabled(inst):
+    """A RESTful service is considered enabled if it was loaded and started a thread."""
+    return inst is not None and (hasattr(inst, 'archive_thread')
+                                 or hasattr(inst, 'loop_thread'))
+
+
+def _force_post(name, inst, record):
+    """Force a single record to be posted to a RESTful service.
+
+    The post is done by calling the posting thread's process_record() directly. This
+    bypasses the normal skip_this_post() checks (the 'stale' and 'post_interval'
+    gates), so the upload happens regardless of when the last upload occurred.
+    """
+    thread = inst.archive_thread
+
+    try:
+        if thread.manager_dict is not None:
+            with weewx.manager.open_manager(thread.manager_dict) as dbmanager:
+                thread.process_record(record, dbmanager)
+        else:
+            thread.process_record(record, None)
+    except weewx.restx.AbortedPost as e:
+        print(f"{name}: post skipped: {e}")
+    except weewx.restx.BadLogin as e:
+        print(f"{name}: bad login: {e}", file=sys.stderr)
+    except weewx.restx.FailedPost as e:
+        print(f"{name}: upload FAILED: {e}", file=sys.stderr)
+    except Exception as e:
+        print(f"{name}: upload error: {e}", file=sys.stderr)
+        log.error("rest run: unexpected error posting to %s: %s", name, e)
+    else:
+        print(f"{name}: upload successful.")

--- a/src/weectllib/rest_cmd.py
+++ b/src/weectllib/rest_cmd.py
@@ -1,0 +1,76 @@
+#
+#    Copyright (c) 2009-2024 Tom Keffer <tkeffer@gmail.com> and Matthew Wall
+#
+#    See the file LICENSE.txt for your rights.
+#
+"""List RESTful services and force uploads on demand."""
+
+import weecfg
+import weectllib
+import weectllib.rest_actions
+from weeutil.weeutil import bcolors
+
+rest_list_usage = f"""{bcolors.BOLD}weectl rest list
+            [--config=FILENAME]{bcolors.ENDC}
+"""
+rest_run_usage = f"""  {bcolors.BOLD}weectl rest run [NAME ...]
+            [--config=FILENAME]{bcolors.ENDC}
+"""
+
+rest_usage = '\n     '.join((rest_list_usage, rest_run_usage))
+
+run_epilog = """In normal operation, WeeWX uploads to RESTful services only when a new archive
+record arrives. This command forces an upload of the most recent archive record,
+irrespective of the normal posting schedule. Use 'weectl rest list' to see the
+names of the configured services."""
+
+
+def add_subparser(subparsers):
+    rest_parser = subparsers.add_parser('rest',
+                                        usage=rest_usage,
+                                        description='List RESTful services, or force an upload',
+                                        help="List RESTful services, or force an upload.")
+    # In the following, the 'prog' argument is necessary to get a proper error message.
+    # See Python issue https://bugs.python.org/issue42297
+    action_parser = rest_parser.add_subparsers(dest='action',
+                                               prog='weectl rest',
+                                               title="Which action to take")
+
+    # ---------- Action 'list' ----------
+    list_rest_parser = action_parser.add_parser('list',
+                                                description="List all configured RESTful services",
+                                                usage=rest_list_usage,
+                                                help='List all configured RESTful services')
+    list_rest_parser.add_argument('--config',
+                                  metavar='FILENAME',
+                                  help=f'Path to configuration file. '
+                                       f'Default is "{weecfg.default_config_path}".')
+    list_rest_parser.set_defaults(func=weectllib.dispatch)
+    list_rest_parser.set_defaults(action_func=list_rest)
+
+    # ---------- Action 'run' ----------
+    run_rest_parser = action_parser.add_parser('run',
+                                               description="Force an upload to RESTful services",
+                                               usage=rest_run_usage,
+                                               help='Force an upload to RESTful services',
+                                               epilog=run_epilog)
+    run_rest_parser.add_argument('--config',
+                                 metavar='FILENAME',
+                                 help=f'Path to configuration file. '
+                                      f'Default is "{weecfg.default_config_path}".')
+    run_rest_parser.add_argument('services',
+                                 nargs="*",
+                                 metavar='NAME',
+                                 help="Services to upload to, separated by spaces. "
+                                      "Names are case insensitive. "
+                                      "If not given, all enabled services will be run.")
+    run_rest_parser.set_defaults(func=weectllib.dispatch)
+    run_rest_parser.set_defaults(action_func=run_rest)
+
+
+def list_rest(config_dict, _):
+    weectllib.rest_actions.list_rest(config_dict)
+
+
+def run_rest(config_dict, namespace):
+    weectllib.rest_actions.run_rest(config_dict, services=namespace.services)

--- a/src/weectllib/rest_cmd.py
+++ b/src/weectllib/rest_cmd.py
@@ -34,7 +34,8 @@ def add_subparser(subparsers):
     # See Python issue https://bugs.python.org/issue42297
     action_parser = rest_parser.add_subparsers(dest='action',
                                                prog='weectl rest',
-                                               title="Which action to take")
+                                               title="Which action to take",
+                                               required=True)
 
     # ---------- Action 'list' ----------
     list_rest_parser = action_parser.add_parser('list',

--- a/zensical.toml
+++ b/zensical.toml
@@ -73,6 +73,7 @@ nav = [
             { Troubleshooting = "utilities/weectl-import-troubleshoot.md" },
         ] },
         { "weectl report" = "utilities/weectl-report.md" },
+        { "weectl rest" = "utilities/weectl-rest.md" },
         { "weectl station" = "utilities/weectl-station.md" },
     ] },
     { "Hardware guide" = [


### PR DESCRIPTION
When sending data to 3rd party services / interfaces, this happens on Weewx default scheduler bi-hourly.

During setup or troubleshooting getting a data-packet every 30minutes is waaaaay too slow. A data packet should be sent at admin's command. Unfortunately `weectl` lacks such subcommand handling data sending.

This PR introduces a new command. Usage:
```text
usage: weectl rest list
            [--config=FILENAME]

       weectl rest run [NAME ...]
            [--config=FILENAME]


List RESTful services, or force an upload

options:
  -h, --help  show this help message and exit

Which action to take:
  {list,run}
    list      List all configured RESTful services
    run       Force an upload to RESTful services
```

Functionality follows other `weectl` subcommands. Admin can get a list of integrations or additionally trigger a data send on all or a selected one. This fills the need for being able to send data at admin's request.