### PR TITLE
Split StdArchive into a record generator and a record store

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -25,7 +25,7 @@ Removed the APRS "messaging-capable" packet flag from `restx.py`.
 
 ### 5.5.0 6-Aug-2026
 
-Split `StdArchive` into `StdArchiveGenerator`, which makes archive records, and
+Split `StdArchive` into `StdArchiveCreator`, which makes archive records, and
 `StdArchiveStore`, which saves them, so that either can be replaced on its own.
 `StdArchive` still runs both, so an existing configuration is unaffected.
 [PR #1129](https://github.com/weewx/weewx/issues/1129).

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -22,13 +22,12 @@ could no longer edit it, and the passwords in it became world-readable. [PR
 Removed the APRS "messaging-capable" packet flag from `restx.py`.
 [PR #1108](https://github.com/weewx/weewx/pull/1108), by `W0CHP`.
 
-
-### 5.5.0 6-Aug-2026
-
 Split `StdArchive` into `StdArchiveCreator`, which makes archive records, and
 `StdArchiveStore`, which saves them, so that either can be replaced on its own.
 `StdArchive` still runs both, so an existing configuration is unaffected.
 [PR #1129](https://github.com/weewx/weewx/issues/1129).
+
+### 5.5.0 6-Aug-2026
 
 Added the ability for services to bind to a `SHUTDOWN` event. This allows
 services to be notified when `weewxd` is being shutdown. 

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -25,6 +25,11 @@ Removed the APRS "messaging-capable" packet flag from `restx.py`.
 
 ### 5.5.0 6-Aug-2026
 
+Split `StdArchive` into `StdArchiveGenerator`, which makes archive records, and
+`StdArchiveStore`, which saves them, so that either can be replaced on its own.
+`StdArchive` still runs both, so an existing configuration is unaffected.
+[PR #1129](https://github.com/weewx/weewx/issues/1129).
+
 Added the ability for services to bind to a `SHUTDOWN` event. This allows
 services to be notified when `weewxd` is being shutdown. 
 [PR #1106](https://github.com/weewx/weewx/issues/1106). Thanks to user

--- a/docs_src/reference/weewx-options/engine.md
+++ b/docs_src/reference/weewx-options/engine.md
@@ -24,7 +24,7 @@ Service lists are run in the order given below.
 | `data_services`    | Augment data, before it is processed.                 |
 | `process_services` | Process, filter, and massage the data.                |
 | `xtype_services`   | Add derived types to the data stream.                 |
-| `archive_services` | Record the data in a database.                        |
+| `archive_services` | Make archive records, and record them in a database.  |
 | `restful_services` | Upload processed data to an external RESTful service. |
 | `report_services`  | Run any reports.                                      |
 
@@ -37,7 +37,7 @@ default distribution.
 | `data_services`	   |                                                                                                                                          |
 | `process_services` | `weewx.engine.StdConvert` <br> `weewx.engine.StdCalibrate` <br> `weewx.engine.StdQC` <br> `weewx.wxservices.StdWXCalculate`              |
 | `xtype_services`   | `weewx.wxxtypes.StdWXXTypes` <br/> `weewx.wxxtypes.StdPressureCooker`<br/> `weewx.wxxtypes.StdRainRater` <br/> `weewx.wxxtypes.StdDelta` |
-| `archive_services` | `weewx.engine.StdArchive`                                                                                                                                                         |
+| `archive_services` | `weewx.engine.StdArchiveGenerator` <br> `weewx.engine.StdArchiveStore`                                                                                                                                                         |
 | `restful_services` | `weewx.restx.StdStationRegistry` <br>`weewx.restx.StdWunderground` <br>`weewx.restx.StdPWSweather` <br>`weewx.restx.StdCWOP` <br>`weewx.restx.StdWOW` <br>`weewx.restx.StdAWEKAS` |
 | `report_services`  | `weewx.engine.StdPrint` <br> `weewx.engine.StdReport`                                                                                                                             |
 
@@ -72,7 +72,16 @@ the data. Typically, they calculate derived variables such as `dewpoint`,
 
 #### archive_services
 
-Once data have been processed, services in this group archive them.
+Once data have been processed, services in this group archive them. There are two,
+and they talk to each other only through the `NEW_ARCHIVE_RECORD` event:
+`StdArchiveGenerator` turns LOOP packets into archive records and emits the event,
+`StdArchiveStore` listens for it and writes to the database. Either one can be
+replaced on its own. An extension that builds records some other way takes the place
+of the generator; a second `StdArchiveStore`, given another data binding, saves the
+same records to another database.
+
+`weewx.engine.StdArchive` does both jobs in one service. Configurations written
+before v5.5 name it, and it behaves as it always has.
 
 #### restful_services
 

--- a/docs_src/reference/weewx-options/engine.md
+++ b/docs_src/reference/weewx-options/engine.md
@@ -78,7 +78,8 @@ and they talk to each other only through the `NEW_ARCHIVE_RECORD` event:
 `StdArchiveStore` listens for it and writes to the database. Either one can be
 replaced on its own. An extension that builds records some other way takes the place
 of the creator; a second `StdArchiveStore`, given another data binding, saves the
-same records to another database.
+same records to another database. A replacement reads `[StdArchive]` for the options
+both halves share, and a stanza of its own for anything else it needs.
 
 `weewx.engine.StdArchive` does both jobs in one service. Configurations written
 before v5.5 name it, and it behaves as it always has.

--- a/docs_src/reference/weewx-options/engine.md
+++ b/docs_src/reference/weewx-options/engine.md
@@ -37,7 +37,7 @@ default distribution.
 | `data_services`	   |                                                                                                                                          |
 | `process_services` | `weewx.engine.StdConvert` <br> `weewx.engine.StdCalibrate` <br> `weewx.engine.StdQC` <br> `weewx.wxservices.StdWXCalculate`              |
 | `xtype_services`   | `weewx.wxxtypes.StdWXXTypes` <br/> `weewx.wxxtypes.StdPressureCooker`<br/> `weewx.wxxtypes.StdRainRater` <br/> `weewx.wxxtypes.StdDelta` |
-| `archive_services` | `weewx.engine.StdArchiveGenerator` <br> `weewx.engine.StdArchiveStore`                                                                                                                                                         |
+| `archive_services` | `weewx.engine.StdArchiveCreator` <br> `weewx.engine.StdArchiveStore`                                                                                                                                                         |
 | `restful_services` | `weewx.restx.StdStationRegistry` <br>`weewx.restx.StdWunderground` <br>`weewx.restx.StdPWSweather` <br>`weewx.restx.StdCWOP` <br>`weewx.restx.StdWOW` <br>`weewx.restx.StdAWEKAS` |
 | `report_services`  | `weewx.engine.StdPrint` <br> `weewx.engine.StdReport`                                                                                                                             |
 
@@ -74,10 +74,10 @@ the data. Typically, they calculate derived variables such as `dewpoint`,
 
 Once data have been processed, services in this group archive them. There are two,
 and they talk to each other only through the `NEW_ARCHIVE_RECORD` event:
-`StdArchiveGenerator` turns LOOP packets into archive records and emits the event,
+`StdArchiveCreator` turns LOOP packets into archive records and emits the event,
 `StdArchiveStore` listens for it and writes to the database. Either one can be
 replaced on its own. An extension that builds records some other way takes the place
-of the generator; a second `StdArchiveStore`, given another data binding, saves the
+of the creator; a second `StdArchiveStore`, given another data binding, saves the
 same records to another database.
 
 `weewx.engine.StdArchive` does both jobs in one service. Configurations written

--- a/docs_src/reference/weewx-options/stdarchive.md
+++ b/docs_src/reference/weewx-options/stdarchive.md
@@ -1,6 +1,11 @@
 # [StdArchive]
 
-The `StdArchive` service stores data into a database.
+This section configures both of the archive services. `StdArchiveGenerator` makes
+archive records out of LOOP packets, `StdArchiveStore` puts them in a database, and
+they read the options below out of the same section.
+
+`weewx.engine.StdArchive` runs both in one service, which is what a configuration
+written before v5.5 names.
 
 #### ==archive_interval==
 

--- a/docs_src/reference/weewx-options/stdarchive.md
+++ b/docs_src/reference/weewx-options/stdarchive.md
@@ -1,6 +1,6 @@
 # [StdArchive]
 
-This section configures both of the archive services. `StdArchiveGenerator` makes
+This section configures both of the archive services. `StdArchiveCreator` makes
 archive records out of LOOP packets, `StdArchiveStore` puts them in a database, and
 they read the options below out of the same section.
 

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -551,7 +551,7 @@ class StdQC(StdService):
 #                    Class StdArchive
 # ==============================================================================
 
-class StdArchiveGenerator(StdService):
+class StdArchiveCreator(StdService):
     """Service that turns LOOP packets into archive records.
 
     It manages an "accumulator", which records high/lows and averages of LOOP packets
@@ -807,7 +807,7 @@ class StdArchiveStore(StdService):
 
     It listens for NEW_ARCHIVE_RECORD and knows nothing about where the record came
     from, so anything that emits that event is served: the accumulator in
-    StdArchiveGenerator, or an extension that replaces it.
+    StdArchiveCreator, or an extension that replaces it.
     """
 
     def __init__(self, engine, config_dict):
@@ -866,13 +866,13 @@ class StdArchive(StdService):
     """Generate archive records and save them, in one service.
 
     This is what a configuration written before v5.5 names, and it behaves as it always
-    has. A configuration that lists StdArchiveGenerator and StdArchiveStore separately
+    has. A configuration that lists StdArchiveCreator and StdArchiveStore separately
     can replace either half.
     """
 
     def __init__(self, engine, config_dict):
         super().__init__(engine, config_dict)
-        self.generator = StdArchiveGenerator(engine, config_dict)
+        self.creator = StdArchiveCreator(engine, config_dict)
         self.store = StdArchiveStore(engine, config_dict)
 
 

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -875,6 +875,16 @@ class StdArchive(StdService):
         self.creator = StdArchiveCreator(engine, config_dict)
         self.store = StdArchiveStore(engine, config_dict)
 
+    def shutDown(self):
+        """Shut both halves down.
+
+        The engine calls shutDown() on the services it loaded, and it loaded this
+        one, not the two it holds. Neither has anything to release today. This is
+        so that neither has to remember it when one of them does.
+        """
+        self.creator.shutDown()
+        self.store.shutDown()
+
 
 # ==============================================================================
 #                    Class StdTimeSynch

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -551,12 +551,16 @@ class StdQC(StdService):
 #                    Class StdArchive
 # ==============================================================================
 
-class StdArchive(StdService):
-    """Service that archives LOOP and archive data in the SQL databases."""
+class StdArchiveGenerator(StdService):
+    """Service that turns LOOP packets into archive records.
 
-    # This service manages an "accumulator", which records high/lows and
-    # averages of LOOP packets over an archive period. At the end of the
-    # archive period it then emits an archive record.
+    It manages an "accumulator", which records high/lows and averages of LOOP packets
+    over an archive period. At the end of the period it emits a NEW_ARCHIVE_RECORD
+    event carrying the record, and the accumulator that made it.
+
+    It does not write to the database. StdArchiveStore does that, listening for the
+    same event, so that either half can be replaced without touching the other.
+    """
 
     def __init__(self, engine, config_dict):
         super().__init__(engine, config_dict)
@@ -570,10 +574,7 @@ class StdArchive(StdService):
         software_interval = to_int(archive_dict.get('archive_interval', 300))
         self.loop_hilo = to_bool(archive_dict.get('loop_hilo', True))
         self.record_augmentation = to_bool(archive_dict.get('record_augmentation', True))
-        self.log_success = to_bool(weeutil.config.search_up(archive_dict, 'log_success', True))
-        self.log_failure = to_bool(weeutil.config.search_up(archive_dict, 'log_failure', True))
 
-        log.info("Archive will use data binding %s", self.data_binding)
         log.info("Record generation will be attempted in '%s'", self.record_generation)
 
         # The timestamp that marks the end of the archive period
@@ -624,37 +625,23 @@ class StdArchive(StdService):
         self.bind(weewx.NEW_LOOP_PACKET, self.new_loop_packet)
         self.bind(weewx.CHECK_LOOP, self.check_loop)
         self.bind(weewx.POST_LOOP, self.post_loop)
-        self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)
 
     def startup(self, _unused):
-        """Called when the engine is starting up. Main task is to set up the database, backfill it,
-        then perform a catch-up if the hardware supports it.
+        """Called when the engine is starting up. Do a catch-up on any data still on the
+        station, but not yet put in the database. Setting up the database is
+        StdArchiveStore's job.
 
         _unused (weewx.Event): Not used.
         """
 
-        # This will create the database if it doesn't exist:
-        dbmanager = self.engine.db_binder.get_manager(self.data_binding, initialize=True)
-        log.info("Using binding '%s' to database '%s'", self.data_binding, dbmanager.database_name)
-
-        # Make sure the daily summaries have not been partially updated
-        if dbmanager._read_metadata('lastWeightPatch'):
-            raise weewx.ViolatedPrecondition("Update of daily summary for database '%s' not"
-                                             " complete. Finish the update first."
-                                             % dbmanager.database_name)
-
-        # Backfill the daily summaries.
-        _nrecs, _ndays = dbmanager.backfill_day_summary()
-
-        # Do a catch-up on any data still on the station, but not yet put in the database.
         if self.no_catchup:
             log.debug("No catchup specified.")
-        else:
-            # Not all consoles can do a hardware catchup, so be prepared to catch the exception:
-            try:
-                self._catchup(self.engine.console.genStartupRecords)
-            except NotImplementedError:
-                pass
+            return
+        # Not all consoles can do a hardware catchup, so be prepared to catch the exception:
+        try:
+            self._catchup(self.engine.console.genStartupRecords)
+        except NotImplementedError:
+            pass
 
     def pre_loop(self, _event):
         """Called before the main packet loop is entered.
@@ -741,31 +728,9 @@ class StdArchive(StdService):
         # Set the time of the next break loop:
         self.end_archive_delay_ts = self.end_archive_period_ts + self.archive_delay
 
-    def new_archive_record(self, event):
-        """Called when a new archive record has arrived.
-        Put it in the archive database.
-
-        event (weewx.Event): The event containing the new archive record.
-        """
-
-        # If requested, extract any extra information we can out of the accumulator and put it in
-        # the record. Not necessary in the case of software record generation because it has
-        # already been done.
-        if self.record_augmentation \
-                and self.old_accumulator \
-                and event.record['dateTime'] == self.old_accumulator.timespan.stop \
-                and event.origin != 'software':
-            self.old_accumulator.augmentRecord(event.record)
-
-        dbmanager = self.engine.db_binder.get_manager(self.data_binding)
-        dbmanager.addRecord(event.record,
-                            accumulator=self.old_accumulator,
-                            log_success=self.log_success,
-                            log_failure=self.log_failure)
-
     def _catchup(self, generator):
         """Pull any unarchived records off the console and archive them.
-        
+
         If the hardware does not support hardware archives, an exception of
         type NotImplementedError will be thrown.
 
@@ -773,7 +738,9 @@ class StdArchive(StdService):
         self.engine.console.genStartupRecords or genArchiveRecords).
         """
 
-        dbmanager = self.engine.db_binder.get_manager(self.data_binding)
+        # 'initialize' because the catchup at startup can run before anything else has
+        # had a reason to open the database.
+        dbmanager = self.engine.db_binder.get_manager(self.data_binding, initialize=True)
         # Find out when the database was last updated.
         lastgood_ts = dbmanager.lastGoodStamp()
 
@@ -787,9 +754,7 @@ class StdArchive(StdService):
             for record in generator(lastgood_ts):
                 ts = record.get('dateTime')
                 if ts and ts < time.time() + self.archive_delay:
-                    self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
-                                                          record=record,
-                                                          origin='hardware'))
+                    self._emit(record, 'hardware')
                 else:
                     log.warning("Ignore historical record: %s" % record)
         except weewx.HardwareError as e:
@@ -797,14 +762,31 @@ class StdArchive(StdService):
             log.error("**** %s" % e)
 
     def _software_catchup(self):
-        # Extract a record out of the old accumulator. 
+        # Extract a record out of the old accumulator.
         record = self.old_accumulator.getRecord()
         # Add the archive interval
         record['interval'] = self.archive_interval / 60
         # Send out an event with the new record:
+        self._emit(record, 'software')
+
+    def _emit(self, record, origin):
+        """Augment the record from the accumulator that covers it, then send it out.
+
+        Augmenting here, rather than on the way into the database, means every service
+        listening for the event sees the same record. It is not needed for a record made
+        by software, which came out of the accumulator to begin with.
+        """
+        accumulator = self.old_accumulator
+        if accumulator is not None and record['dateTime'] != accumulator.timespan.stop:
+            # The record covers some other period, so the accumulator has nothing to say
+            # about it. A hardware catchup after an outage is the usual case.
+            accumulator = None
+        if self.record_augmentation and accumulator is not None and origin != 'software':
+            accumulator.augmentRecord(record)
         self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
                                               record=record,
-                                              origin='software'))
+                                              origin=origin,
+                                              accumulator=accumulator))
 
     def _new_accumulator(self, timestamp):
         start_ts = weeutil.weeutil.startOfInterval(timestamp,
@@ -814,6 +796,84 @@ class StdArchive(StdService):
         # Instantiate a new accumulator
         new_accumulator = weewx.accum.Accum(weeutil.weeutil.TimeSpan(start_ts, end_ts))
         return new_accumulator
+
+
+# ==============================================================================
+#                    Class StdArchiveStore
+# ==============================================================================
+
+class StdArchiveStore(StdService):
+    """Service that puts archive records in a database.
+
+    It listens for NEW_ARCHIVE_RECORD and knows nothing about where the record came
+    from, so anything that emits that event is served: the accumulator in
+    StdArchiveGenerator, or an extension that replaces it.
+    """
+
+    def __init__(self, engine, config_dict):
+        super().__init__(engine, config_dict)
+
+        archive_dict = config_dict.get('StdArchive', {})
+        self.data_binding = archive_dict.get('data_binding', 'wx_binding')
+        self.log_success = to_bool(weeutil.config.search_up(archive_dict, 'log_success', True))
+        self.log_failure = to_bool(weeutil.config.search_up(archive_dict, 'log_failure', True))
+
+        log.info("Archive will use data binding %s", self.data_binding)
+
+        self.bind(weewx.STARTUP, self.startup)
+        self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)
+
+    def startup(self, _unused):
+        """Called when the engine is starting up. Set up the database and backfill it."""
+
+        # This will create the database if it doesn't exist:
+        dbmanager = self.engine.db_binder.get_manager(self.data_binding, initialize=True)
+        log.info("Using binding '%s' to database '%s'", self.data_binding, dbmanager.database_name)
+
+        # Make sure the daily summaries have not been partially updated
+        if dbmanager._read_metadata('lastWeightPatch'):
+            raise weewx.ViolatedPrecondition("Update of daily summary for database '%s' not"
+                                             " complete. Finish the update first."
+                                             % dbmanager.database_name)
+
+        # Backfill the daily summaries.
+        _nrecs, _ndays = dbmanager.backfill_day_summary()
+
+    def new_archive_record(self, event):
+        """Called when a new archive record has arrived.
+        Put it in the archive database.
+
+        event (weewx.Event): The event containing the new archive record.
+        """
+
+        # The accumulator that made the record, where there was one. It carries the
+        # high/lows measured between archive records, which are finer than anything the
+        # record itself can say. An event from somewhere else will not have one.
+        accumulator = getattr(event, 'accumulator', None)
+
+        dbmanager = self.engine.db_binder.get_manager(self.data_binding)
+        dbmanager.addRecord(event.record,
+                            accumulator=accumulator,
+                            log_success=self.log_success,
+                            log_failure=self.log_failure)
+
+
+# ==============================================================================
+#                    Class StdArchive
+# ==============================================================================
+
+class StdArchive(StdService):
+    """Generate archive records and save them, in one service.
+
+    This is what a configuration written before v5.5 names, and it behaves as it always
+    has. A configuration that lists StdArchiveGenerator and StdArchiveStore separately
+    can replace either half.
+    """
+
+    def __init__(self, engine, config_dict):
+        super().__init__(engine, config_dict)
+        self.generator = StdArchiveGenerator(engine, config_dict)
+        self.store = StdArchiveStore(engine, config_dict)
 
 
 # ==============================================================================

