### PR TITLE
Add a SHUTDOWN event

### DIFF
--- a/src/weewx/__init__.py
+++ b/src/weewx/__init__.py
@@ -142,6 +142,10 @@ class POST_LOOP:
     into this to access the console for things other than generating LOOP
     packet."""
 
+class SHUTDOWN:
+    """Event issued right as the engine shut downs, prior to the services shutDown method invocation. 
+    The event contains attribute 'error', a dictionary. If this shut down is due to an exception,
+    it contains the keys 'exception' and 'stacktrace', otherwise it is empty. """
 
 # =============================================================================
 #                       Service groups.

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -245,10 +245,12 @@ class StdEngine:
                 # Call the function with the event as an argument:
                 callback(event)
 
-    def shutDown(self, exception):
+    def shutDown(self, exception=None):
         """Run when an engine shutdown is requested."""
 
-        stacktrace = traceback.format_exc()
+        stacktrace = None
+        if exception:
+            stacktrace = traceback.format_exc()
         
         # Shut down all the services
         while self.service_obj:

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -248,10 +248,18 @@ class StdEngine:
     def shutDown(self, exception=None):
         """Run when an engine shutdown is requested."""
 
-        stacktrace = None
+        # Send out an event saying the engine is shutting down.
+        error = {}
         if exception:
-            stacktrace = traceback.format_exc()
-        
+            error = {
+                "exception": exception,
+                "stacktrace": traceback.format_exc()
+            }
+        try:
+            self.dispatchEvent(weewx.Event(weewx.SHUTDOWN, error=error))
+        except:
+            pass
+
         # Shut down all the services
         while self.service_obj:
             # Wrap each individual service shutdown, in case of a problem.

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -14,6 +14,7 @@ import socket
 import sys
 import threading
 import time
+import traceback
 
 # weewx imports:
 import weeutil.config
@@ -158,10 +159,10 @@ class StdEngine:
                     # Append it to the list of open services.
                     self.service_obj.append(obj)
                     log.debug("Finished loading service %s", svc)
-        except Exception:
+        except Exception as exception:
             # An exception occurred. Shut down any running services, then
             # reraise the exception.
-            self.shutDown()
+            self.shutDown(exception)
             raise
 
     def run(self):
@@ -216,10 +217,14 @@ class StdEngine:
                     # Send out an event saying the packet LOOP is done:
                     self.dispatchEvent(weewx.Event(weewx.POST_LOOP))
 
-        finally:
+        # We are catching BaseException so that we can capture the exception and pass it services via the SHUTDOWN event
+        # We will then reraise it so that weewxd can handle it.
+        # Although not the same as a finally block, this is the only way to capture the exception.
+        except BaseException as exception:
             # The main loop has exited. Shut the engine down.
             log.info("Main loop exiting. Shutting engine down.")
-            self.shutDown()
+            self.shutDown(exception)
+            raise exception
 
     def bind(self, event_type, callback):
         """Binds an event to a callback function."""
@@ -240,9 +245,11 @@ class StdEngine:
                 # Call the function with the event as an argument:
                 callback(event)
 
-    def shutDown(self):
+    def shutDown(self, exception):
         """Run when an engine shutdown is requested."""
 
+        stacktrace = traceback.format_exc()
+        
         # Shut down all the services
         while self.service_obj:
             # Wrap each individual service shutdown, in case of a problem.


### PR DESCRIPTION
This new event will pass the exception and stacktrace to extensions that are bound to the SHUTDOWN event. This will allow an event to notify more information about why WeeWX is shutting down .

For reference see, https://groups.google.com/g/weewx-development/c/lXo3-ZdPBP8/m/q1_XEHonBAAJ