### PR TITLE
Keep the configuration file's mode and ownership when saving it

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,12 @@ WeeWX change history
 
 ### 5.5.n n-Month-2026
 
+Saving the configuration file no longer changes its mode or ownership. Under a
+package installation, `weectl extension install`, `weectl extension uninstall`,
+`weectl station reconfigure` and `weectl station upgrade` were leaving
+`weewx.conf` as `root:weewx 0644` instead of `weewx:weewx 0660`, so the `weewx`
+user could no longer edit it and the passwords in it became world-readable.
+
 Removed the APRS "messaging-capable" packet flag from `restx.py`.
 [PR #1108](https://github.com/weewx/weewx/pull/1108), by `W0CHP`.
 

--- a/src/weecfg/__init__.py
+++ b/src/weecfg/__init__.py
@@ -10,6 +10,7 @@ import importlib
 import os.path
 import pkgutil
 import shutil
+import stat
 import sys
 import tempfile
 
@@ -224,6 +225,13 @@ def save(config_dict, config_path, backup=False):
     # Check to see if the file exists, and we are supposed to make a backup:
     if os.path.exists(config_path) and backup:
 
+        # Note how the file looks before it is moved aside. The copy further down
+        # creates a new file, which would otherwise take its mode from the caller's
+        # umask and its ownership from whoever is running. After a package install
+        # that means root:root 0644 in place of weewx:weewx 0660, and the 'weewx'
+        # user can no longer edit its own configuration.
+        old_stat = os.stat(config_path)
+
         # Yes. We'll have to back it up.
         backup_path = weeutil.weeutil.move_with_timestamp(config_path)
 
@@ -235,6 +243,14 @@ def save(config_dict, config_path, backup=False):
 
             # Now move the temporary file into the proper place:
             shutil.copyfile(tmpfile.name, config_path)
+
+        # Then put the old mode and ownership back.
+        os.chmod(config_path, stat.S_IMODE(old_stat.st_mode))
+        try:
+            os.chown(config_path, old_stat.st_uid, old_stat.st_gid)
+        except PermissionError:
+            # Not running as root, so the file already belongs to us.
+            pass
 
     else:
 

--- a/src/weecfg/tests/test_config.py
+++ b/src/weecfg/tests/test_config.py
@@ -7,6 +7,7 @@
 import io
 import os.path
 import shutil
+import stat
 import sys
 import tempfile
 
@@ -318,6 +319,41 @@ class TestExtensionUtility:
                                                                                 file_list)]
         assert out_list == [('/bar/baz/bin/user/foo.py', '/etc/weewx/bin/user/foo.py'),
                             ('/bar/baz/bin/user/bar.py', '/etc/weewx/bin/user/bar.py')]
+
+
+class TestSavePermissions:
+    """Tests that saving a config file does not change how it is protected."""
+
+    def test_backup_save_keeps_mode(self):
+        """A save with a backup must leave the mode alone.
+
+        The backup path moves the old file aside and copies a new one into
+        place, and a fresh file takes its mode from the caller's umask. On a
+        package installation /etc/weewx/weewx.conf is 0660 so that the 'weewx'
+        user can edit it and nobody else can read the passwords in it; 0644
+        loses both of those.
+        """
+        with tempfile.TemporaryDirectory() as dir_name:
+            config_path = os.path.join(dir_name, 'test.conf')
+            config_dict = configobj.ConfigObj({'WEEWX_ROOT': '/tmp', 'foo': 'bar'}, encoding='utf-8')
+            weecfg.save(config_dict, config_path)
+            os.chmod(config_path, 0o660)
+
+            weecfg.save(config_dict, config_path, backup=True)
+
+            assert stat.S_IMODE(os.stat(config_path).st_mode) == 0o660
+
+    def test_backup_keeps_mode_too(self):
+        """The file that is moved aside keeps its mode as well."""
+        with tempfile.TemporaryDirectory() as dir_name:
+            config_path = os.path.join(dir_name, 'test.conf')
+            config_dict = configobj.ConfigObj({'WEEWX_ROOT': '/tmp', 'foo': 'bar'}, encoding='utf-8')
+            weecfg.save(config_dict, config_path)
+            os.chmod(config_path, 0o660)
+
+            backup_path = weecfg.save(config_dict, config_path, backup=True)
+
+            assert stat.S_IMODE(os.stat(backup_path).st_mode) == 0o660
 
 
 class TestExtensionInstall:


### PR DESCRIPTION
Against `master`, as this is a fix. Found while looking at #1050. The first container
test I wrote for it tripped over this immediately.

## What happens

`weecfg.save()` with `backup=True` moves the old file aside and copies a new one into
place. A copy is a new file. So it takes its mode from the caller's umask, and its
ownership from whoever is running, i.e. root for anything invoked with `sudo`.

The Debian `postinst` deliberately sets `/etc/weewx/weewx.conf` to `weewx:weewx 0660`,
and says why:

```sh
# ensure that the configuration files are not world-readable so that
# we protect any passwords and tokens
chmod 660 /etc/weewx/*.conf*
```

That is undone by `weectl extension install`, `weectl extension uninstall`,
`weectl station reconfigure` and `weectl station upgrade`. All four save with a backup.
Measured in a Debian 12 container, installing the `.deb` built from this tree:

|  | mode and owner |
|---|---|
| fresh install | `-rw-rw---- weewx:weewx` |
| after `extension install` | `-rw-r--r-- root:weewx` |
| after `extension uninstall` | `-rw-r--r-- root:weewx` |
| after `station reconfigure` | `-rw-r--r-- root:weewx` |

With this commit all four stay `-rw-rw---- weewx:weewx`.

## What follows from it

`weewxd` only reads that file, never writes it, so nothing stops working. That is
presumably why this has gone unnoticed. Two things do change, and the packaging sets out
to prevent both:

- The `weewx` user can no longer edit its own configuration. That is what the `0660` and
  the setgid directories are for.
- `weewx.conf` becomes readable by every local account. It holds FTP, RESTful and
  database passwords. That is the case the comment above is explicitly guarding.

A pip installation is unaffected. Everything already belongs to the user running, so the
`chown` is a no-op and the umask gives the same mode back.

## The fix

Note the mode and ownership before the move, put them back after the copy. A
`PermissionError` from `chown` is ignored, since not running as root means the file is
already ours. The no-backup branch never had the problem: it
writes through the existing file, which keeps both.

## Testing

Two unit tests in `test_config.py`, so this is covered without a container. Removing the
`os.chmod` fails the first one.

Verified end to end as above. The `.deb` was built from this tree and installed in a
clean Debian 12 container, the four commands run in turn, `stat` after each.

Full suite: 376 passed, no failures.


