### PR TITLE
Restore sys.path after loading an extension installer

### DIFF
--- a/src/weecfg/__init__.py
+++ b/src/weecfg/__init__.py
@@ -12,6 +12,7 @@ import pkgutil
 import shutil
 import sys
 import tempfile
+from contextlib import contextmanager
 
 import configobj
 
@@ -707,24 +708,33 @@ def extract_zip(filename, target_dir, printer=None):
     return member_names
 
 
+@contextmanager
+def add_path(new_path):
+    """Put a directory at the front of sys.path for the duration of the block.
+
+    A copy, not a reference: sys.path is mutated in place below, so keeping a
+    reference would restore the mutated list."""
+    old_path = list(sys.path)
+    try:
+        sys.path.insert(0, new_path)
+        yield sys.path
+    finally:
+        sys.path = old_path
+
+
 def get_extension_installer(extension_installer_dir):
     """Get the installer in the given extension installer subdirectory"""
-    old_path = sys.path
-    try:
-        # Inject the location of the installer directory into the path
-        sys.path.insert(0, extension_installer_dir)
+    with add_path(extension_installer_dir):
         try:
             # Now I can import the extension's 'install' module:
-            __import__('install')
+            install_module = importlib.import_module('install')
         except ImportError:
             raise ExtensionError("Cannot find 'install' module in %s" % extension_installer_dir)
-        install_module = sys.modules['install']
         loader = getattr(install_module, 'loader')
-        # Get rid of the module:
+        # Every extension names its installer module 'install', so it must not be left in
+        # the module cache: the next extension installed by this process would get this
+        # one's installer back instead of its own.
         sys.modules.pop('install', None)
         installer = loader()
-    finally:
-        # Restore the path
-        sys.path = old_path
 
     return install_module.__file__, installer

--- a/src/weecfg/tests/test_config.py
+++ b/src/weecfg/tests/test_config.py
@@ -320,6 +320,77 @@ class TestExtensionUtility:
                             ('/bar/baz/bin/user/bar.py', '/etc/weewx/bin/user/bar.py')]
 
 
+class TestGetExtensionInstaller:
+    """Tests of loading an extension's 'install' module."""
+
+    # A minimal extension installer. Its name is what tells one apart from another.
+    INSTALL_PY = """from setup import ExtensionInstaller
+
+
+def loader():
+    return MiniInstaller()
+
+
+class MiniInstaller(ExtensionInstaller):
+    def __init__(self):
+        super().__init__(version='1.0', name='%s')
+"""
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        saved_path = list(sys.path)
+        yield
+        sys.path = saved_path
+        sys.modules.pop('install', None)
+
+    @classmethod
+    def _write_installer(cls, directory, name):
+        """Write an 'install.py' for an extension called 'name'. Returns its path."""
+        os.makedirs(directory, exist_ok=True)
+        install_path = os.path.join(directory, 'install.py')
+        with open(install_path, 'w') as fd:
+            fd.write(cls.INSTALL_PY % name)
+        return install_path
+
+    def test_get_installer(self):
+        with tempfile.TemporaryDirectory() as installer_dir:
+            expected_path = self._write_installer(installer_dir, 'alpha')
+            before = list(sys.path)
+            installer_path, installer = weecfg.get_extension_installer(installer_dir)
+            assert os.path.samefile(installer_path, expected_path)
+            assert installer['name'] == 'alpha'
+            # The installer directory must not be left on the path.
+            assert sys.path == before
+            # Nor the module in the cache. See test_get_installer_two_extensions.
+            assert 'install' not in sys.modules
+
+    def test_get_installer_missing(self):
+        """A directory with no 'install.py' in it raises ExtensionError."""
+        with tempfile.TemporaryDirectory() as empty_dir:
+            before = list(sys.path)
+            with pytest.raises(weecfg.ExtensionError):
+                weecfg.get_extension_installer(empty_dir)
+            assert sys.path == before
+
+    def test_get_installer_two_extensions(self):
+        """Every extension calls its installer module 'install'. If the module were
+        left in sys.modules, the second extension loaded by a process would get the
+        first one's installer back instead of its own."""
+        with tempfile.TemporaryDirectory() as parent:
+            alpha_dir = os.path.join(parent, 'alpha')
+            beta_dir = os.path.join(parent, 'beta')
+            alpha_expected = self._write_installer(alpha_dir, 'alpha')
+            beta_expected = self._write_installer(beta_dir, 'beta')
+
+            alpha_path, alpha = weecfg.get_extension_installer(alpha_dir)
+            beta_path, beta = weecfg.get_extension_installer(beta_dir)
+
+            assert alpha['name'] == 'alpha'
+            assert beta['name'] == 'beta'
+            assert os.path.samefile(alpha_path, alpha_expected)
+            assert os.path.samefile(beta_path, beta_expected)
+
+
 class TestExtensionInstall:
     """Tests of the extension installer."""
 

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -8,10 +8,10 @@
 
 # Python imports
 import gc
+import importlib
 import logging
 import math
 import socket
-import importlib
 import threading
 import time
 import traceback


### PR DESCRIPTION
Closes #1109. Against `master`, as this is a fix. Found while working on that issue.

`old_path = sys.path` takes a reference, not a copy. The next line mutates that same list
with `insert()`, so the assignment in the `finally` block puts the mutated list back. The
installer directory stays on the path.

Measured against `master`:

```
sys.path before 6, after 7
directory still on path: True
after four extensions: 10 entries, 4 added
```

Those directories are temporary and get removed afterwards, so what is left behind are
dead entries that every subsequent import walks through.

Now done with the `add_path()` context manager, and with `importlib.import_module()` in
place of `__import__`. The latter makes the `sys.modules['install']` lookup that followed
the call unnecessary, i.e. the same shape you gave `weedb` in e129a14d. That was #1112,
which is closed in favour of this one, since both touched the same fifteen lines.

What stays is the `sys.modules.pop()`. Every extension calls its installer module
`install`, so leaving it in the cache hands the next extension installed by the same
process the previous one's installer. The comment there said only "Get rid of the
module", which does not say why it matters.

A second commit puts `import importlib` back in alphabetical order in `engine.py`.
3a7223de replaced `import sys` with it where it stood, which left it between `socket` and
`threading`.

## Tests

`get_extension_installer()` had none. There are three now: an ordinary load, a directory
with no `install.py`, and two extensions in a row. Reverting either half of the function
breaks them:

| reverted to                          | fails                                            |
|--------------------------------------|--------------------------------------------------|
| `old_path = sys.path`                | `test_get_installer`, `..._missing`              |
| `sys.modules.pop()` deleted          | `test_get_installer`, `..._two_extensions`       |

Full suite, one file per run the way the makefile does it. Debian 12, Python 3.13,
MariaDB, non-root:

|                 | passed | failed |
|-----------------|--------|--------|
| `origin/master` | 374    | 0      |
| this branch     | 377    | 0      |

`vermin --target=3.7` reports the same minimum before and after.