--- a/src/weewx/tests/test_archive_services.py
+++ b/src/weewx/tests/test_archive_services.py
@@ -18,7 +18,7 @@ import pytest
 import weewx
 import weewx.accum
 import weewx.engine
-from weeutil.weeutil import startOfInterval
+from weeutil.weeutil import startOfInterval, to_int
 
 INTERVAL = 300
 DELAY = 15
@@ -323,3 +323,59 @@ class TestConfiguration:
 
         assert not hasattr(store, 'record_generation')
         assert not hasattr(store, 'archive_interval')
+
+
+class TestAnExtensionOfEitherHalf:
+    """What a replacement does about options that [StdArchive] does not have.
+
+    Nothing in the two services provides for this, and nothing needs to: a subclass
+    calls up to the constructor it is replacing, which reads [StdArchive], and then
+    reads its own stanza for whatever else it wants. The shared options stay shared.
+    """
+
+    def test_it_keeps_the_shared_options_and_adds_its_own(self):
+        class Creator(weewx.engine.StdArchiveCreator):
+            def __init__(self, engine, config_dict):
+                super().__init__(engine, config_dict)
+                mine = config_dict.get('MyCreator', {})
+                self.smoothing = to_int(mine.get('smoothing', 0))
+
+        cfg = config()
+        cfg['MyCreator'] = {'smoothing': '3'}
+        creator = Creator(Engine(), cfg)
+
+        assert creator.smoothing == 3
+        assert creator.archive_delay == DELAY          # from [StdArchive]
+        assert creator.data_binding == 'wx_binding'
+
+    def test_it_can_override_a_shared_option_for_itself(self):
+        class Store(weewx.engine.StdArchiveStore):
+            def __init__(self, engine, config_dict):
+                super().__init__(engine, config_dict)
+                mine = config_dict.get('MyStore', {})
+                self.data_binding = mine.get('data_binding', self.data_binding)
+
+        cfg = config()
+        cfg['MyStore'] = {'data_binding': 'other_binding'}
+        store = Store(Engine(), cfg)
+
+        assert store.data_binding == 'other_binding'
+
+    def test_a_replacement_that_shares_nothing_still_serves_the_other_half(self):
+        """The event is the whole contract, so a replacement need not inherit at all."""
+        class Creator(weewx.engine.StdService):
+            def __init__(self, engine, config_dict):
+                super().__init__(engine, config_dict)
+                self.mine = config_dict['MyCreator']['whatever']
+
+        cfg = config()
+        cfg['MyCreator'] = {'whatever': 'yes'}
+        engine = Engine()
+        creator = Creator(engine, cfg)
+        weewx.engine.StdArchiveStore(engine, cfg)
+
+        assert creator.mine == 'yes'
+        engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
+                                         record={'dateTime': START, 'usUnits': weewx.US},
+                                         origin='software'))
+        assert len(engine.manager.records) == 1

