### PR TITLE
Add packaging for openSUSE Leap 16

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,10 @@ WeeWX change history
 
 ### 5.5.n n-Month-2026
 
+Added packaging for openSUSE Leap 16. It does not carry `python3-ephem`, so that
+dependency is dropped for that release, the same way it is for Redhat 9 and 10.
+Fixes [Issue #1065](https://github.com/weewx/weewx/issues/1065).
+
 Saving the configuration file no longer changes its mode or ownership. Under a
 package installation, `weectl extension install`, `weectl extension uninstall`,
 `weectl station reconfigure` and `weectl station upgrade` were leaving

--- a/makefile
+++ b/makefile
@@ -381,10 +381,13 @@ rpm-package-rh10:
 suse-changelog:
 	make rpm-changelog RPMOS=suse
 
-suse-package: rpm-package-suse15
+suse-package: rpm-package-suse15 rpm-package-suse16
 
 rpm-package-suse15:
 	make rpm-package RPMOS=suse OSREL=15
+
+rpm-package-suse16:
+	make rpm-package RPMOS=suse OSREL=16
 
 # run rpmlint on the rpm package
 check-rpm:
@@ -401,8 +404,13 @@ check-rh9:
 check-rh10:
 	make check-rpm RPMOS=el OSREL=10
 
-check-suse:
+check-suse: check-suse15 check-suse16
+
+check-suse15:
 	make check-rpm RPMOS=suse OSREL=15
+
+check-suse16:
+	make check-rpm RPMOS=suse OSREL=16
 
 upload-rpm:
 	scp $(DSTDIR)/$(RPMPKG) $(USER)@$(WEEWX_COM):$(WEEWX_STAGING)
@@ -427,6 +435,7 @@ RHEL8_PKG=weewx-$(RPMVER).el8.$(RPMARCH).rpm
 RHEL9_PKG=weewx-$(RPMVER).el9.$(RPMARCH).rpm
 RHEL10_PKG=weewx-$(RPMVER).el10.$(RPMARCH).rpm
 SUSE15_PKG=weewx-$(RPMVER).suse15.$(RPMARCH).rpm
+SUSE16_PKG=weewx-$(RPMVER).suse16.$(RPMARCH).rpm
 upload-pkgs:
 	scp $(DSTDIR)/$(SRCPKG) \
  $(DSTDIR)/$(DEB3_PKG) \
@@ -434,13 +443,14 @@ upload-pkgs:
  $(DSTDIR)/$(RHEL9_PKG) \
  $(DSTDIR)/$(RHEL10_PKG) \
  $(DSTDIR)/$(SUSE15_PKG) \
+ $(DSTDIR)/$(SUSE16_PKG) \
  $(USER)@$(WEEWX_COM):$(WEEWX_STAGING)
 
 # move files from the upload directory to the release directory and set up the
 # symlinks to them from the download root directory
 DEVDIR=$(WEEWX_DOWNLOADS)/development_versions
 RELDIR=$(WEEWX_DOWNLOADS)/released_versions
-ARTIFACTS=$(DEB3_PKG) $(RHEL8_PKG) $(RHEL9_PKG) $(RHEL10_PKG) $(SUSE15_PKG) $(SRCPKG)
+ARTIFACTS=$(DEB3_PKG) $(RHEL8_PKG) $(RHEL9_PKG) $(RHEL10_PKG) $(SUSE15_PKG) $(SUSE16_PKG) $(SRCPKG)
 release-pkgs:
 	ssh $(USER)@$(WEEWX_COM) "for f in $(ARTIFACTS); do if [ -f $(DEVDIR)/\$$f ]; then mv $(DEVDIR)/\$$f $(RELDIR); fi; done"
 	ssh $(USER)@$(WEEWX_COM) "rm -f $(WEEWX_DOWNLOADS)/weewx*"

--- a/pkg/weewx.spec.in
+++ b/pkg/weewx.spec.in
@@ -17,6 +17,19 @@
 %define python python3
 %endif
 
+# suse 16: python3
+%if 0%{?suse_version} && "%{os_target}" == "16"
+%define app_group Productivity/Scientific/Other
+%define relos .suse16
+%define platform suse
+# leap 16 ships python 3.13. the modules are packaged as python313-*, but each
+# provides the python3-* name, so these resolve.
+# ephem is not packaged for leap 16. weewx falls back to its own almanac
+# calculations without it.
+%define deps python3, python3-importlib_resources, python3-configobj, python3-Cheetah3, python3-Pillow, python3-pyserial, python3-usb
+%define python python3
+%endif
+
 # rh: python3 on redhat, fedora, centos, rocky
 %if "%{_vendor}" == "redhat"
 %define app_group Applications/Science


### PR DESCRIPTION
Closes #1065. Against `master`, as this is a fix.

@tkeffer, your find was right: Leap 16 packages pyusb as `python313-pyusb`. It provides
both `python3-pyusb` and `python3-usb`, so the name already in the spec resolves. The usb
half of this issue has gone away on its own.

What is left is `python3-ephem`, which Leap 16 does not carry at all. That is what blocks
the install now:

```
Problem: 1: nothing provides 'python3-ephem' needed by the to be installed
weewx-5.5.0-1.suse15.noarch
```

So this adds a suse16 block that drops that one dependency, the way the Redhat 9 and 10
blocks already do. weewx falls back to its own almanac calculations without ephem.

Every other dependency in the suse15 list resolves on Leap 16, checked against the
repository:

| | |
|---|---|
| `python3-configobj` | resolves |
| `python3-Cheetah3` | resolves |
| `python3-Pillow` | resolves |
| `python3-pyserial` | resolves |
| `python3-importlib_resources` | resolves |
| `python3-usb` | resolves, via `python313-pyusb` |
| `python3-ephem` | not found |

## Tested

Built with `make rpm-package RPMOS=suse OSREL=16` in an `opensuse/leap:16.0` container,
then installed there:

- 34 packages, no dependency prompts, no `--force` and no ignored dependencies
- `weewxd` runs and writes archive records
- a report cycle produces 5 html files, 60 images and the NOAA summaries
- `python3 -c "import ephem"` fails, as expected, and the almanac still renders

The makefile gets the matching build, check, upload and release targets, mirroring
suse15. `suse-package` now builds both.

The 404 from the original report is gone: `http://weewx.com/suse/weewx/suse16` refreshes
and serves 5.5.0. @matthewwall's symlink is doing its job, though it still points at the
suse15 package, which is the one that cannot install.
