### PR TITLE
Use one spelling for the _ago parameters in the docs

### DIFF
--- a/docs_src/custom/cheetah-generator.md
+++ b/docs_src/custom/cheetah-generator.md
@@ -427,7 +427,7 @@ There are several _aggregation periods_ that can be used:
     </tr>
     <tr>
         <td class="first_col code">$yesterday</td>
-        <td>Yesterday. Synonym for <span class="code">$day($days_ago=1)</span>.
+        <td>Yesterday. Synonym for <span class="code">$day(days_ago=1)</span>.
         </td>
         <td class="code">$yesterday.outTemp.maxtime</td>
         <td>The time of the max temperature yesterday.</td>
@@ -1420,7 +1420,7 @@ and overriding units. [Click here](../examples/tag.htm) for the results.
         <td>Max temperature</td>
         <td>Time</td>
       </tr>
-#for $hour in $day($days_ago=1).hours
+#for $hour in $day(days_ago=1).hours
       <tr>
         <td>$hour.start.format("%H:%M")-$hour.end.format("%H:%M")</td>
         <td>$hour.outTemp.max ($hour.outTemp.max.degree_C)</td>
@@ -1430,7 +1430,7 @@ and overriding units. [Click here](../examples/tag.htm) for the results.
       <caption>
         <p>
           Hourly max temperatures yesterday<br/>
-          $day($days_ago=1).start.format("%d-%b-%Y")
+          $day(days_ago=1).start.format("%d-%b-%Y")
         </p>
       </caption>
     </table>


### PR DESCRIPTION
Against `master`, where the other documentation commits are. Three lines.

`custom/cheetah-generator.md` writes `$day($days_ago=1)` in three places and
`$day(days_ago=1)` everywhere else. Both work. Cheetah strips the `$` from a keyword
argument, checked against Cheetah 3.4:

```
$day(days_ago=1)    ->  day(days_ago=1)
$day($days_ago=1)   ->  day(days_ago=1)
```

But the two spellings side by side read as though one of them must be wrong, and it came
up on weewx-user
([msg54493](https://www.mail-archive.com/weewx-user@googlegroups.com/msg54493.html)):

> `$month($months_ago=$m)` or `$month(months_ago=$m)` with as difference of a `$` before
> the `months_ago`

So all three now match the form used for `weeks_ago`, `months_ago`, `years_ago`,
`hours_ago` and `seasons_ago`, which is also what a python keyword argument looks like.

The change log keeps its `$week($weeks_ago=1)`. Those entries are history.

`python -m zensical build` reports no issues.
