### PR TITLE
Do not lose an archive record when two periods end in one loop

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -5,6 +5,7 @@ WeeWX change history
 
 Fix loss of an archive record when the main loop runs past the end of two archive
 periods without being broken.
+[PR #1126](https://github.com/weewx/weewx/pull/1126).
 
 Say so in the log when a Vantage logger returns far fewer archive records than it
 said it would, which is what corrupt logger memory looks like, and link to the fix.

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,9 @@ WeeWX change history
 
 ### 5.5.n n-Month-2026
 
+Fix loss of an archive record when the main loop runs past the end of two archive
+periods without being broken.
+
 Say so in the log when a Vantage logger returns far fewer archive records than it
 said it would, which is what corrupt logger memory looks like, and link to the fix.
 Fixes [Issue #1105](https://github.com/weewx/weewx/issues/1105).

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -556,9 +556,6 @@ class StdArchive(StdService):
         # than one can be waiting, because the loop is not broken until archive_delay
         # after a period ends, and a packet arriving before that does not break it.
         self.accumulators = collections.deque()
-        # The accumulator whose record is being made, so that new_archive_record can
-        # augment it. None the rest of the time.
-        self.old_accumulator = None
 
         if self.record_generation == 'software':
             self.archive_interval = software_interval
@@ -637,7 +634,6 @@ class StdArchive(StdService):
             start_archive_period_ts = weeutil.weeutil.startOfInterval(now, self.archive_interval)
             self.end_archive_period_ts = start_archive_period_ts + self.archive_interval
             self.end_archive_delay_ts = self.end_archive_period_ts + self.archive_delay
-        self.old_accumulator = None
 
     def new_loop_packet(self, event):
         """Called when A new LOOP record has arrived."""
@@ -669,7 +665,9 @@ class StdArchive(StdService):
                 return accumulator
         accumulator = self._new_accumulator(timestamp)
         place = 0
-        while place < len(self.accumulators)                 and self.accumulators[place].timespan.stop > accumulator.timespan.stop:
+        for held in self.accumulators:
+            if held.timespan.stop < accumulator.timespan.stop:
+                break
             place += 1
         self.accumulators.insert(place, accumulator)
         return accumulator
@@ -703,8 +701,8 @@ class StdArchive(StdService):
         # in the small time interval between the end of the archive interval and the
         # end of the archive delay period, there is nothing behind it yet.
         while len(self.accumulators) > 1:
-            self.old_accumulator = self.accumulators.pop()
-            # If the user has requested software generation, then do that:
+            # The one at the back stays there until its record has been dispatched,
+            # because new_archive_record uses it to augment the record.
             if self.record_generation == 'software':
                 self._software_catchup()
             elif self.record_generation == 'hardware':
@@ -716,10 +714,9 @@ class StdArchive(StdService):
                 except NotImplementedError:
                     self._software_catchup()
             else:
-                self.old_accumulator = None
                 raise ValueError("Unknown station record generation value %s"
                                  % self.record_generation)
-            self.old_accumulator = None
+            self.accumulators.pop()
 
         # Set the time of the next break loop:
         self.end_archive_delay_ts = self.end_archive_period_ts + self.archive_delay
@@ -731,15 +728,16 @@ class StdArchive(StdService):
         # If requested, extract any extra information we can out of the accumulator and put it in
         # the record. Not necessary in the case of software record generation because it has
         # already been done.
+        accumulator = self._finished_accumulator()
         if self.record_augmentation \
-                and self.old_accumulator \
-                and event.record['dateTime'] == self.old_accumulator.timespan.stop \
+                and accumulator \
+                and event.record['dateTime'] == accumulator.timespan.stop \
                 and event.origin != 'software':
-            self.old_accumulator.augmentRecord(event.record)
+            accumulator.augmentRecord(event.record)
 
         dbmanager = self.engine.db_binder.get_manager(self.data_binding)
         dbmanager.addRecord(event.record,
-                            accumulator=self.old_accumulator,
+                            accumulator=accumulator,
                             log_success=self.log_success,
                             log_failure=self.log_failure)
 
@@ -772,9 +770,15 @@ class StdArchive(StdService):
             log.error("Internal error detected. Catchup abandoned")
             log.error("**** %s" % e)
 
+    def _finished_accumulator(self):
+        """The accumulator whose record is being made, or None outside of that.
+
+        Everything but the one at the front has ended, so it is the one at the back."""
+        return self.accumulators[-1] if len(self.accumulators) > 1 else None
+
     def _software_catchup(self):
-        # Extract a record out of the old accumulator. 
-        record = self.old_accumulator.getRecord()
+        # Extract a record out of the accumulator whose period has ended.
+        record = self._finished_accumulator().getRecord()
         # Add the archive interval
         record['interval'] = self.archive_interval / 60
         # Send out an event with the new record:

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -7,6 +7,7 @@
 """Main engine for the weewx weather system."""
 
 # Python imports
+import collections
 import gc
 import importlib
 import logging
@@ -550,14 +551,14 @@ class StdArchive(StdService):
         self.end_archive_period_ts = None
         # The timestamp that marks the end of the archive period, plus a delay
         self.end_archive_delay_ts = None
-        # The accumulator to be used for the current archive period
-        self.accumulator = None
-        # The accumulator that was used for the last archive period. Set to None after it has
-        # been processed.
+        # Accumulators, newest first. The one at the front is the period being filled;
+        # anything behind it has ended and is waiting for the loop to be broken. More
+        # than one can be waiting, because the loop is not broken until archive_delay
+        # after a period ends, and a packet arriving before that does not break it.
+        self.accumulators = collections.deque()
+        # The accumulator whose record is being made, so that new_archive_record can
+        # augment it. None the rest of the time.
         self.old_accumulator = None
-        # Accumulators for periods that have ended and are waiting for the loop to be
-        # broken, oldest first.
-        self.old_accumulators = []
 
         if self.record_generation == 'software':
             self.archive_interval = software_interval
@@ -642,22 +643,20 @@ class StdArchive(StdService):
         """Called when A new LOOP record has arrived."""
 
         # Do we have an accumulator at all? If not, create one:
-        if not self.accumulator:
-            self.accumulator = self._new_accumulator(event.packet['dateTime'])
+        if not self.accumulators:
+            self.accumulators.appendleft(self._new_accumulator(event.packet['dateTime']))
 
-        # Try adding the LOOP packet to the existing accumulator. If the
+        # Try adding the LOOP packet to the current accumulator. If the
         # timestamp is outside the timespan of the accumulator, an exception
         # will be thrown:
         try:
-            self.accumulator.addRecord(event.packet, add_hilo=self.loop_hilo)
+            self.accumulators[0].addRecord(event.packet, add_hilo=self.loop_hilo)
         except weewx.accum.OutOfSpan:
-            # Shuffle accumulators. The old one joins the queue rather than replacing
-            # whatever was already in it: more than one period can end before the loop
-            # is broken, and an accumulator that is replaced never becomes a record.
-            self.old_accumulators.append(self.accumulator)
-            self.accumulator = self._new_accumulator(event.packet['dateTime'])
+            # Put a new one at the front. The old one drops back a place rather than
+            # being replaced: an accumulator that is replaced never becomes a record.
+            self.accumulators.appendleft(self._new_accumulator(event.packet['dateTime']))
             # Try again:
-            self.accumulator.addRecord(event.packet, add_hilo=self.loop_hilo)
+            self.accumulators[0].addRecord(event.packet, add_hilo=self.loop_hilo)
 
     def check_loop(self, event):
         """Called after any loop packets have been processed. This is the opportunity
@@ -680,15 +679,15 @@ class StdArchive(StdService):
         """The main packet loop has ended, so process the old accumulators.
 
         Usually there is one, for the period that just ended. Where the loop ran past
-        the end of a period without being broken there can be more, and they are done
-        oldest first, so that the records reach the database in order.
+        the end of a period without being broken there can be more, and they come off
+        the back of the queue oldest first, so that the records reach the database in
+        order.
         """
-        # If weewx happens to startup in the small time interval between the end of
-        # the archive interval and the end of the archive delay period, then
-        # there will be no old accumulator. Check for this.
-        waiting, self.old_accumulators = self.old_accumulators, []
-        for accumulator in waiting:
-            self.old_accumulator = accumulator
+        # Everything but the one at the front has ended. If weewx happens to startup
+        # in the small time interval between the end of the archive interval and the
+        # end of the archive delay period, there is nothing behind it yet.
+        while len(self.accumulators) > 1:
+            self.old_accumulator = self.accumulators.pop()
             # If the user has requested software generation, then do that:
             if self.record_generation == 'software':
                 self._software_catchup()

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -644,7 +644,7 @@ class StdArchive(StdService):
 
         # Do we have an accumulator at all? If not, create one:
         if not self.accumulators:
-            self.accumulators.appendleft(self._new_accumulator(event.packet['dateTime']))
+            self.accumulators.append(self._new_accumulator(event.packet['dateTime']))
 
         # Try adding the LOOP packet to the current accumulator. If the
         # timestamp is outside the timespan of the accumulator, an exception
@@ -652,11 +652,27 @@ class StdArchive(StdService):
         try:
             self.accumulators[0].addRecord(event.packet, add_hilo=self.loop_hilo)
         except weewx.accum.OutOfSpan:
-            # Put a new one at the front. The old one drops back a place rather than
-            # being replaced: an accumulator that is replaced never becomes a record.
-            self.accumulators.appendleft(self._new_accumulator(event.packet['dateTime']))
-            # Try again:
-            self.accumulators[0].addRecord(event.packet, add_hilo=self.loop_hilo)
+            # The packet belongs to some other period. Find it, or make it.
+            self._accumulator_for(event.packet['dateTime']).addRecord(
+                event.packet, add_hilo=self.loop_hilo)
+
+    def _accumulator_for(self, timestamp):
+        """Return the accumulator whose period holds the given time, making one if
+        there is none.
+
+        The queue is kept in time order, newest at the front, rather than in arrival
+        order. A packet that is older than its predecessor happens whenever more than
+        one source feeds the loop, and it must not make an already running period look
+        like a finished one."""
+        for accumulator in self.accumulators:
+            if accumulator.timespan.includesArchiveTime(timestamp):
+                return accumulator
+        accumulator = self._new_accumulator(timestamp)
+        place = 0
+        while place < len(self.accumulators)                 and self.accumulators[place].timespan.stop > accumulator.timespan.stop:
+            place += 1
+        self.accumulators.insert(place, accumulator)
+        return accumulator
 
     def check_loop(self, event):
         """Called after any loop packets have been processed. This is the opportunity

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -555,6 +555,9 @@ class StdArchive(StdService):
         # The accumulator that was used for the last archive period. Set to None after it has
         # been processed.
         self.old_accumulator = None
+        # Accumulators for periods that have ended and are waiting for the loop to be
+        # broken, oldest first.
+        self.old_accumulators = []
 
         if self.record_generation == 'software':
             self.archive_interval = software_interval
@@ -648,9 +651,11 @@ class StdArchive(StdService):
         try:
             self.accumulator.addRecord(event.packet, add_hilo=self.loop_hilo)
         except weewx.accum.OutOfSpan:
-            # Shuffle accumulators:
-            (self.old_accumulator, self.accumulator) = \
-                (self.accumulator, self._new_accumulator(event.packet['dateTime']))
+            # Shuffle accumulators. The old one joins the queue rather than replacing
+            # whatever was already in it: more than one period can end before the loop
+            # is broken, and an accumulator that is replaced never becomes a record.
+            self.old_accumulators.append(self.accumulator)
+            self.accumulator = self._new_accumulator(event.packet['dateTime'])
             # Try again:
             self.accumulator.addRecord(event.packet, add_hilo=self.loop_hilo)
 
@@ -672,11 +677,18 @@ class StdArchive(StdService):
             raise BreakLoop
 
     def post_loop(self, _event):
-        """The main packet loop has ended, so process the old accumulator."""
+        """The main packet loop has ended, so process the old accumulators.
+
+        Usually there is one, for the period that just ended. Where the loop ran past
+        the end of a period without being broken there can be more, and they are done
+        oldest first, so that the records reach the database in order.
+        """
         # If weewx happens to startup in the small time interval between the end of
         # the archive interval and the end of the archive delay period, then
         # there will be no old accumulator. Check for this.
-        if self.old_accumulator:
+        waiting, self.old_accumulators = self.old_accumulators, []
+        for accumulator in waiting:
+            self.old_accumulator = accumulator
             # If the user has requested software generation, then do that:
             if self.record_generation == 'software':
                 self._software_catchup()
@@ -689,6 +701,7 @@ class StdArchive(StdService):
                 except NotImplementedError:
                     self._software_catchup()
             else:
+                self.old_accumulator = None
                 raise ValueError("Unknown station record generation value %s"
                                  % self.record_generation)
             self.old_accumulator = None

--- a/src/weewx/tests/test_archive_records.py
+++ b/src/weewx/tests/test_archive_records.py
@@ -1,0 +1,207 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test that StdArchive emits a record for every archive period that has data.
+
+The packets go through the same sequence of events the engine dispatches, and what is
+asserted is which records come out the other end.
+"""
+
+import time
+
+import configobj
+import pytest
+
+import weewx
+import weewx.accum
+import weewx.engine
+from weeutil.weeutil import startOfInterval
+
+INTERVAL = 300
+DELAY = 15
+START = int(startOfInterval(time.mktime((2026, 3, 10, 12, 0, 0, 0, 0, -1)), INTERVAL))
+
+
+class Console:
+    """A console with no archive of its own, i.e. software record generation."""
+
+    archive_interval = INTERVAL
+
+    def genArchiveRecords(self, since_ts):
+        raise NotImplementedError("No hardware archive")
+
+    def genStartupRecords(self, since_ts):
+        raise NotImplementedError("No hardware archive")
+
+
+class Manager:
+    """Collects what would go into the database."""
+
+    database_name = 'test.sdb'
+
+    def __init__(self):
+        self.records = []
+
+    def lastGoodStamp(self):
+        return self.records[-1]['dateTime'] if self.records else None
+
+    def _read_metadata(self, key):
+        return None
+
+    def backfill_day_summary(self):
+        return 0, 0
+
+    def addRecord(self, record, accumulator=None, log_success=True, log_failure=True):
+        self.records.append(record)
+
+
+class Engine:
+    """Just enough engine to dispatch events to one service."""
+
+    def __init__(self):
+        self.callbacks = {}
+        self.console = Console()
+        self.manager = Manager()
+        self.db_binder = self
+
+    def get_manager(self, binding, initialize=False):
+        return self.manager
+
+    def bind(self, event_type, callback):
+        self.callbacks.setdefault(event_type, []).append(callback)
+
+    def dispatchEvent(self, event):
+        for callback in self.callbacks.get(event.event_type, []):
+            callback(event)
+
+    def _get_console_time(self):
+        return START
+
+
+def config():
+    return configobj.ConfigObj({
+        'StdArchive': {
+            'record_generation': 'software',
+            'archive_interval': str(INTERVAL),
+            'archive_delay': str(DELAY),
+        },
+        'Accumulator': {},
+    })
+
+
+def packet(timestamp, **values):
+    # 'rain' is a sum, so one tip per packet means the rain in a record counts the
+    # packets that reached it.
+    p = {'dateTime': int(timestamp), 'usUnits': weewx.US, 'outTemp': 20.0, 'rain': 1.0}
+    p.update(values)
+    return p
+
+
+def run(*packets):
+    """Feed packets the way StdEngine.run() does. Returns the records written."""
+    engine = Engine()
+    weewx.engine.StdArchive(engine, config())
+    engine.dispatchEvent(weewx.Event(weewx.STARTUP))
+    engine.dispatchEvent(weewx.Event(weewx.PRE_LOOP))
+    for p in packets:
+        try:
+            engine.dispatchEvent(weewx.Event(weewx.NEW_LOOP_PACKET, packet=p))
+            engine.dispatchEvent(weewx.Event(weewx.CHECK_LOOP, packet=p))
+        except weewx.engine.BreakLoop:
+            engine.dispatchEvent(weewx.Event(weewx.POST_LOOP))
+            engine.dispatchEvent(weewx.Event(weewx.PRE_LOOP))
+    return engine.manager.records
+
+
+def test_a_period_is_not_lost_when_the_loop_runs_past_two_boundaries():
+    """The bug.
+
+    The loop is broken 'archive_delay' seconds after a period ends. A packet that
+    arrives before that does not break it, so a second period can end while the first
+    one's accumulator is still waiting. It used to be replaced, and its record was
+    never written.
+    """
+    records = run(
+        packet(START + 30),                      # period 1
+        packet(START + INTERVAL + 9),            # period 2 begins, no break yet
+        packet(START + INTERVAL + 12),
+        packet(START + 2 * INTERVAL + 8),        # period 3 begins, break at last
+        packet(START + 2 * INTERVAL + 200),
+    )
+
+    assert [r['dateTime'] for r in records] == [START + INTERVAL, START + 2 * INTERVAL]
+
+
+def test_no_reading_is_dropped_along_the_way():
+    """Every packet reaches the record its timestamp belongs to.
+
+    One packet per period, arriving just after the boundary and so before the delay
+    that breaks the loop. That is a driver polling an API on the archive interval, and
+    it is the shape in which whole periods used to go missing.
+    """
+    packets = [packet(START + n * INTERVAL + 9) for n in range(12)]
+    packets.append(packet(START + 12 * INTERVAL + 200))
+
+    records = run(*packets)
+    written = sum(r.get('rain') or 0 for r in records)
+
+    # Twelve periods with a packet each. The thirteenth packet closes the last of
+    # them and then waits in a period of its own, which the stream never reaches.
+    assert len(records) == 12
+    assert written == 12
+
+
+def test_the_records_come_out_in_order():
+    records = run(
+        packet(START + 30),
+        packet(START + INTERVAL + 9),
+        packet(START + 2 * INTERVAL + 8),
+        packet(START + 3 * INTERVAL + 7),
+        packet(START + 3 * INTERVAL + 200),
+    )
+    times = [r['dateTime'] for r in records]
+
+    assert times == sorted(times)
+    assert len(times) == 3
+
+
+def test_the_usual_case_is_one_record_per_period():
+    """A station reporting every few seconds, which is most of them."""
+    packets = [packet(START + n * 10) for n in range(1, 120)]
+
+    records = run(*packets)
+
+    assert [r['dateTime'] for r in records] == [START + INTERVAL, START + 2 * INTERVAL,
+                                                START + 3 * INTERVAL]
+
+
+def test_a_period_with_no_packets_at_all_yields_no_record():
+    """Issue #219: an empty period must not raise, and must not invent a record."""
+    records = run(
+        packet(START + 30),
+        packet(START + 3 * INTERVAL + 30),        # two silent periods in between
+        packet(START + 3 * INTERVAL + 200),
+    )
+
+    assert [r['dateTime'] for r in records] == [START + INTERVAL]
+
+
+def test_a_single_packet_writes_nothing_yet():
+    assert run(packet(START + 30)) == []
+
+
+def test_an_unknown_generation_still_raises():
+    engine = Engine()
+    archive = weewx.engine.StdArchive(engine, config())
+    engine.dispatchEvent(weewx.Event(weewx.STARTUP))
+    engine.dispatchEvent(weewx.Event(weewx.PRE_LOOP))
+    archive.record_generation = 'nonsense'
+    engine.dispatchEvent(weewx.Event(weewx.NEW_LOOP_PACKET, packet=packet(START + 30)))
+    engine.dispatchEvent(weewx.Event(weewx.NEW_LOOP_PACKET,
+                                     packet=packet(START + INTERVAL + 30)))
+
+    with pytest.raises(ValueError):
+        engine.dispatchEvent(weewx.Event(weewx.POST_LOOP))
+    assert archive.old_accumulator is None

--- a/src/weewx/tests/test_archive_records.py
+++ b/src/weewx/tests/test_archive_records.py
@@ -204,4 +204,28 @@ def test_an_unknown_generation_still_raises():
 
     with pytest.raises(ValueError):
         engine.dispatchEvent(weewx.Event(weewx.POST_LOOP))
-    assert archive.old_accumulator is None
+    # Neither accumulator was discarded on the way out.
+    assert len(archive.accumulators) == 2
+
+
+def test_a_packet_from_a_slower_source_still_reaches_its_period():
+    """More than one source means timestamps that go backwards.
+
+    A packet older than the one before it belongs to a period that is still being
+    held. It has to go in there, and it must not make that period look like the
+    current one, or the period that really is current gets its record written early
+    and short.
+    """
+    records = run(
+        packet(START + 290),                     # period 1
+        packet(START + 305),                     # period 2 begins, too early to break
+        packet(START + 265),                     # the other source, running 40 s behind
+        packet(START + 320),                     # breaks the loop
+        packet(START + INTERVAL + 320),          # period 3, breaks it again
+        packet(START + 3 * INTERVAL + 30),
+    )
+    by_time = {r['dateTime']: r for r in records}
+
+    assert sorted(by_time) == [START + INTERVAL, START + 2 * INTERVAL, START + 3 * INTERVAL]
+    assert by_time[START + INTERVAL]['rain'] == 2          # 290 and the late 265
+    assert by_time[START + 2 * INTERVAL]['rain'] == 2      # 305 and 320


### PR DESCRIPTION
`StdArchive` loses an archive record when the main loop runs past the end of two
periods without being broken.

The loop breaks `archive_delay` seconds after a period ends. A packet arriving
before that does not break it, so a second period can end while the first one's
accumulator is still in `old_accumulator`, waiting for `post_loop()`. The next
`OutOfSpan` replaces it, and its record is never written.

```python
(self.old_accumulator, self.accumulator) = \
    (self.accumulator, self._new_accumulator(event.packet['dateTime']))
```

The shape that does it is one packet per archive period, arriving just after the
boundary. A driver polling an API on the archive interval does that. Twelve such
packets write seven records on master and twelve with the patch.

`old_accumulator` becomes a queue. `post_loop()` works through it oldest first, so
records still reach the database in order.

Submitting PR to master, as this is a fix.
