### PR TITLE
`restx.py`: Use non-messaging APRS Data Type Identifier for CWOP position reports

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -1,6 +1,11 @@
 WeeWX change history
 --------------------
 
+### 5.5.n n-Month-2026
+
+Removed the APRS "messaging-capable" packet flag from `restx.py`.
+[PR #1108](https://github.com/weewx/weewx/pull/1108), by `W0CHP`.
+
 ### 5.5.0 6-Aug-2026
 
 Added the ability for services to bind to a `SHUTDOWN` event. This allows

--- a/src/weewx/restx.py
+++ b/src/weewx/restx.py
@@ -1279,7 +1279,11 @@ class CWOPThread(RESTThread):
 
         # Time:
         _time_tt = time.gmtime(record['dateTime'])
-        _time_str = time.strftime("@%d%H%Mz", _time_tt)
+        # Data Type Identifier '/' = position with timestamp, no APRS
+        # messaging. An unattended weather station cannot answer APRS
+        # messages, so it should not advertise itself as messaging-capable
+        # by using '@' (position with timestamp, WITH messaging).
+        _time_str = time.strftime("/%d%H%Mz", _time_tt)
 
         # Position:
         _lat_str = weeutil.weeutil.latlon_string(self.latitude,


### PR DESCRIPTION
`CWOPThread.get_tnc_packet()` builds the position line using `@` as the APRS Data Type Identifier. Per the APRS 1.0.1 protocol spec, `@` means _"position with timestamp, APRS messaging enabled"_, which advertises the station as capable of receiving and acknowledging APRS messages.

An unattended weewx CWOP weather station has no operator monitoring for messages and will never respond to one, so it should not identify itself as messaging-capable to the APRS-IS network. The correct DTI for a timestamped position report without messaging support is `/`.

This changes only the single DTI character; the rest of the packet format (timestamp, position, weather data extension) is unaffected.

The rationale for this PR is...
1. Proper use/implementation of the APRS spec inline with the software's _actual_ capabilities
2. When using APRS client software and filtering for messaging-capable stations, cut down on the "noise" since weewx is not messaging-capable.