### PR TITLE
Say so when a Vantage logger's memory is corrupt

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,10 @@ WeeWX change history
 
 ### 5.5.n n-Month-2026
 
+Say so in the log when a Vantage logger returns far fewer archive records than it
+said it would, which is what corrupt logger memory looks like, and link to the fix.
+Fixes [Issue #1105](https://github.com/weewx/weewx/issues/1105).
+
 Saving the configuration file no longer changes its mode or ownership. Under a
 package installation, `weectl extension install`, `weectl extension uninstall`,
 `weectl station reconfigure` and `weectl station upgrade` were leaving

--- a/src/weewx/drivers/tests/test_vantage.py
+++ b/src/weewx/drivers/tests/test_vantage.py
@@ -1,0 +1,196 @@
+#
+#    Copyright (c) 2026 the WeeWX contributors
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test how the Vantage driver downloads archive records.
+
+These tests stand a fake serial port in front of the driver, so they need no
+hardware. What they are mostly about is telling apart the two reasons the
+download loop can stop early: reaching the end of the data, which is normal, and
+a logger whose memory has gone bad, which is not.
+"""
+import struct
+import time
+import unittest
+from unittest.mock import patch
+
+import weewx.drivers.vantage
+from weewx.drivers.vantage import Vantage
+
+# Midnight, 1-Jan-2024, local time
+START_TS = int(time.mktime((2024, 1, 1, 0, 0, 0, 0, 0, -1)))
+INTERVAL = 300
+
+
+def make_record(ts):
+    """Build one 52 byte Rev B archive record carrying the given timestamp.
+
+    Every other field is left at zero, which the driver decodes without
+    complaint. Only the date and time stamp, and the record type in byte 42,
+    matter here.
+    """
+    tt = time.localtime(ts)
+    date_stamp = tt.tm_mday + (tt.tm_mon << 5) + ((tt.tm_year - 2000) << 9)
+    time_stamp = tt.tm_hour * 100 + tt.tm_min
+    record = bytearray(52)
+    record[0:4] = struct.pack("<HH", date_stamp, time_stamp)
+    record[42] = 0x00  # Rev B
+    return bytes(record)
+
+
+def make_page(records):
+    """Assemble a 267 byte archive page out of up to five records.
+
+    Layout: one sequence byte, five 52 byte records, four unused bytes, then the
+    two byte CRC that get_data_with_crc16() leaves on the end.
+    """
+    assert len(records) <= 5
+    page = bytearray(267)
+    for i, record in enumerate(records):
+        page[1 + 52 * i:53 + 52 * i] = record
+    return bytes(page)
+
+
+def unused_record():
+    """A record the console has never written to. Reads as 0xff throughout."""
+    return b'\xff' * 52
+
+
+class FakePort:
+    """Stands in for VantageSerialWrapper, handing out canned responses.
+
+    It answers the six byte DMPAFT reply with whatever page count it was given,
+    then hands over the pages one at a time. The page count is deliberately not
+    tied to the number of pages supplied: a console that says one thing and does
+    another is exactly what is being tested.
+    """
+
+    def __init__(self, npages, start_index, pages):
+        self.npages = npages
+        self.start_index = start_index
+        self.pages = list(pages)
+        self.pages_read = 0
+
+    def wakeup_console(self, max_tries=3):
+        pass
+
+    def send_data(self, data):
+        pass
+
+    def send_data_with_crc16(self, data, max_tries=3):
+        pass
+
+    def get_data_with_crc16(self, nbytes, prompt=None, max_tries=3):
+        if nbytes == 6:
+            # The reply to DMPAFT: page count, starting index, then the CRC.
+            return struct.pack("<HH", self.npages, self.start_index) + b'\x00\x00'
+        self.pages_read += 1
+        return self.pages.pop(0)
+
+
+def make_station(port):
+    """A Vantage object with just enough filled in to decode archive records.
+
+    Built without __init__, which would go looking for a console.
+    """
+    station = Vantage.__new__(Vantage)
+    station.port = port
+    station.max_tries = 3
+    station.max_dst_jump = 7200
+    station.archive_interval_ = INTERVAL  # what the archive_interval property reads
+    station.rain_bucket_type = 0
+    station.model_type = 2
+    station.iss_id = 1
+    station.hardware_type = 16
+    return station
+
+
+def rendered(mock_log):
+    """The log calls as logging would render them.
+
+    Indexed rather than .args, which is Python 3.8 and later.
+    """
+    return "\n".join(c[0][0] % c[0][1:] for c in mock_log.call_args_list)
+
+
+class ArchiveDownloadTest(unittest.TestCase):
+
+    def test_full_pages(self):
+        """A console that delivers everything it promised."""
+        timestamps = [START_TS + i * INTERVAL for i in range(10)]
+        records = [make_record(ts) for ts in timestamps]
+        port = FakePort(2, 0, [make_page(records[0:5]), make_page(records[5:10])])
+        station = make_station(port)
+
+        with patch.object(weewx.drivers.vantage.log, 'error') as mock_error:
+            got = list(station.genDavisArchiveRecords(START_TS - INTERVAL))
+
+        self.assertEqual([r['dateTime'] for r in got], timestamps)
+        mock_error.assert_not_called()
+
+    def test_wrap_around_within_final_page(self):
+        """The normal way a download ends.
+
+        The logger memory wraps part way through the last page, so the records
+        after the wrap are old ones and the loop stops. Some of the promised
+        records are therefore never returned, and that is not an error.
+        """
+        timestamps = [START_TS + i * INTERVAL for i in range(7)]
+        records = [make_record(ts) for ts in timestamps]
+        # The third record of the second page is from two weeks ago: the wrap.
+        stale = make_record(START_TS - 14 * 24 * 3600)
+        port = FakePort(2, 0, [make_page(records[0:5]),
+                               make_page(records[5:7] + [stale] * 3)])
+        station = make_station(port)
+
+        with patch.object(weewx.drivers.vantage.log, 'error') as mock_error:
+            got = list(station.genDavisArchiveRecords(START_TS - INTERVAL))
+
+        self.assertEqual([r['dateTime'] for r in got], timestamps)
+        mock_error.assert_not_called()
+
+    def test_corrupt_memory(self):
+        """Corrupt logger memory, in the shape the wiki describes.
+
+        The console announces many pages, then the very first record it sends is
+        already older than the time that was asked for. Nothing is returned, and
+        without a message that is hard to tell from "there was no new data".
+        """
+        stale = make_record(START_TS - 14 * 24 * 3600)
+        port = FakePort(45, 1, [make_page([stale] * 5)])
+        station = make_station(port)
+
+        with patch.object(weewx.drivers.vantage.log, 'error') as mock_error:
+            got = list(station.genDavisArchiveRecords(START_TS))
+
+        self.assertEqual(got, [])
+        text = rendered(mock_error)
+        # It says how far apart the promise and the delivery were...
+        self.assertIn("promised 224 archive records, but returned 0", text)
+        # ... and where to go next.
+        self.assertIn(weewx.drivers.vantage.CORRUPT_MEMORY_URL, text)
+
+    def test_unused_records_are_not_corruption(self):
+        """A logger that was cleared recently.
+
+        Its pages hold records that have never been written, which read as 0xff.
+        The loop stops there with most of the promised records outstanding, but
+        the memory is fine: this is what a station looks like just after
+        'weectl device --clear-memory'. Complaining here would send people
+        chasing a fix they had only just applied.
+        """
+        timestamps = [START_TS + i * INTERVAL for i in range(2)]
+        records = [make_record(ts) for ts in timestamps]
+        port = FakePort(20, 0, [make_page(records + [unused_record()] * 3)])
+        station = make_station(port)
+
+        with patch.object(weewx.drivers.vantage.log, 'error') as mock_error:
+            got = list(station.genDavisArchiveRecords(START_TS - INTERVAL))
+
+        self.assertEqual([r['dateTime'] for r in got], timestamps)
+        mock_error.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/weewx/drivers/vantage.py
+++ b/src/weewx/drivers/vantage.py
@@ -24,6 +24,10 @@ log = logging.getLogger(__name__)
 DRIVER_NAME = 'Vantage'
 DRIVER_VERSION = '3.6.3'
 
+# Where to send someone whose logger memory has gone bad.
+CORRUPT_MEMORY_URL = ("https://github.com/weewx/weewx/wiki/"
+                      "Troubleshooting-the-Davis-Vantage-station#corrupt-station-memory")
+
 int2byte = struct.Struct(">B").pack
 
 
@@ -680,6 +684,12 @@ class Vantage(weewx.drivers.AbstractDevice):
         _npages, _start_index = struct.unpack("<HH", _buffer[:4])
         log.debug("Retrieving %d page(s); starting index= %d", _npages, _start_index)
 
+        # The console has just said how many records it is about to send. Count them as
+        # they arrive, so we can tell a normal end of data from a logger whose memory
+        # has gone bad. See the check further down.
+        _expected = _npages * 5 - _start_index
+        _returned = 0
+
         # Cycle through the pages...
         for ipage in range(_npages):
             # ... get a page of archive data
@@ -703,14 +713,27 @@ class Vantage(weewx.drivers.AbstractDevice):
                 # signal that we are done. 
                 if _record['dateTime'] is None \
                         or _record['dateTime'] <= _last_good_ts - self.max_dst_jump:
-                    # The time stamp is declining. We're done.
+                    # The time stamp is declining. Normally this is how we know we have
+                    # reached the end: the logger memory wraps around, so the record we
+                    # are looking at is an old one.
                     log.debug("DMPAFT complete: page timestamp %s less than final timestamp %s",
                               weeutil.weeutil.timestamp_to_string(_record['dateTime']),
                               weeutil.weeutil.timestamp_to_string(_last_good_ts))
+                    # But if that happens while more than a page of the promised records
+                    # is still outstanding, the console was describing data it does not
+                    # actually hold. Up to a page can be left over legitimately, because
+                    # the wrap-around lands somewhere inside the final page.
+                    if _expected - _returned > 5:
+                        log.error("Logger promised %d archive records, but returned %d "
+                                  "before its timestamps went backwards.",
+                                  _expected, _returned)
+                        log.error("This is what corrupt logger memory looks like. "
+                                  "For how to fix it, see %s", CORRUPT_MEMORY_URL)
                     log.debug("Catch up complete.")
                     return
                 # Set the last time to the current time, and yield the packet
                 _last_good_ts = _record['dateTime']
+                _returned += 1
                 yield _record
 
             # The starting index for pages other than the first is always zero


### PR DESCRIPTION
Closes #1105. Against `master`, alongside `314882d6` ("Better error message when unable
to determine hardware type"), which is the same kind of change.

**One question, on the threshold.** The issue says "if the counter is non-zero when
exiting the loop the memory must be corrupt". Taken literally, that fires on healthy
stations. The normal end of a download is also a declining timestamp: the memory wraps
around inside the final page, so up to five of the promised records are never sent. I
therefore log only when more than a page is still outstanding. That is precisely when
the console described pages it could not fill.

## What it does

The console says up front how many records it is about to send, i.e. `_npages * 5 -
_start_index`. The loop now counts them and compares on the way out. When the count
falls short by more than a page:

```
Logger promised 224 archive records, but returned 0 before its timestamps went backwards.
This is what corrupt logger memory looks like. For how to fix it, see
https://github.com/weewx/weewx/wiki/Troubleshooting-the-Davis-Vantage-station#corrupt-station-memory
```

The link goes to the wiki because the fix is several steps, and it is already written up
there: pull the power and batteries, else `weectl device --dump` then `--clear-memory`,
else replace the logger or fall back to `record_generation = software`.

The other early exit, on an unwritten `0xff` record, is deliberately left alone. That is
a freshly cleared logger. Warning there would send someone chasing a fix they had just
applied.

## Testing

No hardware needed. `src/weewx/drivers/tests/test_vantage.py` puts a fake port in front
of the driver and feeds it canned DMPAFT replies and pages. The failure reproduces from
a checkout:

| case | result |
|---|---|
| Two full pages, ten records | all ten returned, nothing logged |
| Wrap inside the final page | seven returned, nothing logged |
| 45 pages promised, first record already stale | nothing returned, message logged with the link |
| Just-cleared logger, `0xff` records | two returned, nothing logged |

The third case is the log from the wiki page, in the same shape. `Retrieving 45 page(s);
starting index= 1`, followed straight away by a timestamp from two weeks earlier.

Both mutations of the check fail the suite, so the tests are not decorative:

- threshold `> 0` instead of `> 5`: the wrap-around case fails, i.e. the false alarm
  described above
- check removed: the corruption case fails

Full suite: 378 passed, no failures. That is 374 before, plus these four.
`vermin --target=3.7` reports the same minimum as before.

There is no precedent for a URL in a log message anywhere in `src/`. Should the message
name the wiki page without the URL instead?

