### PR TITLE
Use `importlib` to load an extension's `install` module

### DIFF
--- a/src/weecfg/__init__.py
+++ b/src/weecfg/__init__.py
@@ -715,12 +715,13 @@ def get_extension_installer(extension_installer_dir):
         sys.path.insert(0, extension_installer_dir)
         try:
             # Now I can import the extension's 'install' module:
-            __import__('install')
+            install_module = importlib.import_module('install')
         except ImportError:
             raise ExtensionError("Cannot find 'install' module in %s" % extension_installer_dir)
-        install_module = sys.modules['install']
         loader = getattr(install_module, 'loader')
-        # Get rid of the module:
+        # Every extension names its installer module 'install', so it must not be left in
+        # the module cache: the next extension installed by this process would get this
+        # one's installer back instead of its own.
         sys.modules.pop('install', None)
         installer = loader()
     finally:

--- a/src/weecfg/tests/test_config.py
+++ b/src/weecfg/tests/test_config.py
@@ -320,6 +320,72 @@ class TestExtensionUtility:
                             ('/bar/baz/bin/user/bar.py', '/etc/weewx/bin/user/bar.py')]
 
 
+class TestGetExtensionInstaller:
+    """Tests of loading an extension's 'install' module."""
+
+    # A minimal extension installer. Its name is what tells one apart from another.
+    INSTALL_PY = """from setup import ExtensionInstaller
+
+
+def loader():
+    return MiniInstaller()
+
+
+class MiniInstaller(ExtensionInstaller):
+    def __init__(self):
+        super().__init__(version='1.0', name='%s')
+"""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        saved_path = list(sys.path)
+        yield
+        sys.path = saved_path
+        sys.modules.pop('install', None)
+
+    @classmethod
+    def _write_installer(cls, directory, name):
+        """Write an 'install.py' for an extension called 'name'. Returns its path."""
+        os.makedirs(directory, exist_ok=True)
+        install_path = os.path.join(directory, 'install.py')
+        with open(install_path, 'w') as fd:
+            fd.write(cls.INSTALL_PY % name)
+        return install_path
+
+    def test_get_installer(self):
+        with tempfile.TemporaryDirectory() as installer_dir:
+            expected_path = self._write_installer(installer_dir, 'alpha')
+            installer_path, installer = weecfg.get_extension_installer(installer_dir)
+            assert os.path.samefile(installer_path, expected_path)
+            assert installer['name'] == 'alpha'
+            # The module must not be left in the cache. See the next test for why.
+            assert 'install' not in sys.modules
+
+    def test_get_installer_missing(self):
+        """A directory with no 'install.py' in it raises ExtensionError."""
+        with tempfile.TemporaryDirectory() as empty_dir:
+            with pytest.raises(weecfg.ExtensionError):
+                weecfg.get_extension_installer(empty_dir)
+
+    def test_get_installer_two_extensions(self):
+        """Every extension calls its installer module 'install'. If the module were
+        left in sys.modules, the second extension loaded by a process would get the
+        first one's installer back instead of its own."""
+        with tempfile.TemporaryDirectory() as parent:
+            alpha_dir = os.path.join(parent, 'alpha')
+            beta_dir = os.path.join(parent, 'beta')
+            alpha_expected = self._write_installer(alpha_dir, 'alpha')
+            beta_expected = self._write_installer(beta_dir, 'beta')
+
+            alpha_path, alpha = weecfg.get_extension_installer(alpha_dir)
+            beta_path, beta = weecfg.get_extension_installer(beta_dir)
+
+            assert alpha['name'] == 'alpha'
+            assert beta['name'] == 'beta'
+            assert os.path.samefile(alpha_path, alpha_expected)
+            assert os.path.samefile(beta_path, beta_expected)
+
+
 class TestExtensionInstall:
     """Tests of the extension installer."""
 

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -8,10 +8,10 @@
 
 # Python imports
 import gc
+import importlib
 import logging
 import math
 import socket
-import importlib
 import threading
 import time
 import traceback


### PR DESCRIPTION
Closes #1109. Against `master`, as this is a fix rather than a feature.

Do you want a change log entry? Your own commit for the `engine.py` half did not get
one, so I left it out.

## What

3a7223de took care of `engine.py` on the day the issue was opened. The one in
`weecfg.get_extension_installer()` was the last `__import__` in the tree; there are now
none.

`importlib.import_module()` returns the module, so the `sys.modules['install']` lookup
that followed the call goes away -- the same shape you gave `weedb` in e129a14d.

What has to stay is the `sys.modules.pop()`. Every extension calls its installer module
`install`, so leaving it in the cache hands the next extension installed by the same
process the previous one's installer. The comment there said only "Get rid of the
module", which does not say why it matters. It does now.

`get_extension_installer()` had no tests of its own. There are three now: an ordinary
load, a directory with no `install.py`, and two extensions in a row. Removing the
`pop()` fails two of them -- the second extension comes back holding the first one's
installer.

The second commit is cosmetic. 3a7223de replaced `import sys` with `import importlib`
where it stood, which left it between `socket` and `threading` in an otherwise
alphabetical block. Drop that commit if you would rather not have it.

Nothing else changes: same exception on a missing `install.py`, same return value, no
new dependency.

## Testing

Full suite, one file per run the way the makefile does it, against `origin/master` and
against this branch. Ubuntu 24.04, Python 3.12, MariaDB 10.11, `make test-setup-ci`.

|                 | passed | failed |
|-----------------|--------|--------|
| `origin/master` | 374    | 0      |
| this branch     | 377    | 0      |

The three extra are the new tests. The output is otherwise identical line for line.

`vermin --target=3.7` reports the same minimum before and after (3.6).