--- a/src/weewx/tests/test_archive_services.py
+++ b/src/weewx/tests/test_archive_services.py
@@ -1,0 +1,325 @@
+#
+#    Copyright (c) 2026 the WeeWX contributors
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test that archive record generation and database storage work apart, and together.
+
+The two halves talk over the NEW_ARCHIVE_RECORD event and nothing else. What is asserted
+here is that either one can be run without the other, that replacing one of them serves
+the other, and that a configuration naming the old combined service behaves as it did.
+"""
+
+import time
+
+import configobj
+import pytest
+
+import weewx
+import weewx.accum
+import weewx.engine
+from weeutil.weeutil import startOfInterval
+
+INTERVAL = 300
+DELAY = 15
+START = int(startOfInterval(time.mktime((2026, 3, 10, 12, 0, 0, 0, 0, -1)), INTERVAL))
+
+
+class Console:
+    """A console with no archive of its own, i.e. software record generation."""
+
+    archive_interval = INTERVAL
+
+    def genArchiveRecords(self, since_ts):
+        raise NotImplementedError("No hardware archive")
+
+    def genStartupRecords(self, since_ts):
+        raise NotImplementedError("No hardware archive")
+
+
+class HardwareConsole(Console):
+    """A console that keeps its own archive and hands records over on request."""
+
+    def __init__(self, records=()):
+        self.records = list(records)
+        self.asked_from = []
+
+    def genArchiveRecords(self, since_ts):
+        self.asked_from.append(since_ts)
+        for record in self.records:
+            yield dict(record)
+
+    genStartupRecords = genArchiveRecords
+
+
+class Manager:
+    """Collects what would go into the database, and what came with it."""
+
+    database_name = 'test.sdb'
+
+    def __init__(self):
+        self.records = []
+        self.accumulators = []
+        self.backfilled = 0
+        self.initialized = False
+
+    def lastGoodStamp(self):
+        return self.records[-1]['dateTime'] if self.records else None
+
+    def _read_metadata(self, key):
+        return None
+
+    def backfill_day_summary(self):
+        self.backfilled += 1
+        return 0, 0
+
+    def addRecord(self, record, accumulator=None, log_success=True, log_failure=True):
+        self.records.append(record)
+        self.accumulators.append(accumulator)
+
+
+class Engine:
+    """Just enough engine to dispatch events to a handful of services."""
+
+    def __init__(self, console=None):
+        self.callbacks = {}
+        self.console = console or Console()
+        self.manager = Manager()
+        self.db_binder = self
+
+    def get_manager(self, binding, initialize=False):
+        if initialize:
+            self.manager.initialized = True
+        return self.manager
+
+    def bind(self, event_type, callback):
+        self.callbacks.setdefault(event_type, []).append(callback)
+
+    def dispatchEvent(self, event):
+        for callback in self.callbacks.get(event.event_type, []):
+            callback(event)
+
+    def _get_console_time(self):
+        return START
+
+
+def config(**overrides):
+    archive = {
+        'record_generation': 'software',
+        'archive_interval': str(INTERVAL),
+        'archive_delay': str(DELAY),
+    }
+    archive.update(overrides)
+    return configobj.ConfigObj({'StdArchive': archive, 'Accumulator': {}})
+
+
+def packet(timestamp, **values):
+    # 'rain' is a sum, so one tip per packet means the rain in a record counts the
+    # packets that reached it.
+    p = {'dateTime': int(timestamp), 'usUnits': weewx.US, 'outTemp': 20.0, 'rain': 1.0}
+    p.update(values)
+    return p
+
+
+def feed(engine, packets):
+    """Push packets through the way StdEngine.run() does."""
+    engine.dispatchEvent(weewx.Event(weewx.STARTUP))
+    engine.dispatchEvent(weewx.Event(weewx.PRE_LOOP))
+    for p in packets:
+        try:
+            engine.dispatchEvent(weewx.Event(weewx.NEW_LOOP_PACKET, packet=p))
+            engine.dispatchEvent(weewx.Event(weewx.CHECK_LOOP, packet=p))
+        except weewx.engine.BreakLoop:
+            engine.dispatchEvent(weewx.Event(weewx.POST_LOOP))
+            engine.dispatchEvent(weewx.Event(weewx.PRE_LOOP))
+    return engine.manager
+
+
+# Four packets that close two archive periods: the first two periods end and are
+# written, the third is still being filled when the stream runs out.
+A_DAY = [packet(START + 30), packet(START + INTERVAL + 9),
+         packet(START + INTERVAL + 30), packet(START + 2 * INTERVAL + 20)]
+TWO_PERIODS = [START + INTERVAL, START + 2 * INTERVAL]
+
+
+class TestTheHalvesTogether:
+    """Both services present, which is what a stock installation runs."""
+
+    def test_records_reach_the_database(self):
+        engine = Engine()
+        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveStore(engine, config())
+
+        manager = feed(engine, A_DAY)
+
+        assert [r['dateTime'] for r in manager.records] == TWO_PERIODS
+
+    def test_the_combined_service_does_the_same(self):
+        """A configuration written before the split names StdArchive."""
+        engine = Engine()
+        weewx.engine.StdArchive(engine, config())
+
+        manager = feed(engine, A_DAY)
+
+        assert [r['dateTime'] for r in manager.records] == TWO_PERIODS
+
+    def test_the_database_is_prepared_once(self):
+        engine = Engine()
+        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveStore(engine, config())
+
+        feed(engine, A_DAY)
+
+        assert engine.manager.initialized
+        assert engine.manager.backfilled == 1
+
+
+class TestEitherHalfAlone:
+
+    def test_the_generator_writes_nothing(self):
+        """It emits the event. Without a store, nothing reaches the database."""
+        engine = Engine()
+        weewx.engine.StdArchiveGenerator(engine, config())
+        seen = []
+        engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(e.record))
+
+        manager = feed(engine, A_DAY)
+
+        assert [r['dateTime'] for r in seen] == TWO_PERIODS
+        assert manager.records == []
+
+    def test_the_store_saves_what_it_is_given(self):
+        """No generator at all: anything that emits the event is served."""
+        engine = Engine()
+        weewx.engine.StdArchiveStore(engine, config())
+        engine.dispatchEvent(weewx.Event(weewx.STARTUP))
+
+        record = {'dateTime': START + INTERVAL, 'usUnits': weewx.US, 'outTemp': 4.0}
+        engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
+                                         record=record, origin='software'))
+
+        assert engine.manager.records == [record]
+        # Nothing said an accumulator was involved, so none is passed on.
+        assert engine.manager.accumulators == [None]
+
+    def test_a_replacement_generator_serves_the_store(self):
+        """The point of the split: swap the half that makes records, keep the half
+        that saves them."""
+
+        class EveryPacketIsARecord(weewx.engine.StdService):
+            """A generator that does no accumulating at all."""
+
+            def __init__(self, engine, config_dict):
+                super().__init__(engine, config_dict)
+                self.bind(weewx.NEW_LOOP_PACKET, self.new_loop_packet)
+
+            def new_loop_packet(self, event):
+                self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
+                                                      record=dict(event.packet),
+                                                      origin='software'))
+
+        engine = Engine()
+        EveryPacketIsARecord(engine, config())
+        weewx.engine.StdArchiveStore(engine, config())
+
+        manager = feed(engine, A_DAY)
+
+        assert [r['dateTime'] for r in manager.records] == [p['dateTime'] for p in A_DAY]
+
+
+class TestTheAccumulatorTravels:
+    """The store needs the accumulator for the daily summary's high/lows, and can only
+    have it if the generator sends it along."""
+
+    def test_it_arrives_with_the_record(self):
+        engine = Engine()
+        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveStore(engine, config())
+
+        manager = feed(engine, A_DAY)
+
+        assert len(manager.accumulators) == len(TWO_PERIODS)
+        for record, accumulator in zip(manager.records, manager.accumulators):
+            assert accumulator is not None
+            assert accumulator.timespan.stop == record['dateTime']
+
+    def test_a_hardware_record_for_another_period_travels_without_one(self):
+        """A catchup after an outage brings records the accumulator knows nothing
+        about. Passing it along anyway would credit them with the wrong high/lows."""
+        old = {'dateTime': START - 10 * INTERVAL, 'usUnits': weewx.US,
+               'outTemp': 1.0, 'interval': INTERVAL / 60}
+        engine = Engine(console=HardwareConsole([old]))
+        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware'))
+        weewx.engine.StdArchiveStore(engine, config(record_generation='hardware'))
+
+        manager = feed(engine, A_DAY)
+
+        by_time = dict(zip((r['dateTime'] for r in manager.records), manager.accumulators))
+        assert by_time[old['dateTime']] is None
+
+
+class TestAugmentation:
+
+    def test_a_hardware_record_is_augmented_before_it_is_sent(self):
+        """Every listener sees the same record, not just the one that saves it."""
+        ends_at = START + INTERVAL
+        from_console = {'dateTime': ends_at, 'usUnits': weewx.US, 'interval': INTERVAL / 60}
+        engine = Engine(console=HardwareConsole([from_console]))
+        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
+                                                        no_catchup='true'))
+        seen = []
+        engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(dict(e.record)))
+
+        feed(engine, A_DAY)
+
+        augmented = [r for r in seen if r['dateTime'] == ends_at]
+        assert augmented, "no record for the period that ended"
+        # The console sent no outTemp. The accumulator has one, from the LOOP packets.
+        assert 'outTemp' in augmented[0]
+
+    def test_it_can_be_turned_off(self):
+        ends_at = START + INTERVAL
+        from_console = {'dateTime': ends_at, 'usUnits': weewx.US, 'interval': INTERVAL / 60}
+        engine = Engine(console=HardwareConsole([from_console]))
+        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
+                                                        record_augmentation='false',
+                                                        no_catchup='true'))
+        seen = []
+        engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(dict(e.record)))
+
+        feed(engine, A_DAY)
+
+        augmented = [r for r in seen if r['dateTime'] == ends_at]
+        assert augmented
+        assert 'outTemp' not in augmented[0]
+
+
+class TestConfiguration:
+
+    def test_an_unknown_generation_is_refused_at_startup(self):
+        engine = Engine()
+        with pytest.raises(ValueError):
+            weewx.engine.StdArchiveGenerator(engine, config(record_generation='nonsense'))
+
+    def test_a_delay_of_zero_is_refused(self):
+        engine = Engine()
+        with pytest.raises(weewx.ViolatedPrecondition):
+            weewx.engine.StdArchiveGenerator(engine, config(archive_delay='0'))
+
+    def test_no_catchup_leaves_the_console_alone(self):
+        console = HardwareConsole([{'dateTime': START - INTERVAL, 'usUnits': weewx.US}])
+        engine = Engine(console=console)
+        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
+                                                        no_catchup='true'))
+        engine.dispatchEvent(weewx.Event(weewx.STARTUP))
+
+        assert console.asked_from == []
+
+    def test_the_store_needs_no_generation_settings(self):
+        """It is the half that a replacement generator keeps, so it must not depend on
+        how records are made."""
+        engine = Engine()
+        store = weewx.engine.StdArchiveStore(engine, config(record_generation='nonsense'))
+
+        assert not hasattr(store, 'record_generation')
+        assert not hasattr(store, 'archive_interval')

--- a/src/weewx/tests/test_archive_services.py
+++ b/src/weewx/tests/test_archive_services.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2026 the WeeWX contributors
+#    Copyright (c) 2026 Manuel Hilgert
 #
 #    See the file LICENSE.txt for your full rights.
 #
@@ -147,7 +147,7 @@ class TestTheHalvesTogether:
 
     def test_records_reach_the_database(self):
         engine = Engine()
-        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveCreator(engine, config())
         weewx.engine.StdArchiveStore(engine, config())
 
         manager = feed(engine, A_DAY)
@@ -165,7 +165,7 @@ class TestTheHalvesTogether:
 
     def test_the_database_is_prepared_once(self):
         engine = Engine()
-        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveCreator(engine, config())
         weewx.engine.StdArchiveStore(engine, config())
 
         feed(engine, A_DAY)
@@ -179,7 +179,7 @@ class TestEitherHalfAlone:
     def test_the_generator_writes_nothing(self):
         """It emits the event. Without a store, nothing reaches the database."""
         engine = Engine()
-        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveCreator(engine, config())
         seen = []
         engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(e.record))
 
@@ -233,7 +233,7 @@ class TestTheAccumulatorTravels:
 
     def test_it_arrives_with_the_record(self):
         engine = Engine()
-        weewx.engine.StdArchiveGenerator(engine, config())
+        weewx.engine.StdArchiveCreator(engine, config())
         weewx.engine.StdArchiveStore(engine, config())
 
         manager = feed(engine, A_DAY)
@@ -249,7 +249,7 @@ class TestTheAccumulatorTravels:
         old = {'dateTime': START - 10 * INTERVAL, 'usUnits': weewx.US,
                'outTemp': 1.0, 'interval': INTERVAL / 60}
         engine = Engine(console=HardwareConsole([old]))
-        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware'))
+        weewx.engine.StdArchiveCreator(engine, config(record_generation='hardware'))
         weewx.engine.StdArchiveStore(engine, config(record_generation='hardware'))
 
         manager = feed(engine, A_DAY)
@@ -265,7 +265,7 @@ class TestAugmentation:
         ends_at = START + INTERVAL
         from_console = {'dateTime': ends_at, 'usUnits': weewx.US, 'interval': INTERVAL / 60}
         engine = Engine(console=HardwareConsole([from_console]))
-        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
+        weewx.engine.StdArchiveCreator(engine, config(record_generation='hardware',
                                                         no_catchup='true'))
         seen = []
         engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(dict(e.record)))
@@ -281,9 +281,9 @@ class TestAugmentation:
         ends_at = START + INTERVAL
         from_console = {'dateTime': ends_at, 'usUnits': weewx.US, 'interval': INTERVAL / 60}
         engine = Engine(console=HardwareConsole([from_console]))
-        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
-                                                        record_augmentation='false',
-                                                        no_catchup='true'))
+        weewx.engine.StdArchiveCreator(engine, config(record_generation='hardware',
+                                                     record_augmentation='false',
+                                                     no_catchup='true'))
         seen = []
         engine.bind(weewx.NEW_ARCHIVE_RECORD, lambda e: seen.append(dict(e.record)))
 
@@ -299,24 +299,24 @@ class TestConfiguration:
     def test_an_unknown_generation_is_refused_at_startup(self):
         engine = Engine()
         with pytest.raises(ValueError):
-            weewx.engine.StdArchiveGenerator(engine, config(record_generation='nonsense'))
+            weewx.engine.StdArchiveCreator(engine, config(record_generation='nonsense'))
 
     def test_a_delay_of_zero_is_refused(self):
         engine = Engine()
         with pytest.raises(weewx.ViolatedPrecondition):
-            weewx.engine.StdArchiveGenerator(engine, config(archive_delay='0'))
+            weewx.engine.StdArchiveCreator(engine, config(archive_delay='0'))
 
     def test_no_catchup_leaves_the_console_alone(self):
         console = HardwareConsole([{'dateTime': START - INTERVAL, 'usUnits': weewx.US}])
         engine = Engine(console=console)
-        weewx.engine.StdArchiveGenerator(engine, config(record_generation='hardware',
-                                                        no_catchup='true'))
+        weewx.engine.StdArchiveCreator(engine, config(record_generation='hardware',
+                                                     no_catchup='true'))
         engine.dispatchEvent(weewx.Event(weewx.STARTUP))
 
         assert console.asked_from == []
 
     def test_the_store_needs_no_generation_settings(self):
-        """It is the half that a replacement generator keeps, so it must not depend on
+        """It is the half that a replacement creator keeps, so it must not depend on
         how records are made."""
         engine = Engine()
         store = weewx.engine.StdArchiveStore(engine, config(record_generation='nonsense'))

