### PR TITLE
Add option loop_timeout, a deadline on driver calls

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -1,6 +1,14 @@
 WeeWX change history
 --------------------
 
+### 5.6.0
+
+Added option `loop_timeout`. If set, WeeWX gives up on a station driver that has
+stopped answering, then restarts the engine. Without it, a driver that blocks and
+never returns takes the archive, the reports and the uploads with it.
+[PR #1135](https://github.com/weewx/weewx/pull/1135).
+
+
 ### 5.5.0 6-Aug-2026
 
 Added the ability for services to bind to a `SHUTDOWN` event. This allows

--- a/docs_src/reference/weewx-options/stations.md
+++ b/docs_src/reference/weewx-options/stations.md
@@ -85,6 +85,25 @@ Valid station types include:
 | **WS28xx**        | La Crosse 28xx stations.                                                |
 
 
+#### loop_timeout
+
+The time (in seconds) WeeWX will wait for the station driver to answer. If the
+deadline passes, WeeWX logs the error, then waits `retry_wait` seconds and
+starts a new engine. No default: without this option WeeWX waits indefinitely.
+
+The deadline applies to every call to the driver, including the wait for the
+next LOOP packet. It must therefore be longer than the longest quiet spell your
+hardware produces.
+
+``` ini
+loop_timeout = 300
+```
+
+!!! note
+
+    Under this option the driver runs on a thread of its own. A driver that
+    registers signal handlers cannot be used with it.
+
 #### ==station_url==
 
 If you have a website, you may optionally specify an URL for its HTML server.

--- a/src/weewx/engine.py
+++ b/src/weewx/engine.py
@@ -21,11 +21,12 @@ import weeutil.config
 import weeutil.logger
 import weeutil.weeutil
 import weewx.accum
+import weewx.loopguard
 import weewx.manager
 import weewx.qc
 import weewx.station
 import weewx.units
-from weeutil.weeutil import to_bool, to_int, to_sorted_string
+from weeutil.weeutil import to_bool, to_float, to_int, to_sorted_string
 from weewx import all_service_groups
 
 log = logging.getLogger(__name__)
@@ -114,6 +115,12 @@ class StdEngine:
             loader_function = getattr(driver_module, 'loader')
             # Call it with the configuration dictionary as the only argument:
             self.console = loader_function(config_dict, self)
+            # Option 'loop_timeout' asks for the driver to be guarded, so that a
+            # station which stops answering cannot stall the main loop. See
+            # weewx.loopguard for what that catches, and what it costs.
+            loop_timeout = to_float(config_dict['Station'].get('loop_timeout'))
+            if loop_timeout:
+                self.console = weewx.loopguard.LoopGuard(self.console, loop_timeout)
         except Exception as ex:
             log.error("Import of driver failed: %s (%s)", ex, type(ex))
             weeutil.logger.log_traceback(log.critical, "    ****  ")

--- a/src/weewx/loopguard.py
+++ b/src/weewx/loopguard.py
@@ -1,0 +1,246 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Put a deadline on a driver, so a station that stops answering cannot stall weewxd.
+
+The engine calls its driver on its own thread, and waits as long as the driver
+takes. A driver that blocks and never returns therefore stops the archive, the
+reports and the uploads, while the process stays alive and the log stays quiet.
+Nothing notices, because there is no event left to notice with.
+
+LoopGuard stands between the two. Every call to the driver runs on a thread of
+its own, and the engine waits for the answer only until 'timeout' seconds have
+passed. After that it gets weewx.WeeWxIOError, which weewxd already knows what to
+do with: it waits 'retry_wait' seconds and builds a fresh engine.
+
+The engine puts the guard in place itself, when option 'loop_timeout' is set:
+
+    [Station]
+        station_type = Vantage
+        loop_timeout = 300
+
+The station type stays the real one, so nothing else changes: 'weectl device'
+still finds its configurator, the station's own stanza is untouched, and any
+driver that loads through the usual loader() is guarded, whether it ships with
+weewx or comes from elsewhere.
+
+The guard never asks the driver for anything on its own. It relays what the
+engine asks for, one call at a time, and a generator the driver returns is pulled
+one element at a time. So the driver runs exactly as far ahead of the engine as
+it does without the guard, which is not at all.
+
+What this cannot do: Python cannot interrupt a blocked thread. If the driver is
+stuck in a read that never returns, that thread stays for the life of the process
+and keeps the device open. The engine comes free, the thread does not. See
+closePort().
+
+What it asks of the driver: it no longer runs on the main thread, so it cannot
+register signal handlers. A driver that calls signal.signal() raises ValueError
+under 'loop_timeout' and has to run without it. That is no great loss, because a
+driver reaching for signal.alarm() is putting a deadline on itself already.
+"""
+
+import collections
+import functools
+import logging
+import queue
+import threading
+
+import weewx
+
+log = logging.getLogger(__name__)
+
+# Seconds to wait for the worker thread to finish during shutdown.
+JOIN_TIMEOUT = 5.0
+
+# 'work' is called on the worker thread. 'answer' receives a (bool, object) pair:
+# whether the call returned, and its result or the exception it raised. It is None
+# for work whose outcome nobody waits for.
+_Job = collections.namedtuple('_Job', ['work', 'answer'])
+
+
+class LoopGuard:
+    """A driver that wraps another one and puts a deadline on every call to it.
+
+    Deliberately not a subclass of weewx.drivers.AbstractDevice. That class
+    defines every method of the driver interface, and a defined method is found
+    before __getattr__ is consulted, which would leave the guard answering for
+    the driver instead of relaying the call.
+
+    Args:
+        driver (weewx.drivers.AbstractDevice): The driver to guard, already
+            loaded and open.
+        timeout (float): Seconds to wait for any one call to the driver. Wants to
+            be generous: the point is to catch a driver that has stopped, not one
+            that is merely unhurried. A poller on a slow radio link can be quiet
+            for minutes and be perfectly well, and the deadline covers the wait
+            for a LOOP packet as much as anything else.
+    """
+
+    # Everything the guard keeps for itself. Every other name, read or written,
+    # belongs to the driver. A test checks that this matches what __init__ sets,
+    # so that adding an attribute here cannot silently start writing it to the
+    # driver instead.
+    _OWN = frozenset(['_driver', '_timeout', '_jobs', '_thread', '_name'])
+
+    def __init__(self, driver, timeout):
+        self._driver = driver
+        self._timeout = timeout
+        self._jobs = queue.Queue()
+        self._thread = threading.Thread(target=self._work, name='LoopGuard', daemon=True)
+        self._thread.start()
+        # Only for messages. Asked through the worker like anything else, so that
+        # a driver already wedged at load time is caught here rather than later.
+        self._name = self.hardware_name
+        self._thread.name = 'LoopGuard-%s' % self._name
+
+    def __getattr__(self, name):
+        """Relay everything the engine asks of the driver, except closePort()."""
+        # __getattr__ runs only for names the instance does not have, so a lookup
+        # before _driver is set would ask for _driver, and ask again, forever.
+        if name == '_driver':
+            raise AttributeError(name)
+        # Ask the class, not the instance: reading a property off the instance
+        # would run the driver's code here, on the engine's thread, which is the
+        # very thing to be avoided.
+        attr = getattr(type(self._driver), name, None)
+        if isinstance(attr, property):
+            return self._relay(lambda: getattr(self._driver, name))
+        if callable(attr):
+            return functools.partial(self._call, name)
+        # A plain data attribute. Reading it is a dictionary lookup and cannot
+        # block, so there is nothing to guard.
+        return getattr(self._driver, name)
+
+    def __setattr__(self, name, value):
+        """Set on the driver, unless the name is one of the guard's own.
+
+        Nothing in weewx assigns to a driver, but an extension may, and the
+        assignment can land on a property with a setter. That runs driver code,
+        so it goes through the worker like every other call.
+        """
+        if name in LoopGuard._OWN:
+            object.__setattr__(self, name, value)
+        else:
+            self._relay(lambda: setattr(self._driver, name, value))
+
+    def closePort(self):
+        """Close the driver, then stop the worker.
+
+        The one call that does not go through the worker. It is the only lever
+        that might free a driver blocked in a read, so queueing it behind that
+        same blocked worker would defeat it.
+
+        A worker that outlives the join is logged, because it still holds the
+        device and the next engine will not get it open.
+        """
+        try:
+            self._driver.closePort()
+        finally:
+            self._jobs.put(None)
+            self._thread.join(JOIN_TIMEOUT)
+            if self._thread.is_alive():
+                log.error("LoopGuard thread for %s did not stop. "
+                          "It still holds the device open.", self._name)
+
+    def _call(self, name, *args, **kwargs):
+        """Call a method on the driver, on the worker thread.
+
+        Args:
+            name (str): Name of the driver method.
+            *args: Passed to the method unchanged.
+            **kwargs: Passed to the method unchanged.
+
+        Returns:
+            object: Whatever the method returned, except that an iterator comes
+                back wrapped, so that pulling from it is guarded too.
+        """
+        return self._relay(lambda: getattr(self._driver, name)(*args, **kwargs))
+
+    def _relay(self, work):
+        """Run one piece of driver work under the deadline.
+
+        Args:
+            work (Callable[[], object]): Called as ``work()`` on the worker
+                thread. Returns whatever the driver returned.
+
+        Returns:
+            object: The result, or a guarded iterator standing in for one.
+        """
+        result = self._await(work)
+        # genLoopPackets(), genArchiveRecords() and genStartupRecords() all hand
+        # back a generator. Pulling from it runs driver code, so it needs the same
+        # treatment as the call that produced it.
+        if hasattr(result, '__next__'):
+            return self._pull(result)
+        return result
+
+    def _await(self, work):
+        """Hand work to the worker thread and wait out the deadline for it.
+
+        Args:
+            work (Callable[[], object]): Called as ``work()`` on the worker
+                thread.
+
+        Returns:
+            object: What the work returned.
+
+        Raises:
+            weewx.WeeWxIOError: If the deadline passed with no answer.
+            Exception: Whatever the driver raised, re-raised here so the engine
+                sees the driver's own error rather than a deadline.
+        """
+        answer = queue.Queue(maxsize=1)
+        self._jobs.put(_Job(work, answer))
+        try:
+            returned, value = answer.get(timeout=self._timeout)
+        except queue.Empty:
+            raise weewx.WeeWxIOError("No answer from %s in %.0f seconds"
+                                     % (self._name, self._timeout))
+        if returned:
+            return value
+        raise value
+
+    def _pull(self, iterator):
+        """Yield from an iterator that lives on the worker thread.
+
+        A generator function, so that abandoning it closes the driver's generator
+        as well. The engine abandons the LOOP generator at the end of every
+        archive period, by raising BreakLoop out of StdArchive.
+
+        Args:
+            iterator (Iterator): The driver's own iterator. Only the worker thread
+                touches it.
+
+        Yields:
+            object: Its elements, one deadline each.
+        """
+        try:
+            while True:
+                try:
+                    yield self._await(lambda: next(iterator))
+                except StopIteration:
+                    return
+        finally:
+            # Nobody waits for this: the engine abandons the LOOP generator every
+            # archive period, and it must not have to wait on the driver to do it.
+            self._jobs.put(_Job(iterator.close, None))
+
+    def _work(self):
+        """Run the driver's calls, one at a time, on this thread.
+
+        Runs as a thread. Every call the engine makes lands here, so the driver
+        only ever runs on this one thread, whatever it does with it.
+        """
+        while True:
+            job = self._jobs.get()
+            if job is None:
+                return
+            try:
+                outcome = (True, job.work())
+            except Exception as e:
+                outcome = (False, e)
+            if job.answer is not None:
+                job.answer.put(outcome)

--- a/src/weewx/tests/guardtarget.py
+++ b/src/weewx/tests/guardtarget.py
@@ -1,0 +1,111 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""A stand-in station for test_loopguard.py, that misbehaves on request.
+
+In a module of its own because the engine loads a driver by importing the module
+the configuration names. Naming the test module there would import it a second
+time, which is the trouble stopper.py was split out to avoid.
+"""
+
+import threading
+import time
+
+import weewx
+import weewx.drivers
+from weeutil.weeutil import to_int
+
+
+def loader(config_dict, engine):
+    return FakeStation(**config_dict['FakeStation'])
+
+
+class FakeStation(weewx.drivers.AbstractDevice):
+    """A station whose LOOP behaves however a test needs it to.
+
+    Args:
+        behaviour (str): What genLoopPackets() does once it has yielded its
+            packets. One of:
+            'quiet'  - block until closePort() releases it, like a station gone
+                       silent whose driver still answers.
+            'stuck'  - block on something closePort() does not release, like a
+                       driver inside a read that never returns. A test that asks
+                       for this must call release_hard() to get the thread back.
+            'raise'  - raise weewx.WeeWxIOError, like a driver that notices.
+            'return' - return, ending the generator.
+        packets (int|str): How many packets to yield first. Comes from the
+            configuration, so it may arrive as a string.
+        hang_in (str): Name of a driver method or property to block in instead of
+            returning. 'getTime' is a method the engine reaches outside the packet
+            loop, 'archive_interval' a property it reads at startup.
+
+    Attributes:
+        closed (bool): Whether closePort() has been called.
+        loops (int): How many times genLoopPackets() has been entered. The engine
+            calls it once per archive period.
+        closed_loops (int): How many of those generators have been closed again.
+        produced (int): How many packets have been handed out in total. Shows how
+            far the station has run ahead of whoever is reading.
+    """
+
+    def __init__(self, behaviour='quiet', packets=0, hang_in='', **_ignored):
+        self.behaviour = behaviour
+        self.packets = to_int(packets)
+        self.hang_in = hang_in
+        self.closed = False
+        self.loops = 0
+        self.closed_loops = 0
+        self.produced = 0
+        self._released = threading.Event()
+        self._released_hard = threading.Event()
+
+    @property
+    def hardware_name(self):
+        return 'FakeStation'
+
+    @property
+    def archive_interval(self):
+        if self.hang_in == 'archive_interval':
+            self._wait()
+        raise NotImplementedError()
+
+    def genLoopPackets(self):
+        self.loops += 1
+        try:
+            for i in range(self.packets):
+                self.produced += 1
+                yield {'dateTime': int(time.time()), 'usUnits': weewx.US,
+                       'outTemp': float(i)}
+
+            if self.behaviour == 'return':
+                return
+            if self.behaviour == 'raise':
+                raise weewx.WeeWxIOError("the station went away")
+            self._wait()
+        finally:
+            self.closed_loops += 1
+
+    def getTime(self):
+        if self.hang_in == 'getTime':
+            self._wait()
+        raise NotImplementedError()
+
+    def release_hard(self):
+        """Free a 'stuck' driver, which closePort() deliberately cannot."""
+        self._released_hard.set()
+
+    def closePort(self):
+        self.closed = True
+        self._released.set()
+
+    def _wait(self):
+        """Block the way a driver blocks in a read that has nothing to read."""
+        if self.behaviour == 'stuck':
+            self._released_hard.wait()
+        else:
+            self._released.wait()
+        # Raise rather than return once released, so that a test tearing down an
+        # engine gets it out of its main loop instead of round it again.
+        raise weewx.WeeWxIOError("released")

--- a/src/weewx/tests/test_loopguard.py
+++ b/src/weewx/tests/test_loopguard.py
@@ -1,0 +1,319 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test module weewx.loopguard"""
+
+import logging
+import threading
+import time
+
+import configobj
+import pytest
+
+import guardtarget
+import weewx
+import weewx.engine
+import weewx.loopguard
+
+# Short enough to keep the suite quick, long enough that a loaded machine cannot
+# trip it by accident.
+TIMEOUT = 0.3
+
+log = logging.getLogger(__name__)
+
+
+def make_config(behaviour='quiet', packets=0, guarded=True, hang_in=''):
+    """Build a configuration whose station is a FakeStation.
+
+    Args:
+        behaviour (str): What the station does once out of packets. See
+            guardtarget.FakeStation.
+        packets (int): How many packets it yields first.
+        guarded (bool): Whether to set 'loop_timeout', which is what puts the
+            guard in place. False leaves the driver bare, to measure against.
+        hang_in (str): A driver method for the station to block in.
+
+    Returns:
+        configobj.ConfigObj: A configuration an engine can be built from.
+    """
+    station = {
+        'station_type': 'FakeStation',
+        # StationInfo insists on these, whatever the driver is.
+        'location': 'Test City',
+        'latitude': '45.686',
+        'longitude': '-121.566',
+        'altitude': ['100', 'meter'],
+    }
+    if guarded:
+        station['loop_timeout'] = str(TIMEOUT)
+    return configobj.ConfigObj({
+        'Station': station,
+        'FakeStation': {
+            'driver': 'guardtarget',
+            'behaviour': behaviour,
+            'packets': str(packets),
+            'hang_in': hang_in,
+        },
+        'Engine': {'Services': {}},
+    })
+
+
+def wait_until(predicate, timeout=2.0):
+    """Poll until a predicate holds, so a test never waits on a fixed sleep.
+
+    Args:
+        predicate (Callable[[], bool]): Called as ``predicate()``. Returns
+            whether the thing being waited for has happened.
+        timeout (float): Seconds to keep trying.
+
+    Returns:
+        bool: Whether the predicate held before the time ran out.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+@pytest.fixture
+def make_guard():
+    """Hand out guarded FakeStations, and take their threads down afterwards."""
+    guards = []
+
+    def _make(behaviour='quiet', packets=0, hang_in=''):
+        station = guardtarget.FakeStation(behaviour=behaviour, packets=packets,
+                                          hang_in=hang_in)
+        guard = weewx.loopguard.LoopGuard(station, TIMEOUT)
+        guards.append(guard)
+        return guard
+
+    yield _make
+
+    for guard in guards:
+        # Straight at the station, not through the guard: a 'stuck' station has
+        # its worker blocked, so a relayed call would only wait out the deadline.
+        guard._driver.release_hard()
+        guard.closePort()
+
+
+def test_packets_reach_the_engine(make_guard):
+    guard = make_guard(packets=3)
+    packets = []
+    for packet in guard.genLoopPackets():
+        packets.append(packet)
+        if len(packets) == 3:
+            break
+    assert [p['outTemp'] for p in packets] == [0.0, 1.0, 2.0]
+
+
+def test_silence_raises_after_the_deadline(make_guard):
+    guard = make_guard(behaviour='quiet')
+    start = time.time()
+    with pytest.raises(weewx.WeeWxIOError, match='No answer'):
+        next(guard.genLoopPackets())
+    # It waits the deadline out rather than giving up on the first quiet moment.
+    assert time.time() - start >= TIMEOUT
+
+
+def test_the_deadline_runs_from_the_last_packet(make_guard):
+    """Packets must not be counted against the deadline that follows them."""
+    guard = make_guard(behaviour='quiet', packets=2)
+    gen = guard.genLoopPackets()
+    start = time.time()
+    next(gen)
+    next(gen)
+    delivered = time.time()
+    with pytest.raises(weewx.WeeWxIOError):
+        next(gen)
+
+    assert delivered - start < TIMEOUT
+    assert time.time() - delivered >= TIMEOUT
+
+
+def test_a_call_outside_the_loop_has_a_deadline_too(make_guard):
+    """The engine asks the driver for more than packets, and waits for all of it.
+
+    StdTimeSynch asks for the clock at STARTUP and every few hours after that
+    (engine.py:810), and StdArchive asks before every archive period through
+    _get_console_time (engine.py:287).
+    """
+    guard = make_guard(hang_in='getTime')
+    start = time.time()
+    with pytest.raises(weewx.WeeWxIOError, match='No answer'):
+        guard.getTime()
+    assert time.time() - start >= TIMEOUT
+
+
+def test_a_property_that_hangs_has_a_deadline(make_guard):
+    """StdArchive reads archive_interval at startup, and it runs driver code."""
+    guard = make_guard(hang_in='archive_interval')
+    with pytest.raises(weewx.WeeWxIOError, match='No answer'):
+        _ = guard.archive_interval
+
+
+def test_abandoning_the_loop_closes_the_driver_generator(make_guard):
+    """Otherwise every archive period leaves another open generator behind."""
+    guard = make_guard(packets=100)
+    gen = guard.genLoopPackets()
+    next(gen)
+    assert guard.closed_loops == 0
+
+    gen.close()
+    assert wait_until(lambda: guard.closed_loops == 1)
+
+
+def test_driver_error_reaches_the_engine(make_guard):
+    """The engine must see the driver's own error, not a deadline."""
+    guard = make_guard(behaviour='raise')
+    with pytest.raises(weewx.WeeWxIOError, match='the station went away'):
+        next(guard.genLoopPackets())
+
+
+def test_a_generator_that_returns_ends_the_loop(make_guard):
+    guard = make_guard(behaviour='return')
+    assert list(guard.genLoopPackets()) == []
+
+
+def test_everything_else_reaches_the_driver(make_guard):
+    guard = make_guard()
+    assert guard.hardware_name == 'FakeStation'
+    # An unimplemented part of the driver interface must still read as
+    # unimplemented, because StdArchive and StdTimeSynch test for exactly that.
+    with pytest.raises(NotImplementedError):
+        _ = guard.archive_interval
+    with pytest.raises(NotImplementedError):
+        guard.getTime()
+    # A plain data attribute comes straight back.
+    assert guard.behaviour == 'quiet'
+
+
+def test_an_assignment_reaches_the_driver(make_guard):
+    """Nothing in weewx assigns to a driver, but an extension may."""
+    guard = make_guard()
+    guard.behaviour = 'raise'
+    assert guard._driver.behaviour == 'raise'
+
+
+def test_an_assignment_has_a_deadline_too(make_guard):
+    """It can land on a property setter, which runs driver code."""
+    guard = make_guard(behaviour='stuck')
+    with pytest.raises(weewx.WeeWxIOError):
+        next(guard.genLoopPackets())
+    # The worker is wedged now, so the assignment cannot get through either.
+    with pytest.raises(weewx.WeeWxIOError, match='No answer'):
+        guard.packets = 5
+
+
+def test_the_guard_keeps_only_its_own_attributes(make_guard):
+    """Add an attribute without listing it, and it would go to the driver."""
+    guard = make_guard()
+    assert set(guard.__dict__) == weewx.loopguard.LoopGuard._OWN
+
+
+def test_close_port_closes_the_driver(make_guard):
+    guard = make_guard()
+    guard.closePort()
+    assert guard.closed
+
+
+def test_a_thread_that_will_not_stop_is_logged(make_guard, monkeypatch, caplog):
+    """The guard's own limit: a driver stuck in a read keeps its thread."""
+    monkeypatch.setattr(weewx.loopguard, 'JOIN_TIMEOUT', 0.1)
+    guard = make_guard(behaviour='stuck')
+    with pytest.raises(weewx.WeeWxIOError):
+        next(guard.genLoopPackets())
+
+    with caplog.at_level(logging.ERROR, logger='weewx.loopguard'):
+        guard.closePort()
+
+    assert 'still holds the device open' in caplog.text
+    assert guard._thread.is_alive()
+
+
+def test_each_archive_period_gets_a_fresh_generator(make_guard):
+    """The driver sees its LOOP restart, exactly as it would without the guard."""
+    guard = make_guard(packets=100)
+    gen = guard.genLoopPackets()
+    next(gen)
+    # What StdArchive's BreakLoop does to the generator at the end of a period.
+    gen.close()
+
+    gen = guard.genLoopPackets()
+    next(gen)
+    assert wait_until(lambda: guard.loops == 2)
+
+
+def test_the_driver_never_runs_ahead(make_guard):
+    """It produces a packet because one was asked for, and then stops.
+
+    A packet made before the engine asks would belong to no archive period by the
+    time it arrives, and StdArchive files a packet by its own timestamp.
+    """
+    guard = make_guard(packets=100)
+    gen = guard.genLoopPackets()
+    next(gen)
+    next(gen)
+    assert guard.produced == 2
+
+    gen.close()
+    # Nothing is pulling now, so nothing more may appear.
+    time.sleep(TIMEOUT)
+    assert guard.produced == 2
+
+
+def test_the_engine_guards_only_when_asked():
+    """Without 'loop_timeout' nothing is wrapped, and with it nothing else changes."""
+    bare = weewx.engine.StdEngine(make_config(guarded=False))
+    assert isinstance(bare.console, guardtarget.FakeStation)
+
+    guarded = weewx.engine.StdEngine(make_config())
+    assert isinstance(guarded.console, weewx.loopguard.LoopGuard)
+    # The station the rest of weewx sees is still the real one.
+    assert guarded.stn_info.hardware == 'FakeStation'
+    guarded.console.closePort()
+
+
+def test_the_engine_breaks_out_of_its_main_loop():
+    """The whole point: a silent station must reach weewxd as a WeeWxIOError.
+
+    weewxd catches that one, waits 'retry_wait' seconds and builds a new engine.
+    """
+    engine = weewx.engine.StdEngine(make_config(behaviour='quiet'))
+    with pytest.raises(weewx.WeeWxIOError):
+        engine.run()
+
+
+def test_the_engine_breaks_out_when_the_driver_hangs_outside_the_loop():
+    """A driver can wedge anywhere it is called, not only in genLoopPackets()."""
+    config = make_config(hang_in='getTime')
+    config['Engine']['Services'] = {'prep_services': 'weewx.engine.StdTimeSynch'}
+    engine = weewx.engine.StdEngine(config)
+    with pytest.raises(weewx.WeeWxIOError):
+        engine.run()
+
+
+def test_the_engine_stalls_without_the_guard():
+    """The premise, measured: the same station stops the engine dead."""
+    engine = weewx.engine.StdEngine(make_config(behaviour='quiet', guarded=False))
+    runner = threading.Thread(target=_run_and_swallow, args=(engine,), daemon=True)
+    runner.start()
+    runner.join(TIMEOUT * 4)
+
+    assert runner.is_alive(), "engine should still be stuck in genLoopPackets()"
+
+    # Let it go, so the thread does not outlive the test.
+    engine.console.closePort()
+    runner.join(2.0)
+    assert not runner.is_alive()
+
+
+def _run_and_swallow(engine):
+    """Run an engine to its end, for a test that only cares whether it got there."""
+    try:
+        engine.run()
+    except Exception as e:
+        log.debug("Engine finished with %s", e)


### PR DESCRIPTION
Submitting to `development`, as this is a feature. Fixes #1134.

With `loop_timeout` set, the engine wraps the driver. Every call runs on a worker
thread, and the engine waits for the answer only that long. After that it raises
`WeeWxIOError`, which `weewxd` already handles: it waits `retry_wait` seconds and
builds a new engine.

``` ini
[Station]
    station_type = Vantage
    loop_timeout = 300
```

Without the option nothing is wrapped. `station_type` stays the real driver, so
`weectl device` and the configurators are untouched.

The guard relays reads, writes, method calls and generators, one element at a
time. The driver runs no further ahead of the engine than it does now.

Two things it cannot do. A thread blocked in a read cannot be interrupted, so it
stays for the life of the process and keeps the device open. The engine comes
free, the thread does not. And the driver no longer runs on the main thread, so
it cannot register signal handlers.

Tested on 3.7 and 3.14. 20 new tests, plus a run of `weewxd` against the
interceptor driver, fed real ecowitt packets across two archive periods.
