### PR TITLE
Extension install: replace files atomically, never overwrite in place

### DIFF
--- a/src/weecfg/extension.py
+++ b/src/weecfg/extension.py
@@ -282,7 +282,25 @@ class ExtensionEngine:
                     os.makedirs(os.path.dirname(destination_path))
                 except OSError:
                     pass
-                shutil.copy(source_path, destination_path)
+                # Copy to a temporary file, then rename it into place, so
+                # that the destination is replaced atomically. Overwriting
+                # it in place would truncate it under a running weewxd,
+                # which may have the old copy open or memory-mapped (a
+                # mapped file, such as a .bsp ephemeris, kills the process
+                # with SIGBUS when truncated underneath it).
+                tmp_fd, tmp_path = tempfile.mkstemp(
+                    dir=os.path.dirname(destination_path),
+                    prefix=os.path.basename(destination_path) + '.tmp')
+                os.close(tmp_fd)
+                try:
+                    shutil.copy(source_path, tmp_path)
+                    os.replace(tmp_path, destination_path)
+                except BaseException:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+                    raise
             N += 1
 
         if self.dry_run:

--- a/src/weecfg/tests/test_config.py
+++ b/src/weecfg/tests/test_config.py
@@ -450,6 +450,35 @@ class TestExtensionInstall:
         # It should be the same as our original:
         assert test_dict == self.config_dict
 
+    @pytest.mark.skipif(sys.platform == 'win32',
+                        reason="st_ino and rename-over-open-file semantics are POSIX")
+    def test_reinstall_replaces_files_atomically(self):
+        """Installing over an existing extension must replace each file by
+        renaming a new file into place, never by overwriting it in place: a
+        running weewxd may hold the old file open or memory-mapped (a mapped
+        file, such as a .bsp ephemeris, kills the process with SIGBUS when
+        truncated underneath it)."""
+        self.engine.install_extension('./pmon.tgz', no_confirm=True)
+        installed_path = os.path.join(self.engine.root_dict['USER_DIR'], 'pmon.py')
+        with open(installed_path, 'rb') as held:
+            original = held.read()
+            ino_before = os.fstat(held.fileno()).st_ino
+            # Install again while the file is held open, as a running
+            # weewxd would hold it:
+            self.engine.install_extension('./pmon.tgz', no_confirm=True)
+            # The held file must be untouched -- same inode, full content...
+            assert os.fstat(held.fileno()).st_ino == ino_before
+            held.seek(0)
+            assert held.read() == original
+        # ... while the destination path is a new file, swapped in whole:
+        assert os.stat(installed_path).st_ino != ino_before
+        with open(installed_path, 'rb') as f:
+            assert f.read() == original
+        # No temporary files were left behind:
+        leftovers = [f for f in os.listdir(os.path.dirname(installed_path))
+                     if '.tmp' in f]
+        assert leftovers == []
+
 
 # ############# Utilities #################
 


### PR DESCRIPTION
Hi Tom,

I hit this issue today when re-installing my weewx-skyfield extension on a running weewx instance.  I now read the file into memory to guard against the issue, but thought it would be worthwhile for install to replace files atomically.  There will be no hard feelings if you don’t take the change.

Issue: weectl extension install can crash a running weewxd; replace files atomically
  
copy_files() copies each file straight onto its destination, truncating and rewriting it in place. A running weewxd holding the old file open — in particular one that has memory-mapped a large data file — dies with SIGBUS if a page fault lands in the sub-second window while the copy is in flight.
  
Observed one time in the field (Pi 5, WeeWX 5.4.0): installing the weewx-skyfield extension that bundles a 16 MB JPL .bsp ephemeris (mapped by Skyfield/jplephem) over a live weewxd killed it with code=killed, signal=BUS seconds after the install. The failure is a race.
  
Fix: copy to a temporary file in the destination directory, then os.replace() it into place. The rename is atomic and the old inode stays alive for any process still reading or mapping it, so installing over a running WeeWX can no longer disturb it. Permissions are unchanged: shutil.copy sets the source's mode on the temporary 
file, and the rename carries it over. If the copy fails, the temporary file is removed.

Testing: adds test_reinstall_replaces_files_atomically to src/weecfg/tests/test_config.py. It installs the pmon test extension, holds an installed file open (as a running weewxd would), installs again, and asserts that the held file keeps its inode and full content, that the destination path is a new inode with the new content, 
and that no temporary files are left behind. The test fails against the old shutil.copy code and passes with this change; all 18 tests in test_config.py pass.

Windows note: the new test is skipped on Windows, where st_ino and rename-over-open-file semantics differ. os.replace() over a file another process holds open can fail there with a sharing violation — but the previous in-place shutil.copy fails in that situation too, so Windows behavior is no worse than before. The mprovement applies on POSIX, where WeeWX daemons actually run.