### PR TITLE
Add a listener for hardware that pushes

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,9 +3,9 @@ WeeWX change history
 
 ### 5.6.0 MM/DD/YYYY
 
-Added `weewx.listener`, a listener for hardware that pushes its data rather than
-answering a poll. Drivers for such hardware no longer have to write their own HTTP
-server. See [Issue #1124](https://github.com/weewx/weewx/issues/1124).
+Added `weewx.listener`, for hardware that pushes its data rather than answering a
+poll. Drivers for such hardware no longer have to write their own HTTP server or UDP
+socket. See [Issue #1124](https://github.com/weewx/weewx/issues/1124).
 
 
 ### 5.5.0 6-Aug-2026

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -1,6 +1,13 @@
 WeeWX change history
 --------------------
 
+### 5.6.0 MM/DD/YYYY
+
+Added `weewx.listener`, a listener for hardware that pushes its data rather than
+answering a poll. Drivers for such hardware no longer have to write their own HTTP
+server. See [Issue #1124](https://github.com/weewx/weewx/issues/1124).
+
+
 ### 5.5.0 6-Aug-2026
 
 Added the ability for services to bind to a `SHUTDOWN` event. This allows

--- a/docs_src/custom/drivers.md
+++ b/docs_src/custom/drivers.md
@@ -308,6 +308,27 @@ What the listener does not check is whatever the device carries in its own paylo
 as the Ecowitt `PASSKEY` or a Weather Underground station ID. Those belong to the
 protocol, so they are the driver's to verify.
 
+### Hardware that broadcasts
+
+Some hardware does not post at all. It puts a datagram on the local network and moves
+on, e.g. WeatherFlow on port 50222, or a Davis WeatherLink Live on 22222. Use
+`weewx.listener.UDPListener` for those. Same queue, same iteration, no response to send:
+
+``` python
+from weewx.listener import UDPListener
+
+self.listener = UDPListener(port=50222)
+```
+
+It takes `port`, `address`, `max_body`, `allowed_hosts`, `log_raw`, and `queue_size`
+with the same meanings, plus `reuse_address`. That one defaults to `True`, so other
+programs on the machine can read the same broadcasts. Set it to `False` to have the port
+to yourself.
+
+Two differences are worth knowing. UDP has no way to refuse an oversized datagram, so
+`max_body` truncates rather than rejects. And a datagram carries no path, no headers and
+no token, so `allowed_hosts` is the only filter there is.
+
 ## Define the configuration
 
 You then include a new section in the configuration file `weewx.conf` that

--- a/docs_src/custom/drivers.md
+++ b/docs_src/custom/drivers.md
@@ -240,8 +240,10 @@ straight through:
   <tr>
     <td class="code">path</td>
     <td><i>every path</i></td>
-    <td>Accept this path only, <i>e.g.</i>
-        <span class="code">/data/report/</span>. Anything else gets a 404.</td>
+    <td>Which paths to answer for, <i>e.g.</i>
+        <span class="code">/data/report/</span>. A comma-separated list, or a
+        Python list, is several. A callable is passed the path and returns whether
+        to accept it. Anything else gets a 404.</td>
   </tr>
   <tr>
     <td class="code">max_body</td>
@@ -298,6 +300,22 @@ a URL, which is most of it, can still carry a secret in the path:
     driver = user.mydriver
     port = 8000
     path = /a8f3c1e0/report
+```
+
+`path` takes more than one, which matters where a driver answers to several kinds of
+hardware: a console whose path you choose, and one whose path is burned into its
+firmware, cannot share a single setting.
+
+``` ini
+    path = /a8f3c1e0/report, /weatherstation/updateweatherstation.php
+```
+
+Where the set of paths is not known when the socket is opened, pass a callable
+instead. A driver that gives each station a path of its own can then accept a new one
+without WeeWX being restarted:
+
+``` python
+self.listener = HTTPListener(port=8000, path=self.knows_this_path)
 ```
 
 None of this is a substitute for TLS, and the listener does not offer any. Put a reverse

--- a/docs_src/custom/drivers.md
+++ b/docs_src/custom/drivers.md
@@ -176,6 +176,111 @@ database, or perform any other activity before the application terminates, then
 you must supply this function. WeeWX will call it if it needs to shut down your
 console (usually in the case of an error).
 
+## Hardware that pushes {#listener}
+
+Some hardware never answers a request. It uploads on its own schedule, so a driver for
+it has to be a server rather than a client. Ecowitt gateways and consoles, Acurite
+bridges, and WeatherFlow hardware all work this way.
+
+Use `weewx.listener.HTTPListener` for these. It owns the socket, the thread, and the
+queue, which leaves the driver with the part that actually differs between devices.
+
+``` python
+from weewx.listener import HTTPListener
+
+class MyDriver(weewx.drivers.AbstractDevice):
+
+    def __init__(self, **stn_dict):
+        self.listener = HTTPListener(**stn_dict)
+
+    def genLoopPackets(self):
+        for request in self.listener:
+            packet = self.parse(request.text)
+            if packet:
+                yield packet
+
+    def closePort(self):
+        self.listener.close()
+```
+
+Each request carries `method`, `path`, `query`, `body`, `headers`, and
+`client_address`. Use `request.text` if the device may use either protocol: it returns
+the body of a POST, and the query string of a GET.
+
+Most devices treat an upload as failed until they have read a response, and what they
+expect is part of their protocol. Give the listener a string, or a function of the
+request:
+
+``` python
+self.listener = HTTPListener(response='{"errcode":"0","errmsg":"ok"}',
+                             content_type='application/json',
+                             **stn_dict)
+```
+
+Options may be given as strings, so a driver can pass its configuration stanza
+straight through:
+
+<table>
+  <tr class="first_row">
+    <td>Option</td>
+    <td>Default</td>
+    <td>Meaning</td>
+  </tr>
+  <tr>
+    <td class="code">port</td>
+    <td>80</td>
+    <td>The port to listen on. Ports below 1024 need root.</td>
+  </tr>
+  <tr>
+    <td class="code">address</td>
+    <td><i>every interface</i></td>
+    <td>The address to bind to. Use <span class="code">localhost</span> when a reverse
+        proxy sits in front.</td>
+  </tr>
+  <tr>
+    <td class="code">path</td>
+    <td><i>every path</i></td>
+    <td>Accept this path only, <i>e.g.</i>
+        <span class="code">/data/report/</span>. Anything else gets a 404.</td>
+  </tr>
+  <tr>
+    <td class="code">max_body</td>
+    <td>65536</td>
+    <td>Largest body accepted, in bytes. Bigger requests get a 413.</td>
+  </tr>
+  <tr>
+    <td class="code">socket_timeout</td>
+    <td>20</td>
+    <td>How long an idle client may hold a connection open, in seconds.</td>
+  </tr>
+  <tr>
+    <td class="code">queue_size</td>
+    <td>10</td>
+    <td>How many requests may wait to be picked up. Beyond that, the oldest is
+        dropped and a warning is logged.</td>
+  </tr>
+  <tr>
+    <td class="code">allowed_hosts</td>
+    <td><i>anywhere</i></td>
+    <td>Accept requests from these addresses only.</td>
+  </tr>
+  <tr>
+    <td class="code">trust_proxy</td>
+    <td>False</td>
+    <td>Take the client address from <span class="code">X-Forwarded-For</span>. Only
+        set this when a proxy you control sets that header.</td>
+  </tr>
+  <tr>
+    <td class="code">log_raw</td>
+    <td>False</td>
+    <td>Log every request body at debug level. This is what you turn on when a sensor
+        is missing from the data.</td>
+  </tr>
+</table>
+
+The socket is bound when the listener is created, so a port that is already in use is
+reported where the driver is built.
+
 ## Define the configuration
 
 You then include a new section in the configuration file `weewx.conf` that

--- a/docs_src/custom/drivers.md
+++ b/docs_src/custom/drivers.md
@@ -265,6 +265,14 @@ straight through:
     <td>Accept requests from these addresses only.</td>
   </tr>
   <tr>
+    <td class="code">token</td>
+    <td><i>none</i></td>
+    <td>Require this token, given as query parameter
+        <span class="code">token</span>, in header
+        <span class="code">X-Auth-Token</span>, or as a bearer token in
+        <span class="code">Authorization</span>. Anything else gets a 403.</td>
+  </tr>
+  <tr>
     <td class="code">trust_proxy</td>
     <td>False</td>
     <td>Take the client address from <span class="code">X-Forwarded-For</span>. Only
@@ -280,6 +288,25 @@ straight through:
 
 The socket is bound when the listener is created, so a port that is already in use is
 reported where the driver is built.
+
+Anyone who can reach the port can post readings, so the listener offers three ways to
+narrow that down: `allowed_hosts`, `token`, and `path`. Hardware that can only be given
+a URL, which is most of it, can still carry a secret in the path:
+
+``` ini
+[MyDriver]
+    driver = user.mydriver
+    port = 8000
+    path = /a8f3c1e0/report
+```
+
+None of this is a substitute for TLS, and the listener does not offer any. Put a reverse
+proxy in front for that, and set `trust_proxy` so the driver still sees the real client
+address.
+
+What the listener does not check is whatever the device carries in its own payload, such
+as the Ecowitt `PASSKEY` or a Weather Underground station ID. Those belong to the
+protocol, so they are the driver's to verify.
 
 ## Define the configuration
 

--- a/docs_src/custom/drivers.md
+++ b/docs_src/custom/drivers.md
@@ -325,6 +325,60 @@ with the same meanings, plus `reuse_address`. That one defaults to `True`, so ot
 programs on the machine can read the same broadcasts. Set it to `False` to have the port
 to yourself.
 
+A whole driver for broadcasting hardware fits in forty lines, and all of them are about
+the hardware:
+
+``` python
+import json
+import time
+
+import weewx
+import weewx.drivers
+from weewx.listener import UDPListener
+
+DRIVER_NAME = 'Tempest'
+
+
+def loader(config_dict, _engine):
+    return TempestDriver(**config_dict[DRIVER_NAME])
+
+
+class TempestDriver(weewx.drivers.AbstractDevice):
+    """Reads WeatherFlow-style JSON broadcasts."""
+
+    def __init__(self, **stn_dict):
+        self.listener = UDPListener(**stn_dict)
+
+    @property
+    def hardware_name(self):
+        return 'Tempest'
+
+    def genLoopPackets(self):
+        for request in self.listener:
+            packet = self.parse(request.text)
+            if packet:
+                yield packet
+
+    @staticmethod
+    def parse(text):
+        """JSON in, a loop packet out. No socket, no engine, testable on its own."""
+        try:
+            message = json.loads(text)
+        except ValueError:
+            return None
+        if message.get('type') != 'obs_st':
+            return None
+        obs = message['obs'][0]
+        return {'dateTime': int(obs[0] or time.time()), 'usUnits': weewx.METRICWX,
+                'outTemp': obs[7], 'outHumidity': obs[8], 'windSpeed': obs[2]}
+
+    def closePort(self):
+        self.listener.close()
+```
+
+`parse()` is a static method for a reason: it needs neither a socket nor an engine, so
+a test can hand it a captured datagram and check what comes out.
+
 Two differences are worth knowing. UDP has no way to refuse an oversized datagram, so
 `max_body` truncates rather than rejects. And a datagram carries no path, no headers and
 no token, so `allowed_hosts` is the only filter there is.

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -37,6 +37,9 @@ upload as failed until they have read one, e.g. an Ecowitt gateway expects JSON:
     HTTPListener(port=8000, response='{"errcode":"0","errmsg":"ok"}',
                  content_type='application/json')
 
+Hardware that broadcasts instead of posting uses `UDPListener` the same way. Same queue,
+same iteration, no response to send.
+
 Options may be passed as strings, so a driver can hand over its configuration stanza
 unchanged.
 """
@@ -245,6 +248,84 @@ class HTTPListener(Listener):
             self.server.shutdown()
             self.server.server_close()
             self.server = None
+        if self.thread is not None:
+            self.thread.join(POLL_INTERVAL * 2)
+            self.thread = None
+        log.info("Stopped listening on port %d", self.port)
+
+
+class UDPListener(Listener):
+    """Listen for UDP datagrams and queue them for a driver.
+
+    Hardware that broadcasts rather than posts, e.g. WeatherFlow on port 50222 or a
+    Davis WeatherLink Live on 22222, ends up here. There is no response to send: a
+    datagram is sent once and nobody waits for an answer.
+
+    Args:
+        port (int): The port to listen on. Required.
+        address (str): The address to bind to. Default is '', i.e. every interface,
+            which is what receiving a broadcast usually needs.
+        max_body (int): Largest datagram accepted, in bytes.
+        allowed_hosts (list): Accept datagrams from these addresses only. Default is
+            empty, i.e. accept from anywhere.
+        reuse_address (bool): Let other programs on this machine read the same
+            broadcasts. Default True, because that is nearly always wanted.
+        log_raw (bool): Log every datagram at debug level.
+        queue_size (int): How many datagrams may wait to be picked up.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.port = to_int(kwargs.get('port', 0))
+        self.address = kwargs.get('address', '')
+        self.max_body = to_int(kwargs.get('max_body', DEFAULT_MAX_BODY))
+        self.allowed_hosts = _as_list(kwargs.get('allowed_hosts'))
+        self.reuse_address = to_bool(kwargs.get('reuse_address', True))
+        self.log_raw = to_bool(kwargs.get('log_raw', False))
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if self.reuse_address:
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            self.socket.bind((self.address, self.port))
+        except OSError as e:
+            log.error("Cannot listen on %s:%s: %s", self.address or '*', self.port, e)
+            self.socket.close()
+            raise
+        # So the reading loop comes up for air often enough to notice a close().
+        self.socket.settimeout(POLL_INTERVAL)
+        self.port = self.socket.getsockname()[1]
+
+        self.thread = threading.Thread(target=self._run, name='WeeWX-listener')
+        self.thread.daemon = True
+        self.thread.start()
+        log.info("Listening for UDP datagrams on %s:%d", self.address or '*', self.port)
+
+    def _run(self):
+        while not self.closed.is_set():
+            try:
+                datagram, sender = self.socket.recvfrom(self.max_body)
+            except socket.timeout:
+                continue
+            except OSError:
+                # The socket was closed under us. That is how this loop ends.
+                return
+            if self.allowed_hosts and sender[0] not in self.allowed_hosts:
+                log.warning("Rejected a datagram from %s", sender[0])
+                continue
+            request = Request(method='UDP', path='', query='', body=datagram,
+                              headers={}, client_address=sender[0])
+            if self.log_raw:
+                log.debug("Raw datagram: %s", request.text)
+            self.put(request)
+
+    def close(self):
+        """Stop listening and release the port."""
+        super().close()
+        if self.socket is not None:
+            self.socket.close()
+            self.socket = None
         if self.thread is not None:
             self.thread.join(POLL_INTERVAL * 2)
             self.thread = None

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -52,6 +52,7 @@ import threading
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+import weewx
 from weeutil.weeutil import to_bool, to_int
 
 log = logging.getLogger(__name__)
@@ -139,7 +140,10 @@ class Listener:
     def get(self, timeout=None):
         """Return the next request, or None if none arrived in time.
 
-        Returns None once the listener has been closed.
+        Returns None once the listener has been closed. Raises weewx.WeeWxIOError if
+        the thread doing the listening has stopped, because from here that is
+        indistinguishable from a station that went quiet, and the two need very
+        different handling.
         """
         deadline = None if timeout is None else timeout
         while not self.closed.is_set():
@@ -147,11 +151,23 @@ class Listener:
             try:
                 return self.queue.get(timeout=wait)
             except queue.Empty:
+                self._still_listening()
                 if deadline is not None:
                     deadline -= wait
                     if deadline <= 0:
                         return None
         return None
+
+    def _still_listening(self):
+        """Raise if the thread that fills the queue is gone.
+
+        Nothing restarts it, and a driver waiting on an empty queue would wait for
+        good. Better to say so and let the engine decide.
+        """
+        thread = getattr(self, 'thread', None)
+        if thread is not None and not thread.is_alive() and not self.closed.is_set():
+            raise weewx.WeeWxIOError("The listener on port %s has stopped"
+                                     % getattr(self, 'port', '?'))
 
     def __iter__(self):
         return self

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -207,8 +207,16 @@ class HTTPListener(Listener):
         port (int): The port to listen on. Default is 80, which needs root.
         address (str): The address to bind to. Default is '', i.e. every interface. Use
             'localhost' when a reverse proxy sits in front.
-        path (str): Accept requests for this path only, e.g. '/data/report/'. Anything
-            else is answered with a 404. Default is None, i.e. accept every path.
+        path (str|list|callable): Which paths to answer for. Anything else is
+            answered with a 404. Default is None, i.e. accept every path.
+
+            A string is one path, e.g. '/data/report/'. A list, or a
+            comma-separated string, is several. A callable is passed the path and
+            returns whether to accept it, which is what a driver needs when the set
+            of paths is not fixed at startup: one path per station, say, where a
+            station can be added while WeeWX is running.
+
+            Trailing slashes are ignored on both sides.
         response (str|bytes|callable): What to send back. A callable is passed the
             Request and returns the body. Default is an empty 200.
         content_type (str): The content type of the response. Default 'text/plain'.
@@ -234,6 +242,10 @@ class HTTPListener(Listener):
         self.port = to_int(kwargs.get('port', 80))
         self.address = kwargs.get('address', '')
         self.path = kwargs.get('path')
+        # Worked out once. A list is the common case and comparing it per request
+        # would mean splitting the same string over and over.
+        self.paths = (None if self.path is None or callable(self.path)
+                      else [p.rstrip('/') for p in _as_list(self.path)])
         self.response = kwargs.get('response', '')
         self.content_type = kwargs.get('content_type', 'text/plain')
         self.max_body = to_int(kwargs.get('max_body', DEFAULT_MAX_BODY))
@@ -261,6 +273,18 @@ class HTTPListener(Listener):
 
     def _listening(self):
         return self.thread is not None and self.thread.is_alive()
+
+    def accepts(self, path):
+        """Whether this listener answers for a path.
+
+        Asked before the request is read any further, so that a path nobody wants
+        costs a dictionary lookup and a 404 rather than a parse.
+        """
+        if self.path is None:
+            return True
+        if callable(self.path):
+            return bool(self.path(path))
+        return path.rstrip('/') in self.paths
 
     def get_response(self, request):
         """The body to send back. Override this, or pass 'response' to the constructor."""
@@ -440,7 +464,7 @@ class _Handler(BaseHTTPRequestHandler):
             return
 
         parts = urllib.parse.urlsplit(self.path)
-        if listener.path is not None and parts.path.rstrip('/') != listener.path.rstrip('/'):
+        if not listener.accepts(parts.path):
             self.send_error(404, "Not Found")
             return
 

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -110,7 +110,9 @@ class Listener:
     """Base class for listeners. Holds the queue and the iteration protocol."""
 
     def __init__(self, **kwargs):
-        self.queue_size = to_int(kwargs.get('queue_size', DEFAULT_QUEUE_SIZE))
+        # At least one, because a Queue of size zero is an unbounded one, which is
+        # the thing this is here to avoid.
+        self.queue_size = max(1, to_int(kwargs.get('queue_size', DEFAULT_QUEUE_SIZE)))
         self.queue = queue.Queue(maxsize=self.queue_size)
         self.closed = threading.Event()
         # Number of requests dropped because nobody picked them up in time.
@@ -145,11 +147,11 @@ class Listener:
         indistinguishable from a station that went quiet, and the two need very
         different handling.
         """
-        deadline = None if timeout is None else timeout
+        deadline = None if timeout is None else max(0.0, float(timeout))
         while not self.closed.is_set():
             wait = POLL_INTERVAL if deadline is None else min(POLL_INTERVAL, deadline)
             try:
-                return self.queue.get(timeout=wait)
+                return self.queue.get(timeout=max(wait, 0.001))
             except queue.Empty:
                 self._still_listening()
                 if deadline is not None:
@@ -158,14 +160,20 @@ class Listener:
                         return None
         return None
 
-    def _still_listening(self):
-        """Raise if the thread that fills the queue is gone.
+    def _listening(self):
+        """Whether this listener is still able to receive anything.
 
-        Nothing restarts it, and a driver waiting on an empty queue would wait for
-        good. Better to say so and let the engine decide.
+        Subclasses that run a thread say so here.
         """
-        thread = getattr(self, 'thread', None)
-        if thread is not None and not thread.is_alive() and not self.closed.is_set():
+        return True
+
+    def _still_listening(self):
+        """Raise if nothing is filling the queue any more.
+
+        Nothing restarts a listener that has stopped, and a driver waiting on an
+        empty queue would wait for good. Better to say so and let the engine decide.
+        """
+        if not self.closed.is_set() and not self._listening():
             raise weewx.WeeWxIOError("The listener on port %s has stopped"
                                      % getattr(self, 'port', '?'))
 
@@ -251,6 +259,9 @@ class HTTPListener(Listener):
         self.thread.start()
         log.info("Listening for HTTP requests on %s:%d", self.address or '*', self.port)
 
+    def _listening(self):
+        return self.thread is not None and self.thread.is_alive()
+
     def get_response(self, request):
         """The body to send back. Override this, or pass 'response' to the constructor."""
         if callable(self.response):
@@ -318,14 +329,18 @@ class UDPListener(Listener):
         self.thread.start()
         log.info("Listening for UDP datagrams on %s:%d", self.address or '*', self.port)
 
+    def _listening(self):
+        return self.thread is not None and self.thread.is_alive()
+
     def _run(self):
         while not self.closed.is_set():
             try:
                 datagram, sender = self.socket.recvfrom(self.max_body)
             except socket.timeout:
                 continue
-            except OSError:
-                # The socket was closed under us. That is how this loop ends.
+            except (OSError, AttributeError):
+                # The socket was closed under us, and may already be gone. Either way
+                # that is how this loop ends.
                 return
             if self.allowed_hosts and sender[0] not in self.allowed_hosts:
                 log.warning("Rejected a datagram from %s", sender[0])
@@ -340,11 +355,13 @@ class UDPListener(Listener):
         """Stop listening and release the port."""
         super().close()
         if self.socket is not None:
+            # Closing wakes the reading thread. Wait for it before dropping the
+            # reference, or it can find self.socket gone mid-call.
             self.socket.close()
+            if self.thread is not None:
+                self.thread.join(POLL_INTERVAL * 2)
+                self.thread = None
             self.socket = None
-        if self.thread is not None:
-            self.thread.join(POLL_INTERVAL * 2)
-            self.thread = None
         log.info("Stopped listening on port %d", self.port)
 
 

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -41,6 +41,7 @@ Options may be passed as strings, so a driver can hand over its configuration st
 unchanged.
 """
 
+import hmac
 import logging
 import queue
 import socket
@@ -188,6 +189,11 @@ class HTTPListener(Listener):
         socket_timeout (int): How long an idle client may hold a connection.
         allowed_hosts (list): Accept requests from these addresses only. Default is
             empty, i.e. accept from anywhere.
+        token (str): Accept a request only if it presents this token, either as query
+            parameter 'token', or in header 'X-Auth-Token', or as a bearer token in
+            header 'Authorization'. Anything else gets a 403. Default is None, i.e. no
+            token is required. A device that cannot set a header or a query parameter
+            can carry the token in 'path' instead.
         trust_proxy (bool): Take the client address from 'X-Forwarded-For'. Only set
             this when a proxy you control sets that header. Default False.
         log_raw (bool): Log every request body at debug level. This is what you turn on
@@ -206,6 +212,7 @@ class HTTPListener(Listener):
         self.max_body = to_int(kwargs.get('max_body', DEFAULT_MAX_BODY))
         self.socket_timeout = to_int(kwargs.get('socket_timeout', DEFAULT_SOCKET_TIMEOUT))
         self.allowed_hosts = _as_list(kwargs.get('allowed_hosts'))
+        self.token = kwargs.get('token')
         self.trust_proxy = to_bool(kwargs.get('trust_proxy', False))
         self.log_raw = to_bool(kwargs.get('log_raw', False))
 
@@ -317,6 +324,11 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_error(404, "Not Found")
             return
 
+        if not self._token_ok(listener, parts.query):
+            log.warning("Rejected a request from %s: bad or missing token", client)
+            self.send_error(403, "Forbidden")
+            return
+
         request = Request(method=self.command,
                           path=parts.path,
                           query=parts.query,
@@ -349,6 +361,25 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         if response:
             self.wfile.write(response)
+
+    def _token_ok(self, listener, query):
+        """Check the token, if one is required.
+
+        Devices differ in what they can send, so look in the three places one can end
+        up: a query parameter, our own header, and a bearer token.
+        """
+        if not listener.token:
+            return True
+        presented = self.headers.get('X-Auth-Token', '')
+        if not presented:
+            authorization = self.headers.get('Authorization', '')
+            if authorization.startswith('Bearer '):
+                presented = authorization[len('Bearer '):].strip()
+        if not presented:
+            presented = urllib.parse.parse_qs(query).get('token', [''])[0]
+        # Constant time, so that a wrong token cannot be found one character at a time.
+        return hmac.compare_digest(presented.encode('utf-8'),
+                                   str(listener.token).encode('utf-8'))
 
     def _client_address(self):
         if self.server.listener.trust_proxy:

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -216,7 +216,13 @@ class HTTPListener(Listener):
         self.trust_proxy = to_bool(kwargs.get('trust_proxy', False))
         self.log_raw = to_bool(kwargs.get('log_raw', False))
 
-        self.server = _Server(self, self.address, self.port)
+        try:
+            self.server = _Server(self, self.address, self.port)
+        except OSError as e:
+            # Almost always a port that something else already holds, e.g. a web server
+            # on 80, or a second WeeWX instance. Say so, then let it stop the startup.
+            log.error("Cannot listen on %s:%s: %s", self.address or '*', self.port, e)
+            raise
         # Report the port the socket actually got. They differ when the caller asked for
         # port 0, i.e. "any free port".
         self.port = self.server.server_address[1]

--- a/src/weewx/listener.py
+++ b/src/weewx/listener.py
@@ -1,0 +1,362 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Listeners for hardware that pushes its data to WeeWX.
+
+Most drivers poll: they ask the hardware for data and wait for an answer. Some hardware
+never answers a request. It posts on its own schedule, and the driver has to be a server.
+
+This module provides that server, so a driver does not have to write one. A driver
+creates a listener, then iterates over it:
+
+    from weewx.listener import HTTPListener
+
+    class MyDriver(weewx.drivers.AbstractDevice):
+
+        def __init__(self, **stn_dict):
+            self.listener = HTTPListener(**stn_dict)
+
+        def genLoopPackets(self):
+            for request in self.listener:
+                packet = self.parse(request.body)
+                if packet:
+                    yield packet
+
+        def closePort(self):
+            self.listener.close()
+
+What the listener owns: the socket, the thread, the queue and the shutdown. What it does
+not own: the protocol. Parsing the body, mapping fields and assigning units are all the
+driver's business, i.e. the parts that differ from one device to the next.
+
+The response is part of the protocol, so it comes from the driver. Many devices treat an
+upload as failed until they have read one, e.g. an Ecowitt gateway expects JSON:
+
+    HTTPListener(port=8000, response='{"errcode":"0","errmsg":"ok"}',
+                 content_type='application/json')
+
+Options may be passed as strings, so a driver can hand over its configuration stanza
+unchanged.
+"""
+
+import logging
+import queue
+import socket
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from weeutil.weeutil import to_bool, to_int
+
+log = logging.getLogger(__name__)
+
+# How long an idle client may hold a connection open, in seconds.
+DEFAULT_SOCKET_TIMEOUT = 20
+# Largest request body accepted, in bytes. Weather uploads are a few hundred bytes.
+DEFAULT_MAX_BODY = 65536
+# How many requests may wait to be picked up before the oldest is dropped.
+DEFAULT_QUEUE_SIZE = 10
+# How often a blocked iterator looks up to see whether the listener has been closed.
+POLL_INTERVAL = 1.0
+
+
+class Request:
+    """A single request, as handed to the driver.
+
+    Attributes:
+        method (str): The HTTP method, e.g. 'POST'.
+        path (str): The path, without the query, e.g. '/data/report/'.
+        query (str): The query string, without the leading '?'. Empty if there was none.
+        body (bytes): The request body. Empty for a GET.
+        headers (dict): The request headers, with lowercased keys.
+        client_address (str): Where the request came from. Taken from 'X-Forwarded-For'
+            if the listener was told to trust a proxy, otherwise the peer address.
+    """
+
+    __slots__ = ('method', 'path', 'query', 'body', 'headers', 'client_address')
+
+    def __init__(self, method, path, query, body, headers, client_address):
+        self.method = method
+        self.path = path
+        self.query = query
+        self.body = body
+        self.headers = headers
+        self.client_address = client_address
+
+    @property
+    def text(self):
+        """The body decoded as UTF-8, falling back to the query for a GET.
+
+        Devices split over two protocols here. Ecowitt POSTs a form body, Weather
+        Underground clients GET a query string. Both end up in the same place.
+        """
+        if self.body:
+            return self.body.decode('utf-8', 'replace')
+        return self.query
+
+    def __str__(self):
+        return "%s %s from %s, %d bytes" % (self.method, self.path,
+                                            self.client_address, len(self.body))
+
+
+class Listener:
+    """Base class for listeners. Holds the queue and the iteration protocol."""
+
+    def __init__(self, **kwargs):
+        self.queue_size = to_int(kwargs.get('queue_size', DEFAULT_QUEUE_SIZE))
+        self.queue = queue.Queue(maxsize=self.queue_size)
+        self.closed = threading.Event()
+        # Number of requests dropped because nobody picked them up in time.
+        self.dropped = 0
+
+    def put(self, request):
+        """Hand a request to whoever is iterating over this listener.
+
+        If the queue is full, the oldest request is dropped. Current weather beats
+        stale weather, and an unbounded queue would grow without limit if the consumer
+        ever stalled.
+        """
+        while True:
+            try:
+                self.queue.put_nowait(request)
+                return
+            except queue.Full:
+                try:
+                    self.queue.get_nowait()
+                except queue.Empty:
+                    # Drained by the consumer in the meantime. Try again.
+                    continue
+                self.dropped += 1
+                log.warning("Queue full. Dropped the oldest request (%d so far).",
+                            self.dropped)
+
+    def get(self, timeout=None):
+        """Return the next request, or None if none arrived in time.
+
+        Returns None once the listener has been closed.
+        """
+        deadline = None if timeout is None else timeout
+        while not self.closed.is_set():
+            wait = POLL_INTERVAL if deadline is None else min(POLL_INTERVAL, deadline)
+            try:
+                return self.queue.get(timeout=wait)
+            except queue.Empty:
+                if deadline is not None:
+                    deadline -= wait
+                    if deadline <= 0:
+                        return None
+        return None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        request = self.get()
+        if request is None:
+            raise StopIteration
+        return request
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        """Stop listening. Safe to call more than once."""
+        self.closed.set()
+
+
+class HTTPListener(Listener):
+    """Listen for HTTP requests and queue them for a driver.
+
+    The socket is bound in the constructor, so a port that is already in use is reported
+    where the driver is created, not later and out of sight in a thread.
+
+    Args:
+        port (int): The port to listen on. Default is 80, which needs root.
+        address (str): The address to bind to. Default is '', i.e. every interface. Use
+            'localhost' when a reverse proxy sits in front.
+        path (str): Accept requests for this path only, e.g. '/data/report/'. Anything
+            else is answered with a 404. Default is None, i.e. accept every path.
+        response (str|bytes|callable): What to send back. A callable is passed the
+            Request and returns the body. Default is an empty 200.
+        content_type (str): The content type of the response. Default 'text/plain'.
+        max_body (int): Largest body accepted, in bytes. Larger requests get a 413.
+        socket_timeout (int): How long an idle client may hold a connection.
+        allowed_hosts (list): Accept requests from these addresses only. Default is
+            empty, i.e. accept from anywhere.
+        trust_proxy (bool): Take the client address from 'X-Forwarded-For'. Only set
+            this when a proxy you control sets that header. Default False.
+        log_raw (bool): Log every request body at debug level. This is what you turn on
+            when a sensor is missing from the data.
+        queue_size (int): How many requests may wait to be picked up.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.port = to_int(kwargs.get('port', 80))
+        self.address = kwargs.get('address', '')
+        self.path = kwargs.get('path')
+        self.response = kwargs.get('response', '')
+        self.content_type = kwargs.get('content_type', 'text/plain')
+        self.max_body = to_int(kwargs.get('max_body', DEFAULT_MAX_BODY))
+        self.socket_timeout = to_int(kwargs.get('socket_timeout', DEFAULT_SOCKET_TIMEOUT))
+        self.allowed_hosts = _as_list(kwargs.get('allowed_hosts'))
+        self.trust_proxy = to_bool(kwargs.get('trust_proxy', False))
+        self.log_raw = to_bool(kwargs.get('log_raw', False))
+
+        self.server = _Server(self, self.address, self.port)
+        # Report the port the socket actually got. They differ when the caller asked for
+        # port 0, i.e. "any free port".
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever,
+                                       name='WeeWX-listener')
+        self.thread.daemon = True
+        self.thread.start()
+        log.info("Listening for HTTP requests on %s:%d", self.address or '*', self.port)
+
+    def get_response(self, request):
+        """The body to send back. Override this, or pass 'response' to the constructor."""
+        if callable(self.response):
+            return self.response(request)
+        return self.response
+
+    def close(self):
+        """Stop the server and release the port."""
+        super().close()
+        if self.server is not None:
+            self.server.shutdown()
+            self.server.server_close()
+            self.server = None
+        if self.thread is not None:
+            self.thread.join(POLL_INTERVAL * 2)
+            self.thread = None
+        log.info("Stopped listening on port %d", self.port)
+
+
+def _as_list(option):
+    """Return an option as a list of strings. configobj may hand over either."""
+    if not option:
+        return []
+    if isinstance(option, str):
+        return [x.strip() for x in option.split(',') if x.strip()]
+    return [str(x).strip() for x in option]
+
+
+class _Server(ThreadingHTTPServer):
+    """The HTTP server. Knows which listener to hand its requests to."""
+
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, listener, address, port):
+        self.listener = listener
+        # Pick the address family from the address itself, so that an IPv6 address
+        # works without any further configuration.
+        self.address_family = _address_family(address, port)
+        super().__init__((address, port), _Handler)
+
+    def handle_error(self, request, client_address):
+        """Log the error rather than printing a traceback to stderr."""
+        log.error("Error while handling a request from %s", client_address, exc_info=True)
+
+
+def _address_family(address, port):
+    """Return the address family to use for an address."""
+    if not address:
+        return socket.AF_INET
+    try:
+        info = socket.getaddrinfo(address, port, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return socket.AF_INET
+    return info[0][0] if info else socket.AF_INET
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Turn a request into a Request object and queue it."""
+
+    # HTTP/1.0, so a connection is closed after every response. Devices upload and go.
+    protocol_version = 'HTTP/1.0'
+
+    @property
+    def timeout(self):
+        return self.server.listener.socket_timeout
+
+    def do_GET(self):
+        self._handle(b'')
+
+    def do_POST(self):
+        listener = self.server.listener
+        try:
+            length = int(self.headers.get('Content-Length', 0))
+        except ValueError:
+            self.send_error(400, "Bad Content-Length")
+            return
+        if length > listener.max_body:
+            log.warning("Request from %s is %d bytes, over the limit of %d",
+                        self._client_address(), length, listener.max_body)
+            self.send_error(413, "Request body too large")
+            return
+        self._handle(self.rfile.read(length) if length else b'')
+
+    def _handle(self, body):
+        listener = self.server.listener
+        client = self._client_address()
+
+        if listener.allowed_hosts and client not in listener.allowed_hosts:
+            log.warning("Rejected a request from %s", client)
+            self.send_error(403, "Forbidden")
+            return
+
+        parts = urllib.parse.urlsplit(self.path)
+        if listener.path is not None and parts.path.rstrip('/') != listener.path.rstrip('/'):
+            self.send_error(404, "Not Found")
+            return
+
+        request = Request(method=self.command,
+                          path=parts.path,
+                          query=parts.query,
+                          body=body,
+                          headers={k.lower(): v for k, v in self.headers.items()},
+                          client_address=client)
+
+        if listener.log_raw:
+            log.debug("Raw request: %s", request.text)
+
+        # Answer first, then queue. Some devices treat an upload as failed if the
+        # response is slow, and a full queue must not hold up the reply.
+        try:
+            response = listener.get_response(request)
+        except Exception as e:
+            log.error("Error while building a response: %s", e)
+            response = ''
+        self._respond(response, listener.content_type)
+
+        listener.put(request)
+
+    def _respond(self, response, content_type):
+        if isinstance(response, str):
+            response = response.encode('utf-8')
+        elif response is None:
+            response = b''
+        self.send_response(200)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(response)))
+        self.end_headers()
+        if response:
+            self.wfile.write(response)
+
+    def _client_address(self):
+        if self.server.listener.trust_proxy:
+            forwarded = self.headers.get('X-Forwarded-For')
+            if forwarded:
+                return forwarded.split(',')[0].strip()
+        return self.client_address[0]
+
+    def log_message(self, fmt, *args):
+        """Send the server's own chatter to the log instead of stderr."""
+        log.debug("%s %s", self.client_address[0], fmt % args)

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -1,0 +1,253 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test module weewx.listener"""
+
+import http.client
+import queue
+import time
+
+import pytest
+
+from weewx.listener import HTTPListener, Request
+
+ECOWITT_BODY = ("PASSKEY=ABC&stationtype=GW1000B_V1.5.5&dateutc=2026-08-25+11:29:50"
+                "&tempinf=67.1&humidityin=39&baromrelin=30.138")
+
+
+@pytest.fixture
+def make_listener():
+    """Hand out listeners on a free port, and close them afterwards."""
+    made = []
+
+    def _make(**kwargs):
+        kwargs.setdefault('port', 0)
+        kwargs.setdefault('address', '127.0.0.1')
+        listener = HTTPListener(**kwargs)
+        made.append(listener)
+        return listener
+
+    yield _make
+
+    for listener in made:
+        listener.close()
+
+
+def send(listener, method='POST', path='/', body=None, headers=None):
+    """Send one request. Returns (status, response body)."""
+    conn = http.client.HTTPConnection('127.0.0.1', listener.port, timeout=5)
+    try:
+        conn.request(method, path, body, headers or {})
+        response = conn.getresponse()
+        return response.status, response.read()
+    finally:
+        conn.close()
+
+
+def test_post_arrives(make_listener):
+    listener = make_listener()
+    status, _ = send(listener, body=ECOWITT_BODY)
+    assert status == 200
+
+    request = listener.get(timeout=5)
+    assert request is not None
+    assert request.method == 'POST'
+    assert request.path == '/'
+    assert request.body == ECOWITT_BODY.encode('utf-8')
+    assert request.text == ECOWITT_BODY
+    assert request.client_address == '127.0.0.1'
+
+
+def test_get_carries_the_query(make_listener):
+    """A Weather Underground client uses GET, and the data are in the query."""
+    listener = make_listener()
+    status, _ = send(listener, method='GET',
+                     path='/weatherstation/updateweatherstation.php?tempf=61.0&humidity=82')
+    assert status == 200
+
+    request = listener.get(timeout=5)
+    assert request.method == 'GET'
+    assert request.path == '/weatherstation/updateweatherstation.php'
+    assert request.query == 'tempf=61.0&humidity=82'
+    # 'text' falls back to the query, so a parser can use it for either protocol.
+    assert request.text == 'tempf=61.0&humidity=82'
+
+
+def test_iteration(make_listener):
+    listener = make_listener()
+    send(listener, body='first')
+    send(listener, body='second')
+
+    collected = []
+    for request in listener:
+        collected.append(request.text)
+        if len(collected) == 2:
+            break
+    assert collected == ['first', 'second']
+
+
+def test_iteration_stops_when_closed(make_listener):
+    listener = make_listener()
+    listener.close()
+    assert list(listener) == []
+
+
+def test_static_response(make_listener):
+    listener = make_listener(response='{"errcode":"0","errmsg":"ok"}',
+                             content_type='application/json')
+    status, body = send(listener, body=ECOWITT_BODY)
+    assert status == 200
+    assert body == b'{"errcode":"0","errmsg":"ok"}'
+
+
+def test_callable_response(make_listener):
+    listener = make_listener(response=lambda request: "saw %d bytes" % len(request.body))
+    _, body = send(listener, body='12345')
+    assert body == b'saw 5 bytes'
+
+
+def test_response_error_does_not_kill_the_request(make_listener):
+    """A driver that raises while building a response still gets its data."""
+
+    def explode(_request):
+        raise ValueError("no response for you")
+
+    listener = make_listener(response=explode)
+    status, body = send(listener, body=ECOWITT_BODY)
+    assert status == 200
+    assert body == b''
+    assert listener.get(timeout=5).text == ECOWITT_BODY
+
+
+def test_path_filter(make_listener):
+    listener = make_listener(path='/data/report/')
+
+    status, _ = send(listener, path='/somewhere/else', body=ECOWITT_BODY)
+    assert status == 404
+
+    status, _ = send(listener, path='/data/report/', body=ECOWITT_BODY)
+    assert status == 200
+    # A trailing slash is not a difference worth a 404.
+    status, _ = send(listener, path='/data/report', body=ECOWITT_BODY)
+    assert status == 200
+
+    assert listener.queue.qsize() == 2
+
+
+def test_body_over_the_limit_is_refused(make_listener):
+    listener = make_listener(max_body=64)
+    status, _ = send(listener, body='x' * 65)
+    assert status == 413
+    assert listener.get(timeout=0.5) is None
+
+
+def test_bad_content_length(make_listener):
+    listener = make_listener()
+    status, _ = send(listener, body=ECOWITT_BODY, headers={'Content-Length': 'garbage'})
+    assert status == 400
+
+
+def test_allowed_hosts(make_listener):
+    listener = make_listener(allowed_hosts='192.168.1.5')
+    status, _ = send(listener, body=ECOWITT_BODY)
+    assert status == 403
+    assert listener.get(timeout=0.5) is None
+
+
+def test_allowed_hosts_as_a_list(make_listener):
+    """configobj hands over a list when the option holds a comma."""
+    listener = make_listener(allowed_hosts=['192.168.1.5', '127.0.0.1'])
+    status, _ = send(listener, body=ECOWITT_BODY)
+    assert status == 200
+
+
+def test_trust_proxy(make_listener):
+    listener = make_listener(trust_proxy=True)
+    send(listener, body=ECOWITT_BODY, headers={'X-Forwarded-For': '10.0.0.9, 10.0.0.1'})
+    assert listener.get(timeout=5).client_address == '10.0.0.9'
+
+
+def test_proxy_header_ignored_unless_trusted(make_listener):
+    listener = make_listener()
+    send(listener, body=ECOWITT_BODY, headers={'X-Forwarded-For': '10.0.0.9'})
+    assert listener.get(timeout=5).client_address == '127.0.0.1'
+
+
+def test_options_may_be_strings(make_listener):
+    """A driver hands over its configuration stanza, where everything is a string."""
+    listener = make_listener(max_body='64', queue_size='3', trust_proxy='true',
+                             log_raw='false', socket_timeout='5')
+    assert listener.max_body == 64
+    assert listener.queue_size == 3
+    assert listener.trust_proxy is True
+    assert listener.log_raw is False
+
+    status, _ = send(listener, body='x' * 65)
+    assert status == 413
+
+
+def test_full_queue_drops_the_oldest(make_listener):
+    listener = make_listener(queue_size=2)
+    for i in range(4):
+        send(listener, body=str(i))
+
+    # Wait for the last one to be queued before looking.
+    deadline = time.time() + 5
+    while listener.dropped < 2 and time.time() < deadline:
+        time.sleep(0.05)
+
+    assert listener.dropped == 2
+    assert [listener.get(timeout=1).text for _ in range(2)] == ['2', '3']
+
+
+def test_get_returns_none_on_timeout(make_listener):
+    listener = make_listener()
+    start = time.time()
+    assert listener.get(timeout=0.2) is None
+    assert time.time() - start < 5
+
+
+def test_close_releases_the_port(make_listener):
+    listener = make_listener()
+    port = listener.port
+    listener.close()
+    # Closing twice is not an error.
+    listener.close()
+
+    with pytest.raises(OSError):
+        conn = http.client.HTTPConnection('127.0.0.1', port, timeout=2)
+        conn.request('POST', '/', ECOWITT_BODY)
+        conn.getresponse()
+
+
+def test_context_manager():
+    with HTTPListener(port=0, address='127.0.0.1') as listener:
+        assert listener.port != 0
+        port = listener.port
+    with pytest.raises(OSError):
+        conn = http.client.HTTPConnection('127.0.0.1', port, timeout=2)
+        conn.request('POST', '/', ECOWITT_BODY)
+        conn.getresponse()
+
+
+def test_port_in_use():
+    """A port that is already taken is reported where the driver is built."""
+    first = HTTPListener(port=0, address='127.0.0.1')
+    try:
+        with pytest.raises(OSError):
+            HTTPListener(port=first.port, address='127.0.0.1')
+    finally:
+        first.close()
+
+
+def test_request_str():
+    request = Request('POST', '/data/report/', '', b'abc', {}, '10.0.0.9')
+    assert str(request) == "POST /data/report/ from 10.0.0.9, 3 bytes"
+
+
+def test_queue_is_not_unbounded(make_listener):
+    listener = make_listener(queue_size=1)
+    assert isinstance(listener.queue, queue.Queue)
+    assert listener.queue.maxsize == 1

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -163,6 +163,63 @@ def test_allowed_hosts_as_a_list(make_listener):
     assert status == 200
 
 
+def test_token_in_the_query(make_listener):
+    listener = make_listener(token='s3cret')
+    status, _ = send(listener, path='/?token=s3cret', body=ECOWITT_BODY)
+    assert status == 200
+    assert listener.get(timeout=5) is not None
+
+
+def test_token_in_a_header(make_listener):
+    listener = make_listener(token='s3cret')
+    status, _ = send(listener, body=ECOWITT_BODY, headers={'X-Auth-Token': 's3cret'})
+    assert status == 200
+
+
+def test_token_as_a_bearer(make_listener):
+    listener = make_listener(token='s3cret')
+    status, _ = send(listener, body=ECOWITT_BODY,
+                     headers={'Authorization': 'Bearer s3cret'})
+    assert status == 200
+
+
+def test_wrong_token(make_listener):
+    listener = make_listener(token='s3cret')
+    status, _ = send(listener, path='/?token=wrong', body=ECOWITT_BODY)
+    assert status == 403
+    assert listener.get(timeout=0.5) is None
+
+
+def test_missing_token(make_listener):
+    listener = make_listener(token='s3cret')
+    status, _ = send(listener, body=ECOWITT_BODY)
+    assert status == 403
+
+
+def test_no_token_required(make_listener):
+    listener = make_listener()
+    status, _ = send(listener, body=ECOWITT_BODY, headers={'X-Auth-Token': 'anything'})
+    assert status == 200
+
+
+def test_token_with_non_ascii(make_listener):
+    """A token outside ASCII must not crash the comparison."""
+    listener = make_listener(token='grün')
+    status, _ = send(listener, body=ECOWITT_BODY, headers={'X-Auth-Token': 'grün'})
+    assert status == 200
+    status, _ = send(listener, body=ECOWITT_BODY, headers={'X-Auth-Token': 'blau'})
+    assert status == 403
+
+
+def test_token_in_the_path(make_listener):
+    """A device that can only be given a URL carries its token in the path."""
+    listener = make_listener(path='/a8f3c1/report')
+    status, _ = send(listener, path='/a8f3c1/report', body=ECOWITT_BODY)
+    assert status == 200
+    status, _ = send(listener, path='/report', body=ECOWITT_BODY)
+    assert status == 404
+
+
 def test_trust_proxy(make_listener):
     listener = make_listener(trust_proxy=True)
     send(listener, body=ECOWITT_BODY, headers={'X-Forwarded-For': '10.0.0.9, 10.0.0.1'})

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -15,6 +15,7 @@ import time
 
 import pytest
 
+import weewx
 import weewx.listener
 from weewx.listener import HTTPListener, Request, UDPListener
 
@@ -428,3 +429,33 @@ def test_udp_context_manager():
         assert listener.port != 0
         send_udp(listener, TEMPEST_OBS)
         assert listener.get(timeout=5).text == TEMPEST_OBS
+
+
+def test_a_dead_thread_is_not_silence(make_listener):
+    """Nothing restarts the listening thread, so a driver must not wait for good."""
+    listener = make_listener()
+    listener.server.shutdown()
+    while listener.thread.is_alive():
+        pass
+
+    with pytest.raises(weewx.WeeWxIOError):
+        listener.get(timeout=2)
+
+
+def test_a_dead_udp_thread_is_not_silence(make_udp_listener):
+    listener = make_udp_listener()
+    listener.socket.close()
+    while listener.thread.is_alive():
+        pass
+
+    with pytest.raises(weewx.WeeWxIOError):
+        listener.get(timeout=2)
+
+
+def test_closing_is_not_an_error(make_listener):
+    """A thread that stopped because we asked it to is not a failure."""
+    listener = make_listener()
+    listener.close()
+
+    assert listener.get(timeout=1) is None
+    assert list(listener) == []

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -142,6 +142,57 @@ def test_path_filter(make_listener):
     assert listener.queue.qsize() == 2
 
 
+def test_several_paths(make_listener):
+    """A driver with more than one kind of hardware answers on more than one path."""
+    listener = make_listener(path=['/data/report/', '/weatherstation/update'])
+
+    assert send(listener, path='/data/report/', body=ECOWITT_BODY)[0] == 200
+    assert send(listener, path='/weatherstation/update', body=ECOWITT_BODY)[0] == 200
+    assert send(listener, path='/somewhere/else', body=ECOWITT_BODY)[0] == 404
+
+    assert listener.queue.qsize() == 2
+
+
+def test_several_paths_as_one_string(make_listener):
+    """configobj hands over a comma-separated option as a list, but a driver may be
+    given the string as it was typed."""
+    listener = make_listener(path='/one/, /two/')
+
+    assert send(listener, path='/one/', body=ECOWITT_BODY)[0] == 200
+    assert send(listener, path='/two', body=ECOWITT_BODY)[0] == 200
+    assert send(listener, path='/three', body=ECOWITT_BODY)[0] == 404
+
+
+def test_a_path_that_is_decided_when_the_request_arrives(make_listener):
+    """Which paths are wanted is not always known when the socket is opened. A driver
+    that gives each station a path of its own has to be able to add one without
+    restarting WeeWX."""
+    wanted = {'/first/'}
+    listener = make_listener(path=lambda path: path.rstrip('/') + '/' in wanted)
+
+    assert send(listener, path='/first/', body=ECOWITT_BODY)[0] == 200
+    assert send(listener, path='/second/', body=ECOWITT_BODY)[0] == 404
+
+    wanted.add('/second/')
+    assert send(listener, path='/second/', body=ECOWITT_BODY)[0] == 200
+
+
+def test_every_path_by_default(make_listener):
+    listener = make_listener()
+
+    assert send(listener, path='/anything/at/all', body=ECOWITT_BODY)[0] == 200
+
+
+def test_a_path_nobody_wants_is_not_queued(make_listener):
+    """The 404 comes before the request is built, so a driver iterating the listener
+    never sees it and a flood of them cannot push real readings out of the queue."""
+    listener = make_listener(path='/data/report/')
+
+    send(listener, path='/somewhere/else', body=ECOWITT_BODY)
+
+    assert listener.queue.empty()
+
+
 def test_body_over_the_limit_is_refused(make_listener):
     listener = make_listener(max_body=64)
     status, _ = send(listener, body='x' * 65)

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -6,11 +6,15 @@
 """Test module weewx.listener"""
 
 import http.client
+import importlib
+import logging
 import queue
+import threading
 import time
 
 import pytest
 
+import weewx.listener
 from weewx.listener import HTTPListener, Request
 
 ECOWITT_BODY = ("PASSKEY=ABC&stationtype=GW1000B_V1.5.5&dateutc=2026-08-25+11:29:50"
@@ -289,14 +293,24 @@ def test_context_manager():
         conn.getresponse()
 
 
-def test_port_in_use():
+def test_port_in_use(caplog):
     """A port that is already taken is reported where the driver is built."""
     first = HTTPListener(port=0, address='127.0.0.1')
     try:
-        with pytest.raises(OSError):
-            HTTPListener(port=first.port, address='127.0.0.1')
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(OSError):
+                HTTPListener(port=first.port, address='127.0.0.1')
+        assert "Cannot listen on 127.0.0.1:%d" % first.port in caplog.text
     finally:
         first.close()
+
+
+def test_importing_the_module_starts_nothing():
+    """The listener is a library. Upgrading to a version that has it changes nothing
+    for a station whose driver does not ask for one."""
+    before = threading.active_count()
+    importlib.reload(weewx.listener)
+    assert threading.active_count() == before
 
 
 def test_request_str():

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -459,3 +459,35 @@ def test_closing_is_not_an_error(make_listener):
 
     assert listener.get(timeout=1) is None
     assert list(listener) == []
+
+
+def test_a_queue_size_of_zero_is_not_unbounded(make_listener):
+    """queue.Queue(maxsize=0) is unbounded, which is what this guards against."""
+    listener = make_listener(queue_size=0)
+
+    assert listener.queue.maxsize == 1
+
+
+def test_a_zero_timeout_returns_promptly(make_listener):
+    listener = make_listener()
+    start = time.time()
+
+    assert listener.get(timeout=0) is None
+    assert time.time() - start < 1
+
+
+def test_a_negative_timeout_is_not_an_error(make_listener):
+    listener = make_listener()
+
+    assert listener.get(timeout=-5) is None
+
+
+def test_closing_a_udp_listener_does_not_race_its_thread(make_udp_listener):
+    """The reading thread must not find the socket gone mid-call."""
+    listener = make_udp_listener()
+    for _ in range(20):
+        send_udp(listener, TEMPEST_OBS)
+    listener.close()
+
+    assert listener.thread is None
+    assert listener.socket is None

--- a/src/weewx/tests/test_listener.py
+++ b/src/weewx/tests/test_listener.py
@@ -9,13 +9,14 @@ import http.client
 import importlib
 import logging
 import queue
+import socket
 import threading
 import time
 
 import pytest
 
 import weewx.listener
-from weewx.listener import HTTPListener, Request
+from weewx.listener import HTTPListener, Request, UDPListener
 
 ECOWITT_BODY = ("PASSKEY=ABC&stationtype=GW1000B_V1.5.5&dateutc=2026-08-25+11:29:50"
                 "&tempinf=67.1&humidityin=39&baromrelin=30.138")
@@ -322,3 +323,108 @@ def test_queue_is_not_unbounded(make_listener):
     listener = make_listener(queue_size=1)
     assert isinstance(listener.queue, queue.Queue)
     assert listener.queue.maxsize == 1
+
+
+# ---------------------------------------------------------------------------- UDP
+
+
+@pytest.fixture
+def make_udp_listener():
+    """Hand out UDP listeners on a free port, and close them afterwards."""
+    made = []
+
+    def _make(**kwargs):
+        kwargs.setdefault('port', 0)
+        kwargs.setdefault('address', '127.0.0.1')
+        listener = UDPListener(**kwargs)
+        made.append(listener)
+        return listener
+
+    yield _make
+
+    for listener in made:
+        listener.close()
+
+
+def send_udp(listener, payload):
+    """Send one datagram to a listener."""
+    if isinstance(payload, str):
+        payload = payload.encode('utf-8')
+    sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sender.sendto(payload, ('127.0.0.1', listener.port))
+    finally:
+        sender.close()
+
+
+TEMPEST_OBS = '{"serial_number":"ST-00000512","type":"obs_st","hub_sn":"HB-00013030"}'
+
+
+def test_datagram_arrives(make_udp_listener):
+    listener = make_udp_listener()
+    send_udp(listener, TEMPEST_OBS)
+
+    request = listener.get(timeout=5)
+    assert request is not None
+    assert request.method == 'UDP'
+    assert request.text == TEMPEST_OBS
+    assert request.client_address == '127.0.0.1'
+
+
+def test_udp_iteration(make_udp_listener):
+    listener = make_udp_listener()
+    send_udp(listener, 'first')
+    send_udp(listener, 'second')
+
+    collected = []
+    for request in listener:
+        collected.append(request.text)
+        if len(collected) == 2:
+            break
+    assert collected == ['first', 'second']
+
+
+def test_udp_allowed_hosts(make_udp_listener):
+    listener = make_udp_listener(allowed_hosts='192.168.1.5')
+    send_udp(listener, TEMPEST_OBS)
+    assert listener.get(timeout=0.5) is None
+
+
+def test_udp_body_is_capped(make_udp_listener):
+    """UDP has no way to refuse an oversized datagram, so it is read short."""
+    listener = make_udp_listener(max_body=8)
+    send_udp(listener, 'x' * 100)
+    assert listener.get(timeout=5).body == b'x' * 8
+
+
+def test_udp_options_may_be_strings(make_udp_listener):
+    listener = make_udp_listener(max_body='512', queue_size='3', reuse_address='true',
+                                 log_raw='false')
+    assert listener.max_body == 512
+    assert listener.queue_size == 3
+    assert listener.reuse_address is True
+
+
+def test_udp_port_may_be_shared(make_udp_listener):
+    """Broadcasts are usually wanted by more than one program on the machine."""
+    first = make_udp_listener()
+    second = make_udp_listener(port=first.port)
+    assert second.port == first.port
+
+
+def test_udp_close_releases_the_port(make_udp_listener):
+    listener = make_udp_listener(reuse_address=False)
+    port = listener.port
+    listener.close()
+    listener.close()
+
+    # Binding again is proof the socket is gone.
+    again = UDPListener(port=port, address='127.0.0.1', reuse_address=False)
+    again.close()
+
+
+def test_udp_context_manager():
+    with UDPListener(port=0, address='127.0.0.1') as listener:
+        assert listener.port != 0
+        send_udp(listener, TEMPEST_OBS)
+        assert listener.get(timeout=5).text == TEMPEST_OBS


### PR DESCRIPTION
Adds `weewx.listener`, so a driver for hardware that pushes does not have to write
its own server. Closes #1124.

Submitting to `development`, as this is a feature.

`HTTPListener` and `UDPListener` share a `Listener` that owns the queue and the
iteration. A driver is left with the part that differs between devices:

``` python
from weewx.listener import HTTPListener

class MyDriver(weewx.drivers.AbstractDevice):

    def __init__(self, **stn_dict):
        self.listener = HTTPListener(**stn_dict)

    def genLoopPackets(self):
        for request in self.listener:
            packet = self.parse(request.text)
            if packet:
                yield packet

    def closePort(self):
        self.listener.close()
```

The listener owns the socket, the thread, a bounded queue and the shutdown. It binds
in the constructor, so a port already in use is reported where the driver is built.
It raises `WeeWxIOError` once it has stopped listening, because from a driver that is
otherwise indistinguishable from a station that went quiet.

What stays with the driver: parsing, field maps, units, and the response, which is
part of the protocol.

No new dependencies: `hmac`, `logging`, `queue`, `socket`, `threading`,
`urllib.parse`, `http.server`, and `to_int`/`to_bool` from `weeutil`.

46 tests in `test_listener.py`, `--target=3.7` clean, full suite 420 passed.
Documented under *Porting to new hardware*, with a change log entry.

One thing I left out. With `MetaDriver`, two receiving drivers can now run in one
process, and they need two ports. A shared listener dispatching by path would fix
that, and `path` is already there for it, but it wants process-wide state and I would
rather add it when somebody has the setup than guess at it now.

## First consumer

<https://github.com/hilman2/weewx-ecowitt>, which I wrote on top of this. It has been
running against an HP2561AE console since today, using the listener from this branch
rather than its bundled copy.

It is also where the encapsulation pays off. Its protocol, catalog and mapping import
without WeeWX, so its tests run from captured payloads with no socket and no engine,
and `python -m user.ecowitt` runs the listener directly to show what a station sends
before anything is configured.
