### PR TITLE
Store text files with LF, whatever the platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Store every text file with LF in the repository, and check it out with LF on
+# every platform.
+#
+# Without this, the line endings a contributor gets depend on their local
+# core.autocrlf setting. On Windows the default hands out CRLF, which is fine
+# for editing but not for files that are read by something other than an editor:
+# a shell script with CRLF fails under dash with "Syntax error: end of file
+# unexpected", and a bash completion with CRLF registers itself for the command
+# name with a trailing carriage return, so it silently does nothing.
+* text=auto eol=lf
+
+# Binary files, so git never inspects or rewrites their contents.
+*.gif   binary
+*.ico   binary
+*.jpg   binary
+*.png   binary
+*.xcf   binary
+*.tar   binary
+*.tgz   binary
+*.zip   binary
+*.ttf   binary
+*.woff  binary
+*.woff2 binary


### PR DESCRIPTION
Against `master`, as this is a fix. One new file, nothing else touched.

**Nothing in the tree changes.** All 511 text files in `HEAD` are already LF, so
`git add --renormalize .` against this commit is a no-op. The file only stops them
arriving as CRLF on someone's checkout.

## Why

Without a `.gitattributes`, the endings a contributor gets depend on their local
`core.autocrlf`, and on Windows the default hands out CRLF. That is harmless for
editing, but not for the files here that something other than an editor reads. Two from
this week, both on a stock Windows checkout:

- `src/weedb/tests/setup_mysql.sh` fails under `dash` with `Syntax error: end of file
  unexpected`. The `if ... then` is fine; the `\r` is not. `make test-setup` is
  unusable until you strip it.
- A bash completion file with CRLF runs `complete -F _weectl weectl\r`, registering the
  completion for a command named `weectl` plus a carriage return. It silently does
  nothing, and nothing tells you why. That one cost me an hour while testing #1110.

Neither is a bug in those files. They are correct in the repository; the checkout
rewrites them.

## What it says

`* text=auto eol=lf` stores text as LF and checks it out as LF everywhere. Then an explicit
`binary` for the extensions actually present in the tree (`png`, `gif`, `jpg`, `ico`,
`xcf`, `tar`, `tgz`, `zip`, `ttf`, `woff`, `woff2`), so git never inspects them, rather
than relying on the NUL-byte heuristic.

Windows editors have handled LF for years, so this costs contributors on that platform
nothing.

It works as a local setting too (`git config core.autocrlf input`), but then every
Windows contributor has to know to do it. That is how both of the above happened.


