### PR TITLE
Stop using the datetime calls Python 3.12 deprecates

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -13,6 +13,11 @@ Say so in the log when a Vantage logger returns far fewer archive records than i
 said it would, which is what corrupt logger memory looks like, and link to the fix.
 Fixes [Issue #1105](https://github.com/weewx/weewx/issues/1105).
 
+The FineOffset USB driver no longer calls `datetime.utcnow()` or
+`datetime.utcfromtimestamp()`, which Python 3.12 deprecates. Its datetimes are now
+aware UTC. Fixes [Issue #1052](https://github.com/weewx/weewx/issues/1052).
+[PR #1117](https://github.com/weewx/weewx/pull/1117).
+
 Saving the configuration file no longer changes its mode or ownership. Under a
 package installation, `weectl extension install`, `weectl extension uninstall`,
 `weectl station reconfigure` and `weectl station upgrade` were leaving

--- a/src/weewx/drivers/fousb.py
+++ b/src/weewx/drivers/fousb.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2024 Matthew Wall
+# Copyright 2012-2026 Matthew Wall
 # See the file LICENSE.txt for your full rights.
 #
 # Thanks to Jim Easterbrook for pywws.  This implementation includes
@@ -226,15 +226,18 @@ import weewx.wxformulas
 log = logging.getLogger(__name__)
 
 DRIVER_NAME = 'FineOffsetUSB'
-DRIVER_VERSION = '1.3'
+DRIVER_VERSION = '1.4'
 
-# Every datetime in this driver is aware UTC. None of them leave it: loop packets are
-# rebuilt by pywws2weewx() with a dateTime of its own, and genArchiveRecords() converts
-# back to epoch seconds before yielding. So the representation is the driver's to
-# choose, and the one that carries its time zone is the one that cannot be mixed up:
-# sync() compares and subtracts the two bounds below against times read from the
-# station, and doing that across a naive and an aware value raises "can't subtract
-# offset-naive and offset-aware datetimes".
+# Every datetime that carries an observation time is aware UTC. None of them leave the
+# driver: loop packets are rebuilt by pywws2weewx() with a dateTime of its own, and
+# genArchiveRecords() converts back to epoch seconds before yielding. So the
+# representation is the driver's to choose, and the one that carries its time zone is
+# the one that cannot be mixed up: sync() compares and subtracts the two bounds below
+# against times read from the station, and doing that across a naive and an aware value
+# raises "can't subtract offset-naive and offset-aware datetimes".
+#
+# The station's own clock is local wall clock time, so set_clock() and the configurator
+# keep naive local datetimes on purpose.
 UTC = datetime.timezone.utc
 DT_MIN = datetime.datetime.min.replace(tzinfo=UTC)
 DT_MAX = datetime.datetime.max.replace(tzinfo=UTC)

--- a/src/weewx/drivers/fousb.py
+++ b/src/weewx/drivers/fousb.py
@@ -228,6 +228,17 @@ log = logging.getLogger(__name__)
 DRIVER_NAME = 'FineOffsetUSB'
 DRIVER_VERSION = '1.3'
 
+# Every datetime in this driver is aware UTC. None of them leave it: loop packets are
+# rebuilt by pywws2weewx() with a dateTime of its own, and genArchiveRecords() converts
+# back to epoch seconds before yielding. So the representation is the driver's to
+# choose, and the one that carries its time zone is the one that cannot be mixed up:
+# sync() compares and subtracts the two bounds below against times read from the
+# station, and doing that across a naive and an aware value raises "can't subtract
+# offset-naive and offset-aware datetimes".
+UTC = datetime.timezone.utc
+DT_MIN = datetime.datetime.min.replace(tzinfo=UTC)
+DT_MAX = datetime.datetime.max.replace(tzinfo=UTC)
+
 def loader(config_dict, engine):
     return FineOffsetUSB(**config_dict[DRIVER_NAME])
 
@@ -1093,11 +1104,8 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
         """
         records = self.get_records(since_ts)
         log.debug('found %d archive records' % len(records))
-        epoch = datetime.datetime.utcfromtimestamp(0)
         for r in records:
-            delta = r['datetime'] - epoch
-            # FIXME: deal with daylight saving corner case
-            ts = delta.days * 86400 + delta.seconds
+            ts = int(r['datetime'].timestamp())
             data = pywws2weewx(r['data'], ts,
                                self._last_rain_arc, self._last_rain_ts_arc,
                                self.max_rain_rate)
@@ -1292,10 +1300,10 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                 if fixed_block['data_count'] is None:
                     raise weewx.WeeWxIOError('invalid data_count in get_records')
                 if since_ts:
-                    dt = datetime.datetime.utcfromtimestamp(since_ts)
+                    dt = datetime.datetime.fromtimestamp(since_ts, UTC)
                     dt += datetime.timedelta(seconds=fixed_block['read_period']*30)
                 else:
-                    dt = datetime.datetime.min
+                    dt = DT_MIN
                 max_count = fixed_block['data_count'] - 1
                 if num_rec == 0 or num_rec > max_count:
                     num_rec = max_count
@@ -1346,15 +1354,15 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
             else:
                 quality = 0
         log.info('synchronising to the weather station (quality=%d)' % quality)
-        range_hi = datetime.datetime.max
-        range_lo = datetime.datetime.min
+        range_hi = DT_MAX
+        range_lo = DT_MIN
         ptr = self.current_pos()
         data = self.get_data(ptr, unbuffered=True)
         last_delay = data['delay']
         if last_delay is None or last_delay == 0:
-            prev_date = datetime.datetime.min
+            prev_date = DT_MIN
         else:
-            prev_date = datetime.datetime.utcnow()
+            prev_date = datetime.datetime.now(UTC)
         maxcount = 10
         count = 0
         for data, last_ptr, logged in self.live_data(logged_only=(quality>1)):
@@ -1369,7 +1377,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                     raise weewx.WeeWxIOError('repeated invalid delay while synchronising')
                 continue
             if quality < 2 and self._station_clock:
-                err = last_date - datetime.datetime.fromtimestamp(self._station_clock)
+                err = last_date - datetime.datetime.fromtimestamp(self._station_clock, UTC)
                 last_date -= datetime.timedelta(minutes=data['delay'],
                                                 seconds=err.seconds % 60)
                 log.debug('log timestamp is %s' % last_date.strftime('%H:%M:%S'))
@@ -1516,7 +1524,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                     while data_time > next_live + live_interval:
                         log.debug('missed interval')
                         next_live += live_interval
-                    result['idx'] = datetime.datetime.utcfromtimestamp(int(next_live))
+                    result['idx'] = datetime.datetime.fromtimestamp(int(next_live), UTC)
                     next_live += live_interval
                     yield result, old_ptr, False
                 old_data = new_data
@@ -1554,7 +1562,7 @@ class FineOffsetUSB(weewx.drivers.AbstractDevice):
                     next_log = None
                     self._station_clock = None
                 if next_log:
-                    result['idx'] = datetime.datetime.utcfromtimestamp(int(next_log))
+                    result['idx'] = datetime.datetime.fromtimestamp(int(next_log), UTC)
                     next_log += log_interval
                     yield result, old_ptr, True
                 if new_ptr != self.inc_ptr(old_ptr):

--- a/src/weewx/drivers/tests/test_fousb.py
+++ b/src/weewx/drivers/tests/test_fousb.py
@@ -1,0 +1,113 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test the datetimes the FineOffset USB driver works with.
+
+The driver uses aware UTC throughout. An earlier attempt at dropping the
+deprecated datetime calls made four of its values aware and left three of them
+naive, which broke synchronisation with "can't subtract offset-naive and
+offset-aware datetimes" and had to be reverted (commit 2202248b). These tests
+cover the arithmetic that failed then, and the conversion back to epoch seconds
+that genArchiveRecords() does.
+"""
+import datetime
+import os
+import time
+import unittest
+
+from weewx.drivers.fousb import DT_MAX, DT_MIN, UTC, FineOffsetUSB
+
+# Neither UTC nor free of daylight saving, so a conversion that went through
+# local time would show up in the timestamps below.
+os.environ['TZ'] = 'America/Los_Angeles'
+time.tzset()
+
+
+def make_station(records):
+    """A FineOffsetUSB object with just enough filled in to yield archive records.
+
+    Built without __init__, which would go looking for a USB device.
+    """
+    station = FineOffsetUSB.__new__(FineOffsetUSB)
+    station._last_rain_arc = None
+    station._last_rain_ts_arc = None
+    station.max_rain_rate = 10
+    station.get_records = lambda since_ts: records
+    return station
+
+
+def record(dt):
+    """One entry of the kind get_records() returns, carrying nothing but its time."""
+    return {'datetime': dt, 'data': {}, 'interval': 5, 'ptr': 0x0100}
+
+
+def make_syncing_station(idx, delay=1):
+    """A FineOffsetUSB object whose live_data() yields one packet, then stops.
+
+    One packet is enough to reach the break in sync(): with the delay unchanged
+    from the one get_data() reported, the estimate lands inside 15 seconds on the
+    first pass through the loop.
+    """
+    packet = {'idx': idx, 'delay': delay}
+    station = FineOffsetUSB.__new__(FineOffsetUSB)
+    station._station_clock = None
+    station.data_format = '1080'  # what dec_ptr() steps by
+    station.current_pos = lambda: 0x0100
+    station.get_data = lambda ptr, unbuffered=False: packet
+    station.live_data = lambda logged_only=False: iter([(packet, 0x0100, False)])
+    return station
+
+
+class ArchiveTimestampTest(unittest.TestCase):
+
+    def test_known_value(self):
+        """genArchiveRecords() yields the epoch time of the record's datetime."""
+        station = make_station([record(datetime.datetime(2009, 2, 13, 23, 31, 30,
+                                                         tzinfo=UTC))])
+        self.assertEqual([r['dateTime'] for r in station.genArchiveRecords(0)],
+                         [1234567890])
+
+    def test_daylight_saving_boundary(self):
+        """The local hour that comes round twice still gives two timestamps.
+
+        Daylight saving ends in America/Los_Angeles on 1-Nov-2026, so 01:30 happens
+        twice there. These two records are an hour apart in UTC, and that is the
+        difference that has to reach the archive.
+        """
+        first = datetime.datetime(2026, 11, 1, 8, 30, tzinfo=UTC)
+        station = make_station([record(first),
+                                record(first + datetime.timedelta(hours=1))])
+        self.assertEqual([r['dateTime'] for r in station.genArchiveRecords(0)],
+                         [1793521800, 1793525400])
+
+
+class SyncBoundsTest(unittest.TestCase):
+
+    def test_bounds_carry_utc(self):
+        """The two bounds sync() starts out with are aware, and still the extremes."""
+        self.assertEqual(DT_MIN.tzinfo, UTC)
+        self.assertEqual(DT_MAX.tzinfo, UTC)
+        self.assertEqual(DT_MIN.replace(tzinfo=None), datetime.datetime.min)
+        self.assertEqual(DT_MAX.replace(tzinfo=None), datetime.datetime.max)
+
+    def test_sync_estimates_from_the_bounds(self):
+        """The estimate sync() arrives at, over the comparisons the revert was about.
+
+        The packet is 60 seconds old and its delay is unchanged, which puts the
+        window 108 to 120 seconds back, so the estimate is 114. Getting there means
+        comparing against both bounds and subtracting one datetime from another,
+        which is where a naive value among the aware ones raised TypeError.
+        """
+        idx = datetime.datetime.fromtimestamp(1234567890, UTC)
+        station = make_syncing_station(idx)
+
+        last_date = station.sync(quality=0)[0]
+
+        self.assertEqual(last_date, idx - datetime.timedelta(seconds=114))
+        self.assertEqual(last_date.tzinfo, UTC)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #1052. Against `master`, as this is a fix.

The FineOffset driver calls `datetime.utcfromtimestamp()` four times and
`datetime.utcnow()` once. Both are deprecated as of 3.12, and a grep over `src/`
finds them nowhere else. Nothing else in the driver trips 3.12 up: it compiles
with no warning, and the PyUSB 0.4 style calls it makes, i.e. `usb.busses()`,
`dev.deviceClass` and `devh.controlMsg()`, are all still present in PyUSB 1.3.1.

**This was tried once before and reverted.** `2d789431` replaced the four
`utcfromtimestamp()` calls with `fromtimestamp(x, timezone.utc)`. You reverted it
in `2202248b`, because it produced "can't subtract offset-naive and offset-aware
datetimes". The reason is in that diff: those four became aware, while
`datetime.min`, `datetime.max` and `utcnow()` in the same function stayed naive,
and `sync()` subtracts and compares across all of them.

This PR makes the rest aware as well. No datetime leaves the driver, i.e. loop
packets are rebuilt by `pywws2weewx()` with a `dateTime` of its own, and
`genArchiveRecords()` converts back to epoch seconds before yielding. So the
representation is the driver's to choose, and aware UTC is the one that cannot be
mixed up.

Two of the changes are more than a change of representation:

- The station clock comparison in `sync()` was subtracting a naive local datetime
  from a naive UTC one. It now subtracts two UTC values. What it computes is
  unchanged, because only `err.seconds % 60` is read and every zone offset is a
  whole number of minutes.
- `genArchiveRecords()` drops its hand-rolled epoch arithmetic, and with it the
  daylight saving FIXME beside it. `timestamp()` on an aware datetime does no
  local conversion.

`set_clock()` and the two `now()` calls in the configurator are unchanged. The
station keeps wall clock local time.

## Visible differences

Four places print a whole datetime and gain a `+00:00` suffix: the "get %d
records since" debug line, the invalid-data error in `get_records()`, the
"synchronised to %s for ptr" debug line at the end of `sync()`, and the
`weectl device --history` output. That matches what the docstrings say those
values are. The `%H:%M:%S` log lines are unchanged.

## Testing

`src/weewx/drivers/tests/test_fousb.py` covers the epoch conversion in
`genArchiveRecords()`, including the local hour that comes round twice when
daylight saving ends, and the estimate `sync()` arrives at over both bounds.
Making the bounds naive again fails with "can't compare offset-naive and
offset-aware datetimes", i.e. the 2023 error.

Full suite: 389 passed on 3.7 and on 3.14, no failures. `vermin --target=3.7`
reports the same minimum as before.

I have no FineOffset hardware. `live_data()` is stubbed in the sync test, so what
it reads off the USB device is not exercised.