--- a/src/weewx_data/weewx.conf
+++ b/src/weewx_data/weewx.conf
@@ -519,6 +519,6 @@ version = 5.6.0
         data_services = ,
         process_services = weewx.engine.StdConvert, weewx.engine.StdCalibrate, weewx.engine.StdQC, weewx.wxservices.StdWXCalculate
         xtype_services = weewx.wxxtypes.StdWXXTypes, weewx.wxxtypes.StdPressureCooker, weewx.wxxtypes.StdRainRater, weewx.wxxtypes.StdDelta
-        archive_services = weewx.engine.StdArchiveGenerator, weewx.engine.StdArchiveStore
+        archive_services = weewx.engine.StdArchiveCreator, weewx.engine.StdArchiveStore
         restful_services = weewx.restx.StdStationRegistry, weewx.restx.StdWunderground, weewx.restx.StdPWSweather, weewx.restx.StdCWOP, weewx.restx.StdWOW, weewx.restx.StdWOWBE, weewx.restx.StdAWEKAS
         report_services = weewx.engine.StdPrint, weewx.engine.StdReport

--- a/src/weewx_data/weewx.conf
+++ b/src/weewx_data/weewx.conf
@@ -519,6 +519,6 @@ version = 5.6.0
         data_services = ,
         process_services = weewx.engine.StdConvert, weewx.engine.StdCalibrate, weewx.engine.StdQC, weewx.wxservices.StdWXCalculate
         xtype_services = weewx.wxxtypes.StdWXXTypes, weewx.wxxtypes.StdPressureCooker, weewx.wxxtypes.StdRainRater, weewx.wxxtypes.StdDelta
