### PR TITLE
Keep a configuration section that is still in use

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -3,6 +3,12 @@ WeeWX change history
 
 ### 5.5.n n-Month-2026
 
+`weectl extension uninstall` no longer removes a configuration section that is still
+in use. A section was pruned as soon as it had no subsections left, so uninstalling
+any driver extension took all of `[Station]` with it, including the location and the
+coordinates. Fixes [Issue #1131](https://github.com/weewx/weewx/issues/1131).
+[PR #PRNUM](https://github.com/weewx/weewx/pull/PRNUM).
+
 Say so in the log when a Vantage logger returns far fewer archive records than it
 said it would, which is what corrupt logger memory looks like, and link to the fix.
 Fixes [Issue #1105](https://github.com/weewx/weewx/issues/1105).

--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -7,7 +7,7 @@ WeeWX change history
 in use. A section was pruned as soon as it had no subsections left, so uninstalling
 any driver extension took all of `[Station]` with it, including the location and the
 coordinates. Fixes [Issue #1131](https://github.com/weewx/weewx/issues/1131).
-[PR #PRNUM](https://github.com/weewx/weewx/pull/PRNUM).
+[PR #1132](https://github.com/weewx/weewx/pull/1132).
 
 Say so in the log when a Vantage logger returns far fewer archive records than it
 said it would, which is what corrupt logger memory looks like, and link to the fix.

--- a/src/weecfg/__init__.py
+++ b/src/weecfg/__init__.py
@@ -357,12 +357,18 @@ def reorder_scalars(scalars, src, dst):
 
 
 def remove_and_prune(a_dict, b_dict):
-    """Remove fields from a_dict that are present in b_dict"""
+    """Remove fields from a_dict that are present in b_dict.
+
+    A section is removed only if nothing is left in it, i.e. it holds neither
+    subsections nor options. An extension that contributes one option to a section the
+    user already had, such as a driver adding 'station_type' to [Station], must not
+    take the rest of that section with it when it is uninstalled.
+    """
     for k in b_dict:
         if isinstance(b_dict[k], dict):
             if k in a_dict and type(a_dict[k]) is configobj.Section:
                 remove_and_prune(a_dict[k], b_dict[k])
-                if not a_dict[k].sections:
+                if not a_dict[k].sections and not a_dict[k].scalars:
                     a_dict.pop(k)
         elif k in a_dict:
             a_dict.pop(k)

--- a/src/weecfg/tests/test_config.py
+++ b/src/weecfg/tests/test_config.py
@@ -157,6 +157,45 @@ class TestConfig:
         d = 4
 """
 
+    def test_remove_and_prune_keeps_a_section_that_is_still_used(self):
+        """An extension that adds one option to a section the user already had must
+        not take the rest of that section with it. A driver adds 'station_type' to
+        [Station]; uninstalling it used to remove the location and the coordinates
+        as well."""
+
+        config_dict = configobj.ConfigObj(io.StringIO("""
+[Station]
+    location = somewhere
+    latitude = 45.0
+    station_type = FileParse
+"""), encoding='utf-8')
+
+        # This is what the fileparse example driver contributes.
+        weecfg.remove_and_prune(config_dict, {'Station': {'station_type': 'FileParse'}})
+
+        assert 'Station' in config_dict
+        assert 'station_type' not in config_dict['Station']
+        assert config_dict['Station']['location'] == 'somewhere'
+        assert config_dict['Station']['latitude'] == '45.0'
+
+    def test_remove_and_prune_removes_a_section_that_is_now_empty(self):
+        """The other half: a section the extension contributed in full does go."""
+
+        config_dict = configobj.ConfigObj(io.StringIO("""
+[Station]
+    location = somewhere
+[FileParse]
+    poll_interval = 10
+    path = /var/tmp/datafile
+"""), encoding='utf-8')
+
+        weecfg.remove_and_prune(config_dict,
+                                {'FileParse': {'poll_interval': '10',
+                                               'path': '/var/tmp/datafile'}})
+
+        assert 'FileParse' not in config_dict
+        assert 'Station' in config_dict
+
     def test_reorder_scalars(self):
         test_list = ['a', 'b', 'd', 'c']
         weecfg.reorder_scalars(test_list, 'c', 'd')


### PR DESCRIPTION
Submitting to master, as this is a fix.

`remove_and_prune()` pruned a section as soon as it had no subsections left. `[Station]`
has only options, so uninstalling a driver extension removed the location and the
coordinates. The `fileparse` example contributes `station_type` that way, so it does
this too.

A section is now removed only when nothing is left in it at all.

Two tests: one for a section that keeps its remaining options, one for a section the
extension contributed in full, which still goes.

Fixes #1131.
