### PR TITLE
Add StdStationWatch, which notices that the data has stopped

### DIFF
--- a/docs_src/changes.md
+++ b/docs_src/changes.md
@@ -1,6 +1,13 @@
 WeeWX change history
 --------------------
 
+### 5.6.0
+
+Added service `StdStationWatch`, which issues `STATION_DOWN` and `STATION_UP` as
+the archive data stops and starts. Set `max_age` to switch it on.
+[PR #1137](https://github.com/weewx/weewx/pull/1137).
+
+
 ### 5.5.0 6-Aug-2026
 
 Added the ability for services to bind to a `SHUTDOWN` event. This allows

--- a/docs_src/reference/weewx-options/stdstationwatch.md
+++ b/docs_src/reference/weewx-options/stdstationwatch.md
@@ -1,0 +1,29 @@
+# [StdStationWatch]
+
+This service watches how old the newest archive record is. When it gets older
+than `max_age`, WeeWX logs a warning and issues a `STATION_DOWN` event. When
+records arrive again, it logs and issues `STATION_UP`.
+
+Both events are issued from the service's own thread, not from the main loop.
+Anything bound to them must not use the console.
+
+#### max_age
+
+Seconds the newest archive record may be, before the station counts as having
+stopped reporting. Make it a multiple of the archive interval, so that a single
+missing record does not trip it. No default: without this option WeeWX does not
+watch at all.
+
+``` ini
+[StdStationWatch]
+    max_age = 1800
+```
+
+#### data_binding
+
+The binding to watch. Default is `wx_binding`.
+
+``` ini
+[StdStationWatch]
+    data_binding = wx_binding
+```

--- a/src/weewx/__init__.py
+++ b/src/weewx/__init__.py
@@ -147,6 +147,25 @@ class SHUTDOWN:
     The event contains attribute 'error', a dictionary. If this shut down is due to an exception,
     it contains the keys 'exception' and 'stacktrace', otherwise it is empty. """
 
+class STATION_DOWN:
+    """Event issued when the archive data has stopped arriving. The event
+    contains attribute 'last_record', the timestamp of the newest record, 'age',
+    how many seconds old it is, and 'gap', which is zero.
+
+    Issued from the thread of StdStationWatch, not from the main loop: the main
+    loop only comes round when a LOOP packet arrives, which is what has stopped
+    happening. Anything bound to it must not touch the console."""
+
+
+class STATION_UP:
+    """Event issued when archive data has started arriving again. The event
+    contains attribute 'last_record', the timestamp of the newest record, 'age',
+    how many seconds old it is, and 'gap', how many seconds are missing in front
+    of it.
+
+    Issued from the thread of StdStationWatch. See STATION_DOWN."""
+
+
 # =============================================================================
 #                       Service groups.
 # =============================================================================

--- a/src/weewx/stationwatch.py
+++ b/src/weewx/stationwatch.py
@@ -1,0 +1,138 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Watch the age of the archive data, and say when it stops moving.
+
+Every other engine event follows something happening: a packet arrived, a record
+was written, the period ended. There is no event for nothing happening, which is
+why a station that stops delivering data goes unremarked. WeeWX keeps running,
+the log stays quiet, and the web page keeps showing the last reading it had.
+
+StdStationWatch checks how old the newest archive record is, and dispatches
+STATION_DOWN when it gets older than 'max_age', STATION_UP when records come
+back. It also logs both. What to do beyond that is left to whoever binds to the
+events.
+
+It is off unless 'max_age' is set:
+
+    [StdStationWatch]
+        max_age = 1800
+"""
+
+import logging
+import threading
+import time
+
+import weedb
+import weewx
+import weewx.manager
+from weeutil.weeutil import timestamp_to_string, to_int
+from weewx.engine import StdService
+
+log = logging.getLogger(__name__)
+
+# Seconds between checks. The deadline is in minutes at least, so there is
+# nothing to gain from looking more often than this.
+CHECK_INTERVAL = 60
+
+
+class StdStationWatch(StdService):
+    """Dispatch STATION_DOWN and STATION_UP as the archive data stops and starts.
+
+    The checking runs on a thread of its own, so both events are dispatched from
+    that thread rather than from the main loop. They have to be: the main loop
+    only comes round when a LOOP packet arrives, which during an outage is
+    exactly what does not happen. Anything bound to these two events therefore
+    runs off the main thread, and must not touch the console.
+    """
+
+    def __init__(self, engine, config_dict):
+        super().__init__(engine, config_dict)
+
+        watch_dict = config_dict.get('StdStationWatch', {})
+        self.max_age = to_int(watch_dict.get('max_age', 0))
+        self.thread = None
+        if not self.max_age:
+            return
+
+        self.data_binding = watch_dict.get('data_binding', 'wx_binding')
+        self.config_dict = config_dict
+        # Whether the station was quiet when last looked at. Held in memory
+        # only, so a restarted engine reports an outage that is still going on.
+        self.down = False
+        self.last_seen = None
+        self.stopping = threading.Event()
+
+        self.bind(weewx.STARTUP, self.startup)
+
+    def startup(self, _event):
+        """Start watching. The database exists by the time this runs."""
+        self.thread = threading.Thread(target=self.watch, name='StdStationWatch',
+                                       daemon=True)
+        self.thread.start()
+        log.info("Watching the station, deadline %d seconds", self.max_age)
+
+    def shutDown(self):
+        """Stop the watching thread. Called by the engine as it shuts down."""
+        if self.thread is not None:
+            self.stopping.set()
+            self.thread.join(CHECK_INTERVAL)
+
+    def watch(self):
+        """Check the record age until the engine shuts down. Runs as a thread."""
+        while not self.stopping.wait(CHECK_INTERVAL):
+            try:
+                self.check()
+            except Exception as e:
+                log.error("Station watch failed: %s", e)
+
+    def check(self):
+        """Compare the newest record against the deadline, and dispatch a change."""
+        last_ts = self.last_record_time()
+        if last_ts is None:
+            # An empty database. There is nothing to have stopped yet.
+            return
+
+        age = time.time() - last_ts
+        down = age > self.max_age
+        if down == self.down:
+            self.last_seen = last_ts
+            return
+
+        if down:
+            log.warning("No archive record from the station since %s, %d seconds ago",
+                        timestamp_to_string(last_ts), age)
+            self.engine.dispatchEvent(weewx.Event(weewx.STATION_DOWN,
+                                                  last_record=last_ts,
+                                                  age=int(age),
+                                                  gap=0))
+        else:
+            gap = last_ts - self.last_seen if self.last_seen else 0
+            log.info("Archive records from the station have resumed. %d seconds missing",
+                     gap)
+            self.engine.dispatchEvent(weewx.Event(weewx.STATION_UP,
+                                                  last_record=last_ts,
+                                                  age=int(age),
+                                                  gap=int(gap)))
+
+        self.down = down
+        self.last_seen = last_ts
+
+    def last_record_time(self):
+        """Ask the database for the timestamp of its newest record.
+
+        Opens its own connection, because this runs on the watching thread and a
+        database connection belongs to the thread that opened it.
+
+        Returns:
+            int|None: The timestamp, or None if there are no records to have one.
+        """
+        try:
+            with weewx.manager.open_manager_with_config(self.config_dict,
+                                                        self.data_binding) as dbmanager:
+                return dbmanager.lastGoodStamp()
+        except weedb.NoDatabaseError:
+            # The engine has not got as far as creating it. Nothing to watch yet.
+            return None

--- a/src/weewx/tests/test_stationwatch.py
+++ b/src/weewx/tests/test_stationwatch.py
@@ -1,0 +1,194 @@
+#
+#    Copyright (c) 2026 Manuel Hilgert
+#
+#    See the file LICENSE.txt for your full rights.
+#
+"""Test module weewx.stationwatch"""
+
+import time
+
+import configobj
+import pytest
+
+import weewx
+import weewx.manager
+import weewx.stationwatch
+
+MAX_AGE = 600
+
+
+class FakeEngine:
+    """Just enough engine to bind to and to catch what gets dispatched.
+
+    Attributes:
+        events (list[weewx.Event]): Everything dispatched, in order.
+        callbacks (dict[type, list[Callable]]): What has bound to what.
+    """
+
+    def __init__(self):
+        self.events = []
+        self.callbacks = {}
+
+    def bind(self, event_type, callback):
+        self.callbacks.setdefault(event_type, []).append(callback)
+
+    def dispatchEvent(self, event):
+        self.events.append(event)
+
+
+def make_config(tmp_path, max_age=MAX_AGE):
+    """Build a configuration with an empty SQLite database.
+
+    Args:
+        tmp_path (pathlib.Path): Where the database goes.
+        max_age (int): The deadline. Zero leaves the service switched off.
+
+    Returns:
+        configobj.ConfigObj: A configuration StdStationWatch can be built from.
+    """
+    watch = {'max_age': str(max_age)} if max_age else {}
+    return configobj.ConfigObj({
+        'WEEWX_ROOT': str(tmp_path),
+        'Station': {'location': 'Test City'},
+        'StdStationWatch': watch,
+        'DataBindings': {
+            'wx_binding': {
+                'database': 'archive_sqlite',
+                'table_name': 'archive',
+                'manager': 'weewx.manager.DaySummaryManager',
+                'schema': 'schemas.wview_extended.schema',
+            },
+        },
+        'Databases': {
+            'archive_sqlite': {'database_name': 'test.sdb', 'database_type': 'SQLite'},
+        },
+        'DatabaseTypes': {
+            'SQLite': {'driver': 'weedb.sqlite', 'SQLITE_ROOT': str(tmp_path)},
+        },
+    })
+
+
+def add_record(config_dict, timestamp):
+    """Put one archive record into the database, creating it if need be.
+
+    Args:
+        config_dict (configobj.ConfigObj): The configuration naming the database.
+        timestamp (int): The record's dateTime.
+    """
+    with weewx.manager.open_manager_with_config(config_dict, 'wx_binding',
+                                                initialize=True) as dbmanager:
+        dbmanager.addRecord({'dateTime': timestamp, 'usUnits': weewx.US,
+                             'interval': 5, 'outTemp': 20.0})
+
+
+@pytest.fixture
+def make_watch():
+    """Build watchers, and stop any thread they started."""
+    built = []
+
+    def _make(config_dict):
+        engine = FakeEngine()
+        watch = weewx.stationwatch.StdStationWatch(engine, config_dict)
+        built.append(watch)
+        return engine, watch
+
+    yield _make
+
+    for watch in built:
+        watch.shutDown()
+
+
+def test_it_stays_out_of_the_way_unless_asked(tmp_path, make_watch):
+    """Without max_age it binds to nothing and starts nothing."""
+    engine, watch = make_watch(make_config(tmp_path, max_age=0))
+
+    assert engine.callbacks == {}
+    assert watch.thread is None
+
+
+def test_it_binds_to_startup_when_asked(tmp_path, make_watch):
+    engine, _ = make_watch(make_config(tmp_path))
+
+    assert list(engine.callbacks) == [weewx.STARTUP]
+
+
+def test_a_fresh_record_dispatches_nothing(tmp_path, make_watch):
+    config = make_config(tmp_path)
+    add_record(config, int(time.time()))
+    engine, watch = make_watch(config)
+
+    watch.check()
+    assert engine.events == []
+
+
+def test_an_old_record_dispatches_station_down(tmp_path, make_watch):
+    config = make_config(tmp_path)
+    last_ts = int(time.time()) - MAX_AGE - 60
+    add_record(config, last_ts)
+    engine, watch = make_watch(config)
+
+    watch.check()
+
+    assert len(engine.events) == 1
+    event = engine.events[0]
+    assert event.event_type == weewx.STATION_DOWN
+    assert event.last_record == last_ts
+    assert event.age >= MAX_AGE + 60
+
+
+def test_it_dispatches_station_down_once(tmp_path, make_watch):
+    """However long the station stays away, it is one event."""
+    config = make_config(tmp_path)
+    add_record(config, int(time.time()) - MAX_AGE - 60)
+    engine, watch = make_watch(config)
+
+    watch.check()
+    watch.check()
+    watch.check()
+    assert len(engine.events) == 1
+
+
+def test_recovery_dispatches_station_up_with_the_gap(tmp_path, make_watch):
+    config = make_config(tmp_path)
+    old_ts = int(time.time()) - MAX_AGE - 1200
+    add_record(config, old_ts)
+    engine, watch = make_watch(config)
+
+    watch.check()
+    new_ts = int(time.time())
+    add_record(config, new_ts)
+    watch.check()
+
+    assert [e.event_type for e in engine.events] == [weewx.STATION_DOWN,
+                                                     weewx.STATION_UP]
+    assert engine.events[1].gap == new_ts - old_ts
+
+
+def test_an_empty_database_dispatches_nothing(tmp_path, make_watch):
+    """There is nothing to have stopped until there has been data."""
+    config = make_config(tmp_path)
+    engine, watch = make_watch(config)
+
+    watch.check()
+    assert engine.events == []
+
+
+def test_a_missing_database_dispatches_nothing(tmp_path, make_watch):
+    """The engine may not have created it yet when the first check comes round."""
+    config = make_config(tmp_path)
+    _, watch = make_watch(config)
+
+    assert watch.last_record_time() is None
+
+
+def test_the_thread_starts_at_startup_and_stops_on_shutdown(tmp_path, make_watch):
+    config = make_config(tmp_path)
+    add_record(config, int(time.time()))
+    engine, watch = make_watch(config)
+
+    for callback in engine.callbacks[weewx.STARTUP]:
+        callback(weewx.Event(weewx.STARTUP))
+    assert watch.thread.is_alive()
+
+    watch.shutDown()
+    assert not watch.thread.is_alive()

--- a/src/weewx_data/weewx.conf
+++ b/src/weewx_data/weewx.conf
@@ -502,6 +502,16 @@ version = 5.5.0
 
 #   This section configures the internal weewx engine.
 
+##############################################################################
+
+#   This section is for the service that watches for the station going quiet.
+
+[StdStationWatch]
+
+    # Seconds the newest archive record may be, before WeeWX decides the station
+    # has stopped reporting. Unset, WeeWX does not watch at all.
+    # max_age = 1800
+
 [Engine]
     
     # This section specifies which services should be run and in what order.
@@ -512,4 +522,4 @@ version = 5.5.0
         xtype_services = weewx.wxxtypes.StdWXXTypes, weewx.wxxtypes.StdPressureCooker, weewx.wxxtypes.StdRainRater, weewx.wxxtypes.StdDelta
         archive_services = weewx.engine.StdArchive
         restful_services = weewx.restx.StdStationRegistry, weewx.restx.StdWunderground, weewx.restx.StdPWSweather, weewx.restx.StdCWOP, weewx.restx.StdWOW, weewx.restx.StdWOWBE, weewx.restx.StdAWEKAS
-        report_services = weewx.engine.StdPrint, weewx.engine.StdReport
+        report_services = weewx.engine.StdPrint, weewx.engine.StdReport, weewx.stationwatch.StdStationWatch

--- a/zensical.toml
+++ b/zensical.toml
@@ -104,6 +104,7 @@ nav = [
             { "[StdWXCalculate]" = "reference/weewx-options/stdwxcalculate.md" },
             { "[StdArchive]" = "reference/weewx-options/stdarchive.md" },
             { "[StdTimeSynch]" = "reference/weewx-options/stdtimesynch.md" },
+            { "[StdStationWatch]" = "reference/weewx-options/stdstationwatch.md" },
             { "[DataBindings]" = "reference/weewx-options/data-bindings.md" },
             { "[Databases]" = "reference/weewx-options/databases.md" },
             { "[DatabaseTypes]" = "reference/weewx-options/database-types.md" },


### PR DESCRIPTION
Submitting to `development`, as this is a feature. Fixes #1136.

`StdStationWatch` checks how old the newest archive record is. Past `max_age` it
logs a warning and issues `STATION_DOWN`, and when records arrive again it logs
and issues `STATION_UP` with the length of the gap.

``` ini
[StdStationWatch]
    max_age = 1800
```

Without `max_age` it binds to nothing and starts nothing.

Both events are issued from the service's own thread, which is the one thing
worth arguing about. They cannot come from the main loop: it only comes round
when a LOOP packet arrives, and that is what has stopped happening. So anything
bound to these two runs off the main thread and must not touch the console. It
is documented on the event classes and in the service docstring.

The state is held in memory, not written anywhere. An engine that restarts
during an outage therefore issues `STATION_DOWN` again. Consumers that mind can
keep their own record, and the alternative was writing to the daily summary
metadata through a private method.

What this does not do is decide what happens next. Mail, Telegram, a webhook, a
program: all of that belongs in an extension binding to the events. I have one,
and it is not part of this.

Tested on 3.7 and 3.14. Nine new tests, and five deliberate mutations of the
service, each caught by the suite.
