### PR TITLE
Document how an extension adds translations to a skin

### DIFF
--- a/docs_src/custom/extensions.md
+++ b/docs_src/custom/extensions.md
@@ -113,6 +113,57 @@ Once an extension has been packaged, it can be installed using `weectl`:
 
     weectl extension install EXTENSION-LOCATION
 
+## Adding translations to someone else's skin
+
+An extension that adds a widget to an existing skin brings text of its own. Do
+not put the translations in the skin's own language files: those edits are lost
+the next time the user upgrades WeeWX or reinstalls the skin.
+
+Instead, put the translations in a subdirectory of the skin's `lang` directory.
+Any subdirectory whose name starts with `lang` is searched, and what it holds
+is merged into the language the report is being run in. So an extension called
+`climate`, which adds a widget to the *Seasons* skin, would install
+
+```
+skins
+└── Seasons
+    └── lang
+        └── lang-climate
+            ├── cz.conf
+            ├── de.conf
+            ├── es.conf
+            └── fr.conf
+```
+
+leaving `skins/Seasons/lang/de.conf` and its siblings untouched. Each file
+holds only the phrases the extension itself introduces:
+
+``` ini
+[Texts]
+    "Record High" = "Rekordhoch"
+```
+
+* The name of the subdirectory must *begin* with `lang`. `lang-climate`,
+  `lang_climate` and `langclimate` are all found; `climate-lang` is not.
+
+* Several extensions can do this at once. Each gets its own subdirectory, and
+  all of them are merged.
+
+* Where an extension and the skin give the same phrase, the extension wins.
+  Better not to depend on that.
+
+* A missing translation is not an error. If the extension ships `de.conf` but
+  no `th.conf`, a station running `lang=th` shows the phrase untranslated, just
+  as for any other entry missing from `[Texts]`.
+
+For how a skin is internationalized in the first place, see
+*[Localization](localization.md)*.
+
+!!! Note
+    Searching the subdirectories was added in WeeWX v5.3. An extension that
+    relies on it will not translate on earlier versions, although it will
+    otherwise work.
+
 ## Default values
 
 Whenever possible, an extension should *just work*, with a minimum of input from


### PR DESCRIPTION
Covers what is left of #1051. Against `master`, where the other documentation commits
are. One new section in `custom/extensions.md`, nothing else touched.

**On the issue itself:** the body asked for the extra arguments feature, and you
documented that in `05a0b18` back in February. What is still outstanding is the
[comment you added on 8-Feb](https://github.com/weewx/weewx/issues/1051#issuecomment-3868445526),
i.e. extensions supplying their own translations to a skin. This PR is that part, so the
issue can be closed once it lands. It went stale this morning, which is what prompted me
to look.

## Why it needs saying

The recursive search of a skin's `lang` directory arrived in 5.3.0 and is in the change
log, but appears nowhere in the documentation. I checked `docs_src` on both branches,
the wiki, and the published 5.5 docs. An extension author has no way to find it.

The alternative they will reach for instead is editing the skin's own `de.conf`, which
is lost on the next upgrade. That is the mistake the feature exists to prevent, so it
seems worth a section rather than a change log line.

## What it says

Where the translations go, using your `weewx-climate` layout as the example, and four
things that are not obvious from the outside. I checked each against
`reportengine.get_lang_dict()` rather than reading the source and guessing:

| | |
|---|---|
| Subdirectory name must **begin** with `lang` | `lang-climate` found, `climate-lang` not |
| Several extensions at once | each in its own subdirectory, all merged |
| Extension and skin define the same phrase | the extension wins |
| Extension ships `de.conf` but no `th.conf` | `lang=th` shows the phrase untranslated, no error |

The third one surprised me, and the section says plainly that it is best avoided.

A note records that this needs 5.3 or later, so an author knows what they are asking of
their users.

`python -m zensical build` reports no issues, and the link to *Localization* resolves in
the built HTML.