-        archive_services = weewx.engine.StdArchive
+        archive_services = weewx.engine.StdArchiveGenerator, weewx.engine.StdArchiveStore
         restful_services = weewx.restx.StdStationRegistry, weewx.restx.StdWunderground, weewx.restx.StdPWSweather, weewx.restx.StdCWOP, weewx.restx.StdWOW, weewx.restx.StdWOWBE, weewx.restx.StdAWEKAS
         report_services = weewx.engine.StdPrint, weewx.engine.StdReport


### PR DESCRIPTION
From your comment in #1127: "By separating archive record generation from database
storage we could support this as an extension."

`StdArchiveGenerator` makes archive records out of LOOP packets. It emits
`NEW_ARCHIVE_RECORD`. `StdArchiveStore` listens for that and writes to the database.
They share nothing else. Replace either one and the other keeps working. A second
store on another binding saves the same records twice.

`StdArchive` stays, and runs both. A configuration that names it is unaffected.

Two things move:

- The accumulator travels on the event. The store needs it for the daily summary's
  high/lows. It can no longer reach into the generator for it. A record covering
  some other period, which a hardware catchup brings, travels without one.
- Augmentation happens before the event is dispatched, not on the way into the
  database. Every listener now sees the same record. Before, it depended on service
  order.

14 tests in `src/weewx/tests/test_archive_services.py`. They cover either half alone,
both together, the combined service, and a replacement generator driving the stock
store. Four mutations to the new code each fail exactly one test.

End to end, `weewxd` against the simulator, same start, once each way:

| | |
|---|---|
| records compared | 2235 |
| fields compared | 227970 |
| fields differing | 0 |
| daily summary tables | 100, none differing |
| replacement generator, stock store | 2632 records |

Full suite 388 passed on 3.12 and 3.13. `vermin` unchanged from `development`.

One question. Should `update_config.py` rewrite `archive_services` for existing
installations? They work as they are. But they do not get the split until someone
edits the line by hand.
